### PR TITLE
chore(opencode): update plugins and adjust feature flags

### DIFF
--- a/.config/opencode/AGENTS.md
+++ b/.config/opencode/AGENTS.md
@@ -59,19 +59,6 @@ If you cannot verify, you must say so explicitly and propose the next best verif
 - “security by vibes” — if you’re unsure, ask and threat-model lightly
 </safety_boundaries>
 
-<action_bias>
-Default to action when:
-- the task is unambiguous
-- risk is low and reversible
-- you have enough context to proceed
-
-Default to asking when:
-- action falls under "Ask First" boundaries
-- multiple valid interpretations exist with meaningfully different effort/risk
-- you're about to make an architectural decision that's hard to undo
-- if you're unsure whether an action is risky, irreversible, or hard to undo, ask first
-</action_bias>
-
 ## Code Philosophy
 
 ### Design Principles (defaults)

--- a/.config/opencode/dcp.jsonc
+++ b/.config/opencode/dcp.jsonc
@@ -39,7 +39,7 @@
     // Distills key findings into preserved knowledge before removing raw content
     "distill": {
       // Permission mode: "allow" (no prompt), "ask" (prompt), "deny" (tool not registered)
-      "permission": "allow",
+      "permission": "deny",
       // Show distillation content as an ignored message notification
       "showDistillation": false
     },

--- a/.config/opencode/oh-my-opencode.json
+++ b/.config/opencode/oh-my-opencode.json
@@ -95,8 +95,13 @@
       "model": "google/antigravity-gemini-3-flash"
     }
   },
+  "claude_code": {
+    "mcp": false
+  },
   "disabled_agents": ["hephaestus"],
+  "disabled_hooks": ["todo-continuation-enforcer"],
   "disabled_mcps": ["websearch", "context7", "grep_app"],
+  "disabled_skills": ["git-master"],
   "git_master": {
     "commit_footer": false,
     "include_co_authored_by": false
@@ -107,5 +112,8 @@
       "command": ["remark-language-server", "--stdio"],
       "extensions": [".md"]
     }
+  },
+  "sisyphus_agent": {
+    "default_builder_enabled": true
   }
 }

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -2,8 +2,7 @@
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
     "opencode-antigravity-auth@1.5.0-beta.0",
-    "oh-my-opencode@3.2.4",
-    "@tarquinen/opencode-dcp@2.0.2",
+    "oh-my-opencode@3.4.0",
     "@franlol/opencode-md-table-formatter@latest"
   ],
   "provider": {


### PR DESCRIPTION
- Upgrade oh-my-opencode to 3.4.0 and remove opencode-dcp plugin
- Disable distill permission, MCP integration, todo-continuation-enforcer, and git-master
- Enable sisyphus default builder and remove action_bias docs section