### PR TITLE
chore(opencode): optimize agent configs and update dependencies

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -23,7 +23,7 @@ ast-grep = "0.40.5"
 "npm:@bfra.me/prettier-config" = "0.16.6"
 "npm:rimraf" = "6.1.2"
 "npm:tsx" = "4.21.0"
-"npm:opencode-ai" = "1.1.47"
+"npm:opencode-ai" = "1.1.48"
 "npm:agent-browser" = "0.7.6"
 
 # Language Servers

--- a/.config/opencode/oh-my-opencode.json
+++ b/.config/opencode/oh-my-opencode.json
@@ -4,7 +4,7 @@
     "sisyphus": {
       "description": "Primary orchestrator agent with powerful AI capabilities",
       "model": "google/antigravity-claude-opus-4-5-thinking",
-      "variant": "max",
+      "variant": "low",
       "permission": {
         "question": "allow"
       },
@@ -64,10 +64,6 @@
     }
   },
   "auto_update": false,
-  "sisyphus_agent": {
-    "planner_enabled": true,
-    "replace_plan": true
-  },
   "git_master": {
     "commit_footer": false,
     "include_co_authored_by": false
@@ -89,7 +85,7 @@
       "variant": "high"
     },
     "quick": {
-      "model": "google/antigravity-gemini-3-flash",
+      "model": "google/antigravity-claude-sonnet-4-5-thinking",
       "variant": "low"
     },
     "unspecified-low": {

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -2,7 +2,7 @@
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
     "opencode-antigravity-auth@1.4.3",
-    "oh-my-opencode@3.1.9",
+    "oh-my-opencode@3.1.11",
     "@tarquinen/opencode-dcp@1.2.8",
     "@franlol/opencode-md-table-formatter@latest"
   ],
@@ -148,17 +148,6 @@
           }
         }
       }
-    }
-  },
-  "lsp": {
-    "remark-language-server": {
-      "command": [
-        "remark-language-server",
-        "--stdio"
-      ],
-      "extensions": [
-        ".md"
-      ]
     }
   },
   "model": "google/antigravity-claude-opus-4-5-thinking",


### PR DESCRIPTION
Refactor OpenCode configuration to reduce thinking budget costs and consolidate LSP settings while updating to latest plugin versions.

Changes:
- Downgrade sisyphus agent variant from max to low (8K vs 32K thinking budget)
- Remove sisyphus_agent planner_enabled config (deprecated/redundant)
- Update oh-my-opencode plugin from 3.1.9 to 3.1.11
- Update opencode-ai tool from 1.1.47 to 1.1.48
- Switch quick category model from gemini-flash to claude-sonnet with low variant
- Remove duplicate LSP remark-language-server config from opencode.json
- Consolidate LSP configuration in oh-my-opencode.json only