### PR TITLE
chore(opencode): upgrade plugins and align config

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -31,7 +31,7 @@ ast-grep = "0.40.5"
 "npm:skills" = "1.5.0"
 "npm:ocx" = "2.0.6"
 "npm:@cortexkit/opencode-magic-context" = "0.9.0"
-"npm:@cortexkit/aft-opencode" = "0.12.2"
+"npm:@cortexkit/aft-opencode" = "0.13.0"
 "npm:@marcusrbrown/infra" = "latest"
 
 # Language Servers

--- a/.config/opencode/magic-context.jsonc
+++ b/.config/opencode/magic-context.jsonc
@@ -1,11 +1,11 @@
 {
-  "$schema": "https://raw.githubusercontent.com/cortexkit/opencode-magic-context/master/assets/magic-context.schema.json",
+  "$schema": "https://raw.githubusercontent.com/cortexkit/opencode-magic-context/refs/heads/master/assets/magic-context.schema.json",
   "historian": {
-    "model": "github-copilot/claude-sonnet-4.6"
+    "model": "anthropic/claude-sonnet-4-6"
   },
   "dreamer": {
     "enabled": true,
-    "model": "github-copilot/claude-sonnet-4.6"
+    "model": "anthropic/claude-sonnet-4-6"
   },
   "sidekick": {
     "enabled": true,

--- a/.config/opencode/oh-my-openagent.json
+++ b/.config/opencode/oh-my-openagent.json
@@ -87,9 +87,23 @@
     "plugins": false,
     "skills": true
   },
-  "disabled_agents": ["atlas", "hephaestus"],
-  "disabled_hooks": ["context-window-monitor", "preemptive-compaction", "anthropic-context-window-limit-recovery"],
-  "disabled_skills": ["git-master"],
+  "disabled_agents": [
+    "atlas",
+    "hephaestus"
+  ],
+  "disabled_hooks": [
+    "context-window-monitor",
+    "preemptive-compaction",
+    "anthropic-context-window-limit-recovery"
+  ],
+  "disabled_skills": [
+    "git-master"
+  ],
+  "git_master": {
+    "commit_footer": false,
+    "include_co_authored_by": false,
+    "git_env_prefix": "GIT_MASTER=1"
+  },
   "hashline_edit": true,
   "sisyphus_agent": {
     "default_builder_enabled": true,

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
-    "@ex-machina/opencode-anthropic-auth@1.7.0",
-    "oh-my-openagent@3.17.2",
+    "@ex-machina/opencode-anthropic-auth@1.7.1",
+    "oh-my-openagent@3.17.4",
     "@fro.bot/systematic@latest",
     "@franlol/opencode-md-table-formatter@latest",
     "@cortexkit/opencode-magic-context@0.9.0",
-    "@cortexkit/aft-opencode@0.12.2"
+    "@cortexkit/aft-opencode@0.13.0"
   ],
   "mcp": {
     "context7": {

--- a/.config/opencode/tui.json
+++ b/.config/opencode/tui.json
@@ -3,6 +3,6 @@
   "theme": "catppuccin",
   "plugin": [
     "@cortexkit/opencode-magic-context@0.9.0",
-    "@cortexkit/aft-opencode@0.12.2"
+    "@cortexkit/aft-opencode@0.13.0"
   ]
 }


### PR DESCRIPTION
- bump @cortexkit/aft-opencode from 0.12.2 to 0.13.0 in mise, opencode, and tui configs
- bump oh-my-openagent from 3.17.2 to 3.17.4
- bump @ex-machina/opencode-anthropic-auth from 1.7.0 to 1.7.1
- update magic-context schema URL to refs/heads/master path
- switch magic-context historian and dreamer model ids to anthropic/claude-sonnet-4-6
- expand oh-my-openagent git_master settings