### PR TITLE
chore(opencode): bump plugins and tune context

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -30,8 +30,8 @@ ast-grep = "0.40.5"
 "npm:agent-browser" = "0.25.3"
 "npm:skills" = "1.4.9"
 "npm:ocx" = "2.0.6"
-"npm:@cortexkit/opencode-magic-context" = "0.8.11"
-"npm:@cortexkit/aft-opencode" = "0.11.5"
+"npm:@cortexkit/opencode-magic-context" = "0.8.12"
+"npm:@cortexkit/aft-opencode" = "0.12.1"
 "npm:@marcusrbrown/infra" = "latest"
 
 # Language Servers

--- a/.config/opencode/magic-context.jsonc
+++ b/.config/opencode/magic-context.jsonc
@@ -9,7 +9,7 @@
   },
   "sidekick": {
     "enabled": true,
-    "model": "opencode/gpt-5-nano"
+    "model": "github-copilot/gpt-5-mini"
   },
   "cache_ttl": {
     "default": "5m",
@@ -30,6 +30,7 @@
     "user_memories": {
       "enabled": true,
       "promotion_threshold": 3
-    }
+    },
+    "compaction_markers": true
   }
 }

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -2,11 +2,11 @@
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
     "@ex-machina/opencode-anthropic-auth@1.6.1",
-    "oh-my-openagent@3.17.0",
+    "oh-my-openagent@3.17.2",
     "@fro.bot/systematic@latest",
     "@franlol/opencode-md-table-formatter@latest",
-    "@cortexkit/opencode-magic-context@0.8.11",
-    "@cortexkit/aft-opencode@0.11.5"
+    "@cortexkit/opencode-magic-context@0.8.12",
+    "@cortexkit/aft-opencode@0.12.1"
   ],
   "mcp": {
     "context7": {

--- a/.config/opencode/tui.json
+++ b/.config/opencode/tui.json
@@ -2,7 +2,7 @@
   "$schema": "https://opencode.ai/tui.json",
   "theme": "catppuccin",
   "plugin": [
-    "@cortexkit/opencode-magic-context@0.8.11",
-    "@cortexkit/aft-opencode@0.11.5"
+    "@cortexkit/opencode-magic-context@0.8.12",
+    "@cortexkit/aft-opencode@0.12.1"
   ]
 }


### PR DESCRIPTION
- bump `@cortexkit/opencode-magic-context` from `0.8.11` to `0.8.12` across mise and opencode configs
- bump `@cortexkit/aft-opencode` from `0.11.5` to `0.12.1` across mise and opencode configs
- bump `oh-my-openagent` from `3.17.0` to `3.17.2`
- switch magic-context sidekick model to `github-copilot/gpt-5-mini`
- enable `compaction_markers` in magic-context memory settings