### PR TITLE
feat(config): migrate to Antigravity Claude Opus models

### DIFF
--- a/.config/opencode/oh-my-opencode.json
+++ b/.config/opencode/oh-my-opencode.json
@@ -4,6 +4,7 @@
     "sisyphus": {
       "description": "Primary orchestrator agent with powerful AI capabilities",
       "model": "google/antigravity-claude-opus-4-5-thinking",
+      "variant": "max",
       "permission": {
         "question": "allow"
       },
@@ -17,14 +18,14 @@
       "model": "google/antigravity-claude-opus-4-5-thinking"
     },
     "prometheus": {
-      "description": "Strategic planning agent with minimal creativity",
-      "model": "github-copilot/gpt-5.2",
-      "variant": "xhigh"
+      "description": "Strategic planning agent - verbose, detailed plans with tables and file references",
+      "model": "google/antigravity-claude-opus-4-5-thinking",
+      "variant": "max"
     },
     "metis": {
-      "description": "Pre-planning analysis for hidden requirements and AI failure points",
-      "model": "github-copilot/gpt-5.2",
-      "variant": "xhigh"
+      "description": "Pre-planning gap analyzer - different model perspective catches what planner misses",
+      "model": "google/antigravity-gemini-3-pro",
+      "variant": "high"
     },
     "oracle": {
       "description": "Expert technical advisor for architecture decisions and code analysis",
@@ -53,17 +54,19 @@
       "model": "google/antigravity-gemini-3-flash"
     },
     "momus": {
-      "model": "github-copilot/gpt-5.2-codex",
-      "variant": "medium"
+      "description": "Meticulous plan reviewer - catches issues through rigorous analysis",
+      "model": "github-copilot/gpt-5.2",
+      "variant": "xhigh"
     },
     "atlas": {
-      "model": "google/antigravity-claude-sonnet-4-5-thinking"
+      "description": "Master orchestrator - executes plans through delegation",
+      "model": "google/antigravity-claude-opus-4-5-thinking"
     }
   },
   "auto_update": false,
   "sisyphus_agent": {
-    "planner_enabled": false,
-    "replace_plan": false
+    "planner_enabled": true,
+    "replace_plan": true
   },
   "git_master": {
     "commit_footer": false,

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -8,8 +8,8 @@
   ],
   "agent": {
     "plan": {
-      "model": "github-copilot/gpt-5.2",
-      "variant": "xhigh"
+      "model": "google/antigravity-claude-opus-4-5-thinking",
+      "variant": "max"
     }
   },
   "provider": {
@@ -161,7 +161,7 @@
       ]
     }
   },
-  "model": "github-copilot/gpt-5.2-codex",
-  "small_model": "github-copilot/gemini-3-flash-preview",
+  "model": "google/antigravity-claude-opus-4-5-thinking",
+  "small_model": "google/antigravity-gemini-3-flash",
   "theme": "catppuccin"
 }


### PR DESCRIPTION
Replace GitHub Copilot models with Google Antigravity models across OpenCode configuration for improved AI agent performance.

Changes:
- Update default model from gpt-5.2-codex to antigravity-claude-opus-4-5-thinking
- Update small_model from gemini-3-flash-preview to antigravity-gemini-3-flash
- Configure planning agent with claude-opus-4-5-thinking (max variant)
- Upgrade sisyphus agent to use max variant with enhanced thinking budget
- Reconfigure prometheus agent with opus-4-5-thinking for detailed planning
- Switch metis agent to gemini-3-pro for diverse model perspective
- Upgrade atlas agent from sonnet to opus for master orchestration
- Enhance momus agent configuration with detailed description and xhigh variant
- Enable sisyphus planner with replace_plan functionality
- Refine agent descriptions for clarity and purpose