### PR TITLE
chore(gitignore): remove dead .claude/skills/ allowlist entry

### DIFF
--- a/.dotfiles/.gitignore
+++ b/.dotfiles/.gitignore
@@ -16,7 +16,6 @@
 !/.claude/CLAUDE.md
 !/.claude/rules/
 !/.claude/settings.json
-!/.claude/skills/
 !/.config/
 !/.devcontainer/
 /.devcontainer/.*Marker


### PR DESCRIPTION
The `!/.claude/skills/` entry in `.dotfiles/.gitignore` allowlists a directory that has zero tracked files and no local copy at `~/.claude/skills/`. Fro Bot daily maintenance reports have been flagging it since 2026-04-06.

Skills live at `~/.agents/skills/` (already allowlisted via `!/.agents/`), not under `.claude/`.

Fixes one of the standing hygiene items called out in `#1430` and every prior daily report.