### PR TITLE
feat(opencode): re-enable hephaestus agent and update model assignments

### DIFF
--- a/.config/opencode/oh-my-opencode.json
+++ b/.config/opencode/oh-my-opencode.json
@@ -7,14 +7,19 @@
       "variant": "max",
       "prompt_append": "---\n\n## Session Management (MANDATORY)\nAt the start of the session or before investigating any issue:\n1. Use the `session_search` tool to find relevant prior sessions for this project\n2. Use the `session_read` tool to review prior work if found\n3. Avoid repeating investigation already completed in previous sessions\n\nBefore completing:\n1. Ensure your session contains a summary of work done\n2. Include key decisions, findings, and outcomes\n3. This summary will be searchable in future agent runs\n\n---\n\nALWAYS USE THE QUESTION TOOL IF YOU NEED TO ASK USER."
     },
+    // Autonomous Deep Worker - goal-oriented execution with GPT 5.2 Codex. Explores thoroughly before acting, uses explore/librarian agents for comprehensive context, completes tasks end-to-end. Inspired by AmpCode deep mode.
+    "hephaestus": {
+      "model": "opencode/gpt-5.3-codex",
+      "variant": "medium"
+    },
     // Read-only consultation agent. High-IQ reasoning specialist for debugging hard problems and high-difficulty architecture design.
     "oracle": {
-      "model": "opencode/gpt-5.3-codex",
+      "model": "github-copilot/gpt-5.2",
       "variant": "high"
     },
     // Specialized codebase understanding agent for multi-repository analysis, searching remote codebases, retrieving official documentation, and finding implementation examples using GitHub CLI, Context7, and Web Search. MUST BE USED when users ask to look up code in remote repositories, explain library internals, or find usage examples in open source.
     "librarian": {
-      "model": "anthropic/claude-sonnet-4-6"
+      "model": "github-copilot/gemini-3-flash-preview"
     },
     // Contextual grep for codebases. Answers "Where is X?", "Which file has Y?", "Find the code that does Z". Fire multiple in parallel for broad searches. Specify thoroughness: "quick" for basic, "medium" for moderate, "very thorough" for comprehensive analysis.
     "explore": {
@@ -54,7 +59,8 @@
   "categories": {
     // Frontend, UI/UX, design, styling, animation
     "visual-engineering": {
-      "model": "github-copilot/gemini-3-pro-preview"
+      "model": "github-copilot/gemini-3.1-pro-preview",
+      "variant": "high"
     },
     // Use ONLY for genuinely hard, logic-heavy tasks. Give clear goals only, not step-by-step instructions.
     "ultrabrain": {
@@ -63,12 +69,12 @@
     },
     // Goal-oriented autonomous problem-solving. Thorough research before action. For hairy problems requiring deep understanding.
     "deep": {
-      "model": "github-copilot/gpt-5.2-codex",
+      "model": "opencode/gpt-5.3-codex",
       "variant": "medium"
     },
     // Complex problem-solving with unconventional, creative approaches - beyond standard patterns
     "artistry": {
-      "model": "github-copilot/gemini-3-pro-preview",
+      "model": "github-copilot/gemini-3.1-pro-preview",
       "variant": "high"
     },
     // Trivial tasks - single file changes, typo fixes, simple modifications
@@ -97,8 +103,7 @@
     "plugins": false,
     "skills": false
   },
-  "disabled_agents": ["hephaestus"],
-  "disabled_hooks": ["keyword-detector", "no-sisyphus-gpt", "todo-continuation-enforcer"],
+  "disabled_hooks": ["keyword-detector", "todo-continuation-enforcer"],
   "disabled_mcps": ["websearch", "context7", "grep_app"],
   "git_master": {
     "commit_footer": false,


### PR DESCRIPTION
- Re-enable hephaestus agent (Deep Worker with GPT 5.3 Codex)
- Update oracle agent from opencode/gpt-5.3-codex to github-copilot/gpt-5.2
- Update librarian agent from claude-sonnet-4-6 to github-copilot/gemini-3-flash
- Upgrade visual-engineering category to gemini-3.1-pro with variant high
- Switch deep category to opencode/gpt-5.3-codex
- Upgrade artistry category to gemini-3.1-pro with variant high
- Remove no-sisyphus-gpt from disabled hooks
- Optimize model distribution across agents and categories