### PR TITLE
chore(opencode): update opencode plugins + telemetry

### DIFF
--- a/.config/bash/exports
+++ b/.config/bash/exports
@@ -355,6 +355,11 @@ export AZURE_CONFIG_DIR="$XDG_DATA_HOME"/azure
 
 export VIBE_TOOLS_NO_TELEMETRY=1
 
+# OMO (oh-my-openagent)
+
+export OMO_SEND_ANONYMOUS_TELEMETRY=0
+export OMO_DISABLE_POSTHOG=1
+
 # ASDF
 
 if command_exists asdf; then

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -30,8 +30,8 @@ ast-grep = "0.40.5"
 "npm:agent-browser" = "0.25.3"
 "npm:skills" = "1.4.9"
 "npm:ocx" = "2.0.6"
-"npm:@cortexkit/opencode-magic-context" = "0.8.6"
-"npm:@cortexkit/aft-opencode" = "0.11.1"
+"npm:@cortexkit/opencode-magic-context" = "0.8.10"
+"npm:@cortexkit/aft-opencode" = "0.11.4"
 "npm:@marcusrbrown/infra" = "latest"
 
 # Language Servers

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -2,11 +2,11 @@
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
     "opencode-claude-auth@1.4.9",
-    "oh-my-openagent@3.15.3",
+    "oh-my-openagent@3.17.0",
     "@fro.bot/systematic@latest",
     "@franlol/opencode-md-table-formatter@latest",
-    "@cortexkit/opencode-magic-context@0.8.6",
-    "@cortexkit/aft-opencode@0.11.1"
+    "@cortexkit/opencode-magic-context@0.8.10",
+    "@cortexkit/aft-opencode@0.11.4"
   ],
   "mcp": {
     "context7": {


### PR DESCRIPTION
- bump `@cortexkit/opencode-magic-context` from 0.8.6 to 0.8.10 in mise and opencode config
- bump `@cortexkit/aft-opencode` from 0.11.1 to 0.11.4 in mise and opencode config
- bump `oh-my-openagent` from 3.15.3 to 3.17.0 in opencode config
- add OMO telemetry opt-out env vars in bash exports