### PR TITLE
docs(research-tools): remove unneeded Tavily tools; prioritize Exa

### DIFF
--- a/.config/opencode/skills/research-tools/SKILL.md
+++ b/.config/opencode/skills/research-tools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-tools
-description: External research via Context7 (docs), Grep.app (code examples), Tavily (web search, extract, crawl), and Exa (web search). Loads MCPs on-demand via skill_mcp.
+description: External research via Context7 (docs), Grep.app (code examples), Exa (web search), and Tavily (web search). Loads MCPs on-demand via skill_mcp.
 license: MIT
 compatibility: opencode
 metadata:
@@ -26,11 +26,8 @@ skill_mcp(mcp_name="<MCP_SERVER>", tool_name="<TOOL>", arguments='<JSON>')
 | `context7` | `resolve-library-id` | Get library ID (required first) |
 | `context7` | `query-docs` | Query library documentation |
 | `grep_app` | `searchGitHub` | GitHub code pattern search |
-| `tavily` | `tavily_search` | Web search (real-time, news, finance) |
-| `tavily` | `tavily_extract` | Extract content from specific URLs |
-| `tavily` | `tavily_crawl` | Crawl multiple pages from a base URL |
-| `tavily` | `tavily_map` | Map/discover website structure and URLs |
 | `websearch` | `web_search_exa` | Web search |
+| `tavily` | `tavily_search` | Web search (real-time, news, finance) |
 
 ## Examples
 
@@ -45,33 +42,16 @@ skill_mcp(mcp_name="context7", tool_name="query-docs", arguments='{"libraryId": 
 skill_mcp(mcp_name="grep_app", tool_name="searchGitHub", arguments='{"query": "useActionState(", "language": ["TypeScript", "TSX"]}')
 ```
 
+**Exa**:
+```
+skill_mcp(mcp_name="websearch", tool_name="web_search_exa", arguments='{"query": "Next.js 15 features", "numResults": 5}')
+```
+
 **Tavily Search** (real-time web search with topic filtering):
 ```
 skill_mcp(mcp_name="tavily", tool_name="tavily_search", arguments='{"query": "Next.js 15 features", "max_results": 5}')
 skill_mcp(mcp_name="tavily", tool_name="tavily_search", arguments='{"query": "OpenAI API pricing", "topic": "news", "days": 7}')
 skill_mcp(mcp_name="tavily", tool_name="tavily_search", arguments='{"query": "AAPL stock", "topic": "finance"}')
-```
-
-**Tavily Extract** (get full content from specific URLs):
-```
-skill_mcp(mcp_name="tavily", tool_name="tavily_extract", arguments='{"urls": ["https://docs.example.com/guide"]}')
-skill_mcp(mcp_name="tavily", tool_name="tavily_extract", arguments='{"urls": ["https://linkedin.com/in/someone"], "extract_depth": "advanced"}')
-```
-
-**Tavily Crawl** (crawl multiple pages from a starting URL):
-```
-skill_mcp(mcp_name="tavily", tool_name="tavily_crawl", arguments='{"url": "https://docs.example.com", "max_depth": 2, "limit": 10}')
-skill_mcp(mcp_name="tavily", tool_name="tavily_crawl", arguments='{"url": "https://blog.example.com", "instructions": "Find all tutorial pages"}')
-```
-
-**Tavily Map** (discover site structure without extracting content):
-```
-skill_mcp(mcp_name="tavily", tool_name="tavily_map", arguments='{"url": "https://docs.example.com", "max_depth": 3}')
-```
-
-**Exa**:
-```
-skill_mcp(mcp_name="websearch", tool_name="web_search_exa", arguments='{"query": "Next.js 15 features", "numResults": 5}')
 ```
 
 ## Common Mistakes


### PR DESCRIPTION
- Remove documentation for tavily_extract, tavily_crawl, and tavily_map tools
- Update description to remove mentions of extract and crawl capabilities
- Reorder tools table: move websearch before tavily
- Add separate Exa examples section
- Reorder examples to match tools table order