### PR TITLE
feat(opencode): enable semantic search and refresh plugins

### DIFF
--- a/.config/opencode/aft.jsonc
+++ b/.config/opencode/aft.jsonc
@@ -1,3 +1,4 @@
 {
-  "experimental_search_index": true
+  "experimental_search_index": true,
+  "experimental_semantic_search": true
 }

--- a/.config/opencode/magic-context.jsonc
+++ b/.config/opencode/magic-context.jsonc
@@ -1,11 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/cortexkit/opencode-magic-context/master/assets/magic-context.schema.json",
   "historian": {
-    "model": "anthropic/claude-sonnet-4-6"
+    "model": "github-copilot/claude-sonnet-4.6"
   },
   "dreamer": {
     "enabled": true,
-    "model": "anthropic/claude-sonnet-4-6"
+    "model": "github-copilot/claude-sonnet-4.6"
   },
   "sidekick": {
     "enabled": true,

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -5,8 +5,8 @@
     "oh-my-openagent@3.15.3",
     "@fro.bot/systematic@latest",
     "@franlol/opencode-md-table-formatter@latest",
-    "@cortexkit/aft-opencode@0.9.1",
-    "@cortexkit/opencode-magic-context@0.8.3"
+    "@cortexkit/opencode-magic-context@0.8.3",
+    "@cortexkit/aft-opencode@0.11.1"
   ],
   "mcp": {
     "context7": {

--- a/.config/opencode/tui.json
+++ b/.config/opencode/tui.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://opencode.ai/tui.json",
   "theme": "catppuccin",
-  "plugin": ["@cortexkit/opencode-magic-context@latest"]
+  "plugin": [
+    "@cortexkit/opencode-magic-context@latest",
+    "@cortexkit/aft-opencode@0.11.1"
+  ]
 }


### PR DESCRIPTION
- enable `experimental_semantic_search` in AFT config
- switch Magic Context historian/dreamer models to `github-copilot/claude-sonnet-4.6`
- bump `@cortexkit/aft-opencode` from `0.9.1` to `0.11.1`
- add AFT plugin to TUI plugin list
- normalize JSON formatting/newline in Magic Context config