### PR TITLE
chore(config): migrate opencode to npm package and simplify agent configs

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -23,13 +23,13 @@ go = "1.25.6"
 "npm:rimraf" = "6.1.2"
 "npm:@anthropic-ai/claude-code" = "2.1.7"
 "npm:tsx" = "4.21.0"
+"npm:opencode-ai" = "1.1.25"
 
 # Language Servers
 "npm:pyright" = "1.1.408"
 "npm:typescript-language-server" = "5.1.3"
 
 "github:mazznoer/lolcrab" = "0.4.1"
-"github:sst/opencode" = "1.1.24"
 
 [task_config]
 includes = ["tasks/dotfiles.toml", "tasks/_mise.toml"]

--- a/.config/opencode/oh-my-opencode.json
+++ b/.config/opencode/oh-my-opencode.json
@@ -28,18 +28,15 @@
     },
     "frontend-ui-ux-engineer": {
       "description": "Designer-turned-developer for stunning UI/UX implementation",
-      "model": "google/antigravity-gemini-3-pro",
-      "temperature": 0.5
+      "model": "google/antigravity-gemini-3-pro"
     },
     "document-writer": {
       "description": "Technical writing expert for documentation and guides",
-      "model": "google/antigravity-gemini-3-pro",
-      "temperature": 0.3
+      "model": "google/antigravity-gemini-3-pro"
     },
     "multimodal-looker": {
       "description": "Analyzes PDFs, images, diagrams beyond raw text",
-      "model": "google/antigravity-gemini-3-flash",
-      "temperature": 0.2
+      "model": "google/antigravity-gemini-3-flash"
     }
   },
   "experimental": {


### PR DESCRIPTION
- Replace github:sst/opencode (1.1.24) with npm:opencode-ai (1.1.25) in mise config
- Remove explicit temperature settings from frontend-ui-ux-engineer, document-writer, and multimodal-looker agents
- Standardize agent configuration by removing redundant temperature overrides