### PR TITLE
feat(opencode): upgrade to OpenCode 1.1.53 w/ Opus 4.6 and DCP v2

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -23,7 +23,7 @@ ast-grep = "0.40.5"
 "npm:@bfra.me/prettier-config" = "0.16.6"
 "npm:rimraf" = "6.1.2"
 "npm:tsx" = "4.21.0"
-"npm:opencode-ai" = "1.1.51"
+"npm:opencode-ai" = "1.1.53"
 "npm:agent-browser" = "0.7.6"
 
 # Language Servers

--- a/.config/opencode/antigravity.json
+++ b/.config/opencode/antigravity.json
@@ -2,5 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/NoeFabris/opencode-antigravity-auth/main/assets/antigravity.schema.json",
   "account_selection_strategy": "round-robin",
   "switch_on_first_rate_limit": true,
-  "pid_offset_enabled": true
+  "pid_offset_enabled": true,
+  "auto_update": false,
+  "cli_first": true
 }

--- a/.config/opencode/dcp.jsonc
+++ b/.config/opencode/dcp.jsonc
@@ -1,15 +1,27 @@
 {
+  "$schema": "https://raw.githubusercontent.com/Opencode-DCP/opencode-dynamic-context-pruning/master/dcp.schema.json",
   // Enable or disable the plugin
   "enabled": true,
   // Enable debug logging to ~/.config/opencode/logs/dcp/
   "debug": false,
   // Notification display: "off", "minimal", or "detailed"
   "pruneNotification": "off",
-  // Protect from pruning for <turns> message turns
-  "turnProtection": {
+  // Notification type: "chat" (in-conversation) or "toast" (system toast)
+  "pruneNotificationType": "toast",
+  // Slash commands configuration
+  "commands": {
     "enabled": true,
+    // Additional tools to protect from pruning via commands (e.g., /dcp sweep)
+    "protectedTools": []
+  },
+  // Protect from pruning for <turns> message turns past tool invocation
+  "turnProtection": {
+    "enabled": false,
     "turns": 4
   },
+  // Protect file operations from pruning via glob patterns
+  // Patterns match tool parameters.filePath (e.g. read/write/edit)
+  "protectedFilePatterns": [],
   // LLM-driven context pruning tools
   "tools": {
     // Shared settings for all prune tools
@@ -17,27 +29,31 @@
       // Nudge the LLM to use prune tools (every <nudgeFrequency> tool results)
       "nudgeEnabled": true,
       "nudgeFrequency": 10,
+      // Token limit at which the model compresses session context
+      // to keep the model in the "smart zone" (not a hard limit)
+      // Accepts: number or "X%" (percentage of model's context window)
+      "contextLimit": 100000,
       // Additional tools to protect from pruning
-      "protectedTools": [
-        "task",
-        "todowrite",
-        "todoread",
-        "lsp_rename",
-        "lsp_code_action_resolve",
-        "session_read",
-        "session_write",
-        "session_search"
-      ]
-    },
-    // Removes tool content from context without preservation (for completed tasks or noise)
-    "discard": {
-      "enabled": true
+      "protectedTools": []
     },
     // Distills key findings into preserved knowledge before removing raw content
-    "extract": {
-      "enabled": false,
+    "distill": {
+      // Permission mode: "allow" (no prompt), "ask" (prompt), "deny" (tool not registered)
+      "permission": "allow",
       // Show distillation content as an ignored message notification
       "showDistillation": false
+    },
+    // Collapses a range of conversation content into a single summary
+    "compress": {
+      // Permission mode: "deny" (tool not registered), "ask" (prompt), "allow" (no prompt)
+      "permission": "deny",
+      // Show summary content as an ignored message notification
+      "showCompression": false
+    },
+    // Removes tool content from context without preservation (for completed tasks or noise)
+    "prune": {
+      // Permission mode: "allow" (no prompt), "ask" (prompt), "deny" (tool not registered)
+      "permission": "allow"
     }
   },
   // Automatic pruning strategies
@@ -48,9 +64,9 @@
       // Additional tools to protect from pruning
       "protectedTools": []
     },
-    // Prune write tool in`pu`ts when the file has been subsequently read
+    // Prune write tool inputs when the file has been subsequently read
     "supersedeWrites": {
-      "enabled": false
+      "enabled": true
     },
     // Prune tool inputs for errored tools after X turns
     "purgeErrors": {

--- a/.config/opencode/oh-my-opencode.json
+++ b/.config/opencode/oh-my-opencode.json
@@ -3,7 +3,7 @@
   "agents": {
     // Powerful AI orchestrator. Plans obsessively with todos, assesses search complexity before exploration, delegates strategically via category+skills combinations. Uses explore for internal code (parallel-friendly), librarian for external docs.
     "sisyphus": {
-      "model": "google/antigravity-claude-opus-4-5-thinking",
+      "model": "google/antigravity-claude-opus-4-6-thinking",
       "variant": "max",
       "prompt_append": "---\n\n## Session Management (MANDATORY)\nAt the start of the session or before investigating any issue:\n1. Use the `session_search` tool to find relevant prior sessions for this project\n2. Use the `session_read` tool to review prior work if found\n3. Avoid repeating investigation already completed in previous sessions\n\nBefore completing:\n1. Ensure your session contains a summary of work done\n2. Include key decisions, findings, and outcomes\n3. This summary will be searchable in future agent runs\n\n---\n\nALWAYS USE THE QUESTION TOOL IF YOU NEED TO ASK USER."
     },
@@ -32,13 +32,13 @@
     },
     // Strategic planning agent - verbose, detailed plans with tables and file references.
     "prometheus": {
-      "model": "google/antigravity-claude-opus-4-5-thinking",
+      "model": "google/antigravity-claude-opus-4-6-thinking",
       "variant": "max",
       "prompt_append": "---\n\n## Session Management (MANDATORY)\nAt the start of the session or before investigating any issue:\n1. Use the `session_search` tool to find relevant prior sessions for this project\n2. Use the `session_read` tool to review prior work if found\n3. Avoid repeating investigation already completed in previous sessions\n\nBefore completing:\n1. Ensure your session contains a summary of work done\n2. Include key decisions, findings, and outcomes\n3. This summary will be searchable in future agent runs\n\n---\n\nALWAYS USE THE QUESTION TOOL IF YOU NEED TO ASK USER."
     },
     // Pre-planning consultant that analyzes requests to identify hidden intentions, ambiguities, and AI failure points.
     "metis": {
-      "model": "google/antigravity-claude-opus-4-5-thinking",
+      "model": "google/antigravity-claude-opus-4-6-thinking",
       "variant": "max",
       "prompt_append": "\nALWAYS USE THE QUESTION TOOL IF YOU NEED TO ASK USER."
     },
@@ -87,7 +87,7 @@
     },
     // Tasks that don't fit other categories, high effort required
     "unspecified-high": {
-      "model": "google/antigravity-claude-opus-4-5-thinking",
+      "model": "google/antigravity-claude-opus-4-6-thinking",
       "variant": "max"
     },
     // Documentation, prose, technical writing

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -1,120 +1,90 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
-    "opencode-antigravity-auth@1.4.3",
-    "oh-my-opencode@3.2.3",
-    "@tarquinen/opencode-dcp@1.2.8",
+    "opencode-antigravity-auth@1.5.0-beta.0",
+    "oh-my-opencode@3.2.4",
+    "@tarquinen/opencode-dcp@2.0.2",
     "@franlol/opencode-md-table-formatter@latest"
   ],
   "provider": {
     "google": {
-      "name": "Google",
       "models": {
         "antigravity-gemini-3-pro": {
           "name": "Gemini 3 Pro (Antigravity)",
-          "limit": {
-            "context": 1048576,
-            "output": 65535
-          },
-          "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
-          },
+          "limit": { "context": 1048576, "output": 65535 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
           "variants": {
-            "low": {
-              "thinkingLevel": "low"
-            },
-            "high": {
-              "thinkingLevel": "high"
-            }
+            "low": { "thinkingLevel": "low" },
+            "high": { "thinkingLevel": "high" }
           }
         },
         "antigravity-gemini-3-flash": {
           "name": "Gemini 3 Flash (Antigravity)",
-          "limit": {
-            "context": 1048576,
-            "output": 65536
-          },
-          "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
-          },
+          "limit": { "context": 1048576, "output": 65536 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
           "variants": {
-            "minimal": {
-              "thinkingLevel": "minimal"
-            },
-            "low": {
-              "thinkingLevel": "low"
-            },
-            "medium": {
-              "thinkingLevel": "medium"
-            },
-            "high": {
-              "thinkingLevel": "high"
-            }
+            "minimal": { "thinkingLevel": "minimal" },
+            "low": { "thinkingLevel": "low" },
+            "medium": { "thinkingLevel": "medium" },
+            "high": { "thinkingLevel": "high" }
           }
         },
         "antigravity-claude-sonnet-4-5": {
           "name": "Claude Sonnet 4.5 (Antigravity)",
-          "limit": {
-            "context": 200000,
-            "output": 64000
-          },
-          "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
-          }
+          "limit": { "context": 200000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         },
         "antigravity-claude-sonnet-4-5-thinking": {
           "name": "Claude Sonnet 4.5 Thinking (Antigravity)",
-          "limit": {
-            "context": 200000,
-            "output": 64000
-          },
-          "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
-          },
+          "limit": { "context": 200000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
           "variants": {
-            "low": {
-              "thinkingConfig": {
-                "thinkingBudget": 8192
-              }
-            },
-            "max": {
-              "thinkingConfig": {
-                "thinkingBudget": 32768
-              }
-            }
+            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
+            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
           }
         },
         "antigravity-claude-opus-4-5-thinking": {
           "name": "Claude Opus 4.5 Thinking (Antigravity)",
-          "limit": {
-            "context": 200000,
-            "output": 64000
-          },
-          "modalities": {
-            "input": ["text", "image", "pdf"],
-            "output": ["text"]
-          },
+          "limit": { "context": 200000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
           "variants": {
-            "low": {
-              "thinkingConfig": {
-                "thinkingBudget": 8192
-              }
-            },
-            "max": {
-              "thinkingConfig": {
-                "thinkingBudget": 32768
-              }
-            }
+            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
+            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
           }
+        },
+        "antigravity-claude-opus-4-6-thinking": {
+          "name": "Claude Opus 4.6 Thinking (Antigravity)",
+          "limit": { "context": 200000, "output": 64000 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+          "variants": {
+            "low": { "thinkingConfig": { "thinkingBudget": 8192 } },
+            "max": { "thinkingConfig": { "thinkingBudget": 32768 } }
+          }
+        },
+        "gemini-2.5-flash": {
+          "name": "Gemini 2.5 Flash (Gemini CLI)",
+          "limit": { "context": 1048576, "output": 65536 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "gemini-2.5-pro": {
+          "name": "Gemini 2.5 Pro (Gemini CLI)",
+          "limit": { "context": 1048576, "output": 65536 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "gemini-3-flash-preview": {
+          "name": "Gemini 3 Flash Preview (Gemini CLI)",
+          "limit": { "context": 1048576, "output": 65536 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
+        },
+        "gemini-3-pro-preview": {
+          "name": "Gemini 3 Pro Preview (Gemini CLI)",
+          "limit": { "context": 1048576, "output": 65535 },
+          "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] }
         }
       }
     }
   },
-  "model": "google/antigravity-claude-opus-4-5-thinking",
+  "model": "google/antigravity-claude-opus-4-6-thinking",
   "small_model": "google/antigravity-gemini-3-flash",
   "theme": "catppuccin"
 }


### PR DESCRIPTION
Update OpenCode ecosystem with latest plugins and model support:

- Upgrade opencode-ai from 1.1.51 to 1.1.53
- Update plugins:
  - opencode-antigravity-auth: 1.4.3 → 1.5.0-beta.0
  - oh-my-opencode: 3.2.3 → 3.2.4
  - @tarquinen/opencode-dcp: 1.2.8 → 2.0.2

Model updates:
- Add antigravity-claude-opus-4-6-thinking model definition
- Add Gemini 2.5 and 3 preview models (flash, pro variants)
- Update default model to claude-opus-4-6-thinking
- Migrate sisyphus, prometheus, metis agents to opus-4-6

DCP configuration overhaul:
- Migrate to permission-based tool system (distill/compress/prune)
- Add schema reference and slash commands support
- Enable supersedeWrites strategy
- Add protectedFilePatterns and contextLimit settings
- Disable turnProtection by default

Antigravity enhancements:
- Disable auto_update
- Enable cli_first mode