### PR TITLE
feat(opencode): improve magic-context model resilience

### DIFF
--- a/.config/opencode/magic-context.jsonc
+++ b/.config/opencode/magic-context.jsonc
@@ -1,11 +1,13 @@
 {
   "$schema": "https://raw.githubusercontent.com/cortexkit/opencode-magic-context/refs/heads/master/assets/magic-context.schema.json",
   "historian": {
-    "model": "github-copilot/claude-sonnet-4.6"
+    "model": "anthropic/claude-sonnet-4-6",
+    "fallback_models": ["github-copilot/claude-sonnet-4.6"]
   },
   "dreamer": {
     "enabled": true,
-    "model": "github-copilot/claude-sonnet-4.6"
+    "model": "anthropic/claude-sonnet-4-6",
+    "fallback_models": ["github-copilot/claude-sonnet-4.6"]
   },
   "sidekick": {
     "enabled": true,
@@ -14,23 +16,30 @@
   "cache_ttl": {
     "default": "5m",
     "anthropic/claude-sonnet-4-6": "59m",
-    "anthropic/claude-opus-4-6": "59m"
+    "anthropic/claude-opus-4-6": "59m",
+    "anthropic/claude-opus-4-7": "59m"
   },
   "execute_threshold_percentage": {
     "default": 65,
     "anthropic/claude-sonnet-4-6": 40,
-    "anthropic/claude-opus-4-6": 40
+    "anthropic/claude-opus-4-6": 40,
+    "anthropic/claude-opus-4-7": 40
   },
   "experimental": {
     "pin_key_files": {
       "enabled": true,
-      "token_budget": 10000,
+      "token_budget": 20000,
       "min_reads": 4
     },
     "user_memories": {
       "enabled": true,
       "promotion_threshold": 3
     }
+  },
+  "history_budget_percentage": 0.21,
+  "historian_timeout_ms": 420000,
+  "memory": {
+    "injection_budget_tokens": 20000
   },
   "compaction_markers": true,
   "ctx_reduce_enabled": false


### PR DESCRIPTION
- switch historian and dreamer to anthropic/claude-sonnet-4-6
- add github-copilot/claude-sonnet-4.6 as fallback_models for both agents
- add claude-opus-4-7 entries for cache TTL and execute threshold maps
- increase experimental pin_key_files token_budget from 10000 to 20000
- add history_budget_percentage (0.21) and historian_timeout_ms (420000)
- add memory.injection_budget_tokens set to 20000