### PR TITLE
chore(opencode): update plugins and auth package

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -30,8 +30,8 @@ ast-grep = "0.40.5"
 "npm:agent-browser" = "0.25.3"
 "npm:skills" = "1.4.9"
 "npm:ocx" = "2.0.6"
-"npm:@cortexkit/opencode-magic-context" = "0.8.10"
-"npm:@cortexkit/aft-opencode" = "0.11.4"
+"npm:@cortexkit/opencode-magic-context" = "0.8.11"
+"npm:@cortexkit/aft-opencode" = "0.11.5"
 "npm:@marcusrbrown/infra" = "latest"
 
 # Language Servers

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
-    "opencode-claude-auth@1.4.9",
+    "@ex-machina/opencode-anthropic-auth@1.6.1",
     "oh-my-openagent@3.17.0",
     "@fro.bot/systematic@latest",
     "@franlol/opencode-md-table-formatter@latest",
-    "@cortexkit/opencode-magic-context@0.8.10",
-    "@cortexkit/aft-opencode@0.11.4"
+    "@cortexkit/opencode-magic-context@0.8.11",
+    "@cortexkit/aft-opencode@0.11.5"
   ],
   "mcp": {
     "context7": {

--- a/.config/opencode/tui.json
+++ b/.config/opencode/tui.json
@@ -2,7 +2,7 @@
   "$schema": "https://opencode.ai/tui.json",
   "theme": "catppuccin",
   "plugin": [
-    "@cortexkit/opencode-magic-context@0.8.10",
-    "@cortexkit/aft-opencode@0.11.4"
+    "@cortexkit/opencode-magic-context@0.8.11",
+    "@cortexkit/aft-opencode@0.11.5"
   ]
 }


### PR DESCRIPTION
- bump `@cortexkit/opencode-magic-context` from `0.8.10` to `0.8.11` in mise, opencode, and tui configs
- bump `@cortexkit/aft-opencode` from `0.11.4` to `0.11.5` in mise, opencode, and tui configs
- replace `opencode-claude-auth@1.4.9` with `@ex-machina/opencode-anthropic-auth@1.6.1` in opencode plugin list