### PR TITLE
fix(devcontainer): remove `exec "$SHELL"` from mise install

### DIFF
--- a/.devcontainer/features/dotfiles-dev/install.sh
+++ b/.devcontainer/features/dotfiles-dev/install.sh
@@ -84,7 +84,8 @@ tee -a "$POST_CREATE_SCRIPT_PATH" > /dev/null << 'EOF'
 # - Show verbose output.
 # - Always answer "yes" to prompts.
 if type mise > /dev/null 2>&1; then
-   exec "$SHELL" -lc 'mise install --verbose --yes || true' # Temporary workaround for poetry install failure.
+   # Temporary workaround for poetry install failure.
+   mise install --verbose --yes || true
 fi
 
 EOF


### PR DESCRIPTION
- Simplified the mise installation command for clarity.