### PR TITLE
refactor(opencode): optimize PRD command workflows and efficiency

### DIFF
--- a/.config/opencode/command/prd/update.md
+++ b/.config/opencode/command/prd/update.md
@@ -16,7 +16,7 @@ $ARGUMENTS
 !`ls FEATURES.md docs/FEATURES.md 2>/dev/null | grep . || echo "No FEATURES.md found"`</existing-features>
 
 <existing-rfcs>
-!`ls RFCs/RFC-*.md docs/rfc/RFC-*.md docs/rfcs/RFC-*.md 2>/dev/null || echo "No RFC files found"`</existing-rfcs>
+!`ls RFCs/RFC-*.md docs/rfc/RFC-*.md docs/rfcs/RFC-*.md 2>/dev/null | grep . || echo "No RFC files found"`</existing-rfcs>
 
 <git-status>
 !`git status --porcelain 2>/dev/null | head -30 || echo "No git repository"`</git-status>


### PR DESCRIPTION
Improve PRD-related command performance and maintainability:

- refactor(to-rules): limit find depth to 4 and reduce file types checked
- refactor(to-rules): simplify existing-docs command to basic ls
- refactor(to-rules): restructure workflow with phased approach and approval gates
- refactor(to-rules): add mandatory oracle review gate before user approval
- refactor(to-rules): add explicit drift detection for existing RULES.md
- refactor(to-rules): replace prose instructions with structured phases and tables
- fix(update): add grep filter to existing-rfcs command to suppress errors

Performance improvements:
- Reduced find traversal from unlimited to depth 4 (faster discovery)
- Reduced file type filters from 14 to 6 most common types
- Limited output to 40 files instead of 50 (less noise)

Workflow improvements:
- Added structured 6-phase workflow with clear gates
- Mandatory oracle validation before presenting to user
- Explicit drift assessment for existing RULES.md
- Clearer approval points to prevent premature writes