### PR TITLE
feat(opencode): modernize configuration and tool setup

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -27,6 +27,7 @@ go = "1.25.6"
 
 # Language Servers
 "npm:pyright" = "1.1.408"
+"npm:remark-language-server" = "3.0.0"
 "npm:typescript-language-server" = "5.1.3"
 
 "github:mazznoer/lolcrab" = "0.4.1"

--- a/.config/opencode/antigravity.json
+++ b/.config/opencode/antigravity.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/NoeFabris/opencode-antigravity-auth/main/assets/antigravity.schema.json",
+  "account_selection_strategy": "hybrid",
+  "switch_on_first_rate_limit": true,
+  "pid_offset_enabled": true,
+  "web_search": {
+    "default_mode": "auto"
+  }
+}

--- a/.config/opencode/oh-my-opencode.json
+++ b/.config/opencode/oh-my-opencode.json
@@ -4,7 +4,7 @@
     "Sisyphus": {
       "description": "Primary orchestrator agent with powerful AI capabilities",
       "model": "google/antigravity-claude-opus-4-5-thinking",
-      "prompt_append": "\n---\n\n## Session Management (REQUIRED)\n\nBefore investigating any issue:\n1. Use `session_search` to find relevant prior sessions for this repository\n2. Use `session_read` to review prior work if found\n3. Avoid repeating investigation already completed in previous sessions\n\nBefore completing:\n1. Ensure your session contains a summary of work done\n2. Include key decisions, findings, and outcomes\n3. This summary will be searchable in future agent runs"
+      "prompt_append": "\n---\n\n## Session Management (MANDATORY)\n\nBefore investigating any issue:\n1. Use `session_search` to find relevant prior sessions for this repository\n2. Use `session_read` to review prior work if found\n3. Avoid repeating investigation already completed in previous sessions\n\nBefore completing:\n1. Ensure your session contains a summary of work done\n2. Include key decisions, findings, and outcomes\n3. This summary will be searchable in future agent runs\n"
     },
     "OpenCode-Builder": {
       "description": "Default build agent for development tasks",
@@ -16,12 +16,11 @@
     },
     "oracle": {
       "description": "Expert technical advisor for architecture decisions and code analysis",
-      "model": "github-copilot/gpt-5.2"
+      "model": "github-copilot/gpt-5.2-codex"
     },
     "librarian": {
       "description": "Multi-repository analysis, official docs, and implementation examples",
-      "model": "google/antigravity-claude-sonnet-4-5",
-      "prompt_append": "\n---\n\n**Important:** The EXTERNAL RESOURCES section in AGENTS.md documents key dependencies, references, and documentation to assist you in providing accurate and context-aware responses. Read this section carefully before you begin."
+      "model": "opencode/grok-code"
     },
     "explore": {
       "description": "Fast agent for codebase exploration and pattern matching",
@@ -29,22 +28,33 @@
     },
     "frontend-ui-ux-engineer": {
       "description": "Designer-turned-developer for stunning UI/UX implementation",
-      "model": "google/antigravity-gemini-3-pro"
+      "model": "google/antigravity-gemini-3-pro",
+      "variant": "high"
     },
     "document-writer": {
       "description": "Technical writing expert for documentation and guides",
-      "model": "google/antigravity-gemini-3-pro"
+      "model": "google/antigravity-gemini-3-flash"
     },
     "multimodal-looker": {
       "description": "Analyzes PDFs, images, diagrams beyond raw text",
-      "model": "google/antigravity-gemini-3-flash"
+      "model": "google/gemini-2.5-flash"
     }
   },
-  "experimental": {
-    "aggressive_truncation": false,
-    "auto_resume": false,
-    "dcp_for_compaction": true,
-    "truncate_all_tool_outputs": false
-  },
-  "google_auth": false
+  "auto_update": false,
+  "disabled_mcps": [
+    "websearch",
+    "context7"
+  ],
+  "google_auth": false,
+  "lsp": {
+    "remark-language-server": {
+      "command": [
+        "remark-language-server",
+        "--stdio"
+      ],
+      "extensions": [
+        ".md"
+      ]
+    }
+  }
 }

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -1,10 +1,20 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
-    "oh-my-opencode",
-    "opencode-antigravity-auth@1.2.8",
-    "@tarquinen/opencode-dcp@latest"
+    "opencode-antigravity-auth@1.3.0",
+    "oh-my-opencode@2.14.0",
+    "@tarquinen/opencode-dcp@latest",
+    "@franlol/opencode-md-table-formatter@latest"
   ],
+  "agent": {
+    "compaction": {
+      "model": "opencode/glm-4.7-free"
+    },
+    "plan": {
+      "model": "google/antigravity-claude-opus-4-5-thinking",
+      "variant": "max"
+    }
+  },
   "provider": {
     "google": {
       "models": {
@@ -210,15 +220,37 @@
       }
     }
   },
+  "lsp": {
+    "remark-language-server": {
+      "command": [
+        "remark-language-server",
+        "--stdio"
+      ],
+      "extensions": [
+        ".md"
+      ]
+    }
+  },
   "mcp": {
+    "context7": {
+      "type": "remote",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
+      },
+      "oauth": false
+    },
     "tavily": {
       "type": "remote",
-      "url": "https://mcp.tavily.com/mcp/?tavilyApiKey={file:~/.secrets/tavily-api-key}"
+      "url": "https://mcp.tavily.com/mcp/?tavilyApiKey={env:TAVILY_API_KEY}",
+      "oauth": false
+    },
+    "websearch": {
+      "type": "remote",
+      "url": "https://mcp.exa.ai/mcp?exaApiKey={env:EXA_API_KEY}&tools=web_search_exa",
+      "oauth": false
     }
   },
   "small_model": "github-copilot/gemini-3-flash-preview",
-  "theme": "catppuccin",
-  "permission": {
-    "webfetch": "deny"
-  }
+  "theme": "catppuccin"
 }


### PR DESCRIPTION
Update OpenCode and Oh-My-OpenCode configurations with the following improvements:

- Upgrade plugins to latest versions (opencode-antigravity-auth@1.3.0, oh-my-opencode@2.14.0)
- Add @franlol/opencode-md-table-formatter plugin
- Configure agent models for compaction (glm-4.7-free) and planning (claude-opus-4-5-thinking)
- Update agent model assignments:
  - oracle: switch to gpt-5.2-codex
  - librarian: switch to opencode/grok-code
  - document-writer: downgrade to gemini-3-flash for efficiency
  - multimodal-looker: use standard gemini-2.5-flash
  - frontend-ui-ux-engineer: add high-level thinking variant
- Add remark-language-server LSP configuration for Markdown support
- Standardize MCP authentication to use environment variables
- Add context7 and websearch MCP configurations
- Disable websearch and context7 MCPs in oh-my-opencode
- Remove obsolete experimental settings
- Clean up permission and webfetch configurations
- Add antigravity.json with hybrid account selection and web search auto mode
- Install remark-language-server in mise config