### PR TITLE
chore(opencode): update magic-context to 0.9.1

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -30,7 +30,7 @@ ast-grep = "0.40.5"
 "npm:agent-browser" = "0.25.4"
 "npm:skills" = "1.5.0"
 "npm:ocx" = "2.0.6"
-"npm:@cortexkit/opencode-magic-context" = "0.9.0"
+"npm:@cortexkit/opencode-magic-context" = "0.9.1"
 "npm:@cortexkit/aft-opencode" = "0.13.0"
 "npm:@marcusrbrown/infra" = "latest"
 

--- a/.config/opencode/magic-context.jsonc
+++ b/.config/opencode/magic-context.jsonc
@@ -1,11 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/cortexkit/opencode-magic-context/refs/heads/master/assets/magic-context.schema.json",
   "historian": {
-    "model": "anthropic/claude-sonnet-4-6"
+    "model": "github-copilot/claude-sonnet-4.6"
   },
   "dreamer": {
     "enabled": true,
-    "model": "anthropic/claude-sonnet-4-6"
+    "model": "github-copilot/claude-sonnet-4.6"
   },
   "sidekick": {
     "enabled": true,

--- a/.config/opencode/oh-my-openagent.json
+++ b/.config/opencode/oh-my-openagent.json
@@ -94,7 +94,9 @@
   "disabled_hooks": [
     "context-window-monitor",
     "preemptive-compaction",
-    "anthropic-context-window-limit-recovery"
+    "anthropic-context-window-limit-recovery",
+    "keyword-detector",
+    "todo-continuation-enforcer"
   ],
   "disabled_skills": [
     "git-master"

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -5,7 +5,7 @@
     "oh-my-openagent@3.17.4",
     "@fro.bot/systematic@latest",
     "@franlol/opencode-md-table-formatter@latest",
-    "@cortexkit/opencode-magic-context@0.9.0",
+    "@cortexkit/opencode-magic-context@0.9.1",
     "@cortexkit/aft-opencode@0.13.0"
   ],
   "mcp": {

--- a/.config/opencode/tui.json
+++ b/.config/opencode/tui.json
@@ -2,7 +2,7 @@
   "$schema": "https://opencode.ai/tui.json",
   "theme": "catppuccin",
   "plugin": [
-    "@cortexkit/opencode-magic-context@0.9.0",
+    "@cortexkit/opencode-magic-context@0.9.1",
     "@cortexkit/aft-opencode@0.13.0"
   ]
 }


### PR DESCRIPTION
- bump @cortexkit/opencode-magic-context from 0.9.0 to 0.9.1 in mise and opencode plugin configs
- switch magic-context model IDs from anthropic namespace to github-copilot namespace
- disable keyword-detector and todo-continuation-enforcer hooks in oh-my-openagent settings