### PR TITLE
chore(ai-config): adjust Claude and OpenAgent settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -160,8 +160,6 @@
       "Bash(rm -rf /)",
       "Bash(rm -rf ~)",
       "Bash(rm -rf /*)",
-      "Bash(sudo:*passwd*)",
-      "Bash(sudo:*shadow*)",
       "Bash(sudo chmod 777:*)",
       "Bash(sudo chown:*)",
       "Bash(sudo -i:*)",
@@ -211,5 +209,6 @@
   "statusLine": {
     "type": "command",
     "command": "bun x ccusage@latest statusline"
-  }
+  },
+  "model": "sonnet"
 }

--- a/.config/opencode/oh-my-openagent.json
+++ b/.config/opencode/oh-my-openagent.json
@@ -95,8 +95,7 @@
     "context-window-monitor",
     "preemptive-compaction",
     "anthropic-context-window-limit-recovery",
-    "keyword-detector",
-    "todo-continuation-enforcer"
+    "keyword-detector"
   ],
   "disabled_skills": [
     "git-master"


### PR DESCRIPTION
- remove sudo passwd/shadow command patterns from blocked command list in Claude settings
- set Claude default model to sonnet
- update OpenAgent disabled hooks by removing todo-continuation-enforcer while keeping keyword-detector disabled