### PR TITLE
docs(agents-md): refresh from /init-deep against HEAD 90742fb

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
 # DOTFILES KNOWLEDGE BASE
 
-**Generated:** 2026-02-02
-**Commit:** 9631f9a
+**Generated:** 2026-04-20
+**Commit:** 90742fb
 **Branch:** main
 
 ## OVERVIEW
 
-Bare git dotfiles repo. `GIT_DIR=~/.dotfiles`, `GIT_WORK_TREE=~/`. Shell/dev configs synced across machines.
+Bare git dotfiles repo. `GIT_DIR=~/.dotfiles`, `GIT_WORK_TREE=~/`. 162 tracked files spanning shell init, dev tooling, AI agent configs, devcontainer setup, and CI. Sync across machines via allowlist `.gitignore`.
 
 ## GIT OPERATIONS
 
@@ -32,98 +32,128 @@ git status  # now works on dotfiles
 
 ```
 ~/
-├── .bashrc               # Sources .config/bash/main
-├── .zshenv               # Sources .config/zsh/.zshenv
-├── .profile              # Login shell entry
-├── .config/
-│   ├── bash/             # Bash config (main entry: main)
-│   │   ├── main          # Core bash setup, path mgmt
-│   │   ├── aliases       # Shell aliases (.dotfiles defined here)
-│   │   ├── functions     # Shell functions
-│   │   ├── exports       # Environment variables
-│   │   ├── init.d/       # Per-tool init scripts (nvm, rust, go, etc)
-│   │   ├── completion.d/ # Tab completion scripts
-│   │   └── local.d/      # Machine-local overrides (gitignored)
-│   ├── zsh/              # Zsh config (uses sheldon for plugins)
-│   ├── git/              # Git config (config, attributes, ignore)
-│   ├── opencode/         # OpenCode AI config (has own AGENTS.md)
-│   ├── mise/             # Tool version management + tasks
-│   └── sheldon/          # Zsh plugin manager
-├── .claude/              # Claude Code config
-│   ├── agents/           # Custom agents (dotfiles-reviewer)
-│   └── rules/            # Context rules
-├── .devcontainer/        # Devcontainer for dotfiles dev
-│   └── features/         # Custom features (dotfiles-dev, mise, sheldon)
-├── .dotfiles/            # Bare repo metadata + docs
-│   ├── .gitconfig        # Extended git config for dotfiles repo
-│   └── .gitignore        # Allowlist pattern (ignore all, then !exceptions)
-├── .github/              # CI workflows
-├── Brewfile              # macOS Homebrew deps
-└── Library/LaunchAgents/ # macOS launch agents
+├── .bashrc              # → sources .config/bash/main
+├── .zshenv              # → sets ZDOTDIR, sources .config/zsh/.zshenv
+├── .profile             # Login entry; sources .config/bash/exports
+├── AGENTS.md            # This file
+├── Brewfile             # macOS Homebrew + mas + casks source of truth
+├── .config/             # XDG_CONFIG_HOME — most config lives here
+│   ├── bash/            # Bash entry, init.d/ load order, local.d/ overrides
+│   ├── zsh/             # Zsh + sheldon plugin manager
+│   ├── git/             # Global git config (GPG, rebase defaults)
+│   ├── mise/            # Tool versions + tasks (.config/mise/tasks/)
+│   ├── sheldon/         # Zsh plugin manifest
+│   ├── opencode/        # OpenCode AI (own AGENTS.md = system prompt, not structural)
+│   ├── starship.toml    # Prompt
+│   └── ghostty/, bat/, gh/, ... # Other tool configs
+├── .agents/             # Global AI-skill bus (cross-platform)
+│   ├── .skill-lock.json # Tracks global skills (writing-skills, TDD, etc.)
+│   └── skills/          # Loadable by Claude Code, OpenCode, etc.
+├── .claude/             # Claude Code: agents/, rules/, commands/, settings.json
+├── .devcontainer/       # Devcontainer + custom features (dotfiles-dev, mise, sheldon, keychain)
+├── .dotfiles/           # Bare repo metadata (.gitignore allowlist, .gitconfig, docs/)
+├── .github/             # CI workflows + settings.yml (branch protection)
+├── .ssh/                # SSH config only (no credentials)
+├── .vim/, .vimrc        # vim config
+├── .vscode/             # VS Code settings + spellright dictionary
+└── Library/LaunchAgents/ # macOS launchd plists (only dev.mrbro.environment.plist tracked)
 ```
 
 ## WHERE TO LOOK
 
 | Task | Location | Notes |
 |------|----------|-------|
-| Add tracked file | Test with `git add -n` first | Only update `.dotfiles/.gitignore` if file is ignored |
+| Add tracked file | Test with `git add -n` first | Only update `.dotfiles/.gitignore` allowlist if blocked |
 | Shell aliases | `.config/bash/aliases` | `.dotfiles` alias defined here |
-| Environment vars | `.config/bash/exports` | Shared by bash and zsh |
-| Tool-specific init | `.config/bash/init.d/` | One file per tool |
-| Zsh plugins | `.config/sheldon/plugins.toml` | Sheldon manages plugins |
-| Git settings | `.config/git/config` | Global git config |
-| AI agent rules | `.claude/rules/` or `.config/opencode/` | Per-tool AI configs |
-| Mise tool versions | `.config/mise/config.toml` | Node, Python, Rust, etc |
-| Mise tasks | `.config/mise/tasks/` | dotfiles.toml has install/format |
-| macOS launch agents | `Library/LaunchAgents/` | Only tracked: dev.mrbro.environment.plist |
+| Environment vars | `.config/bash/exports` | Sourced by both bash and zsh |
+| Tool-specific init | `.config/bash/init.d/` | Numbered prefix = load order; `d`-prefix = disabled (e.g., `dnvm.bash`) |
+| Machine-local overrides | `.config/bash/local.d/` | Gitignored; sourced last by main |
+| Zsh plugins | `.config/sheldon/plugins.toml` | sheldon is the active plugin manager |
+| Prompt | `.config/starship.toml` | Starship; installed via devcontainer feature |
+| Git settings | `.config/git/config` | GPG signing on, rebase defaults, autoStash |
+| Mise tool versions | `.config/mise/config.toml` | Node, Python, Rust, etc. — `nvm` is disabled |
+| Mise tasks | `.config/mise/tasks/{dotfiles,_mise}.toml` | `format`, `install`, `opencode:doctor` |
+| Brewfile | `Brewfile` | macOS apps + casks + mas + 140+ vscode extensions |
+| Claude Code agents/rules | `.claude/agents/`, `.claude/rules/` | Custom agent + rule definitions |
+| OpenCode config | `.config/opencode/` | Has own AGENTS.md (collaboration system prompt) |
+| Global agent skills | `.agents/skills/` | Cross-platform skill bus; lock at `.agents/.skill-lock.json` |
+| Devcontainer features | `.devcontainer/features/` | dotfiles-dev, mise, sheldon, keychain |
+| CI workflows | `.github/workflows/` | main, fro-bot, renovate, update-repo-settings |
+| Repo settings (auto-applied) | `.github/settings.yml` | Branch protection, status checks; synced daily |
+| LaunchAgents | `Library/LaunchAgents/` | Only `dev.mrbro.environment.plist` tracked |
 
 ## CONVENTIONS
 
-### Allowlist .gitignore Pattern
+### Allowlist `.gitignore` Pattern
 
-The repo ignores EVERYTHING by default, then allowlists tracked files:
+Repo ignores EVERYTHING by default, allowlists tracked paths in `.dotfiles/.gitignore`:
 
 ```gitignore
-# Ignore everything
-/*
-
-# Include specific paths
-!/.config/
+/*                  # Ignore everything
+!/.config/          # Then un-ignore specific paths
 !/.bashrc
-!/README.md
 ```
 
 **To add a new file**:
-1. Test if git will accept it: `git add -n <file>`
+1. Try `git add -n <file>` first
 2. If ignored, add `!/path/to/file` to `.dotfiles/.gitignore` and retry
-3. Many common directories already have allowlist patterns - check before adding specific file entries
 
 ### Shell Config Organization
 
-- `init.d/` pattern: Numbered prefixes for ordering (e.g., `002-prompt.bash`)
-- `local.d/` for machine-specific overrides (not committed)
-- Shared exports in `.config/bash/exports` (sourced by both bash and zsh)
+- **Bash entry**: `.bashrc` → `.config/bash/main` → `functions` → `aliases` → `init.d/*` (alphabetical) → `local.d/*`
+- **Zsh entry**: `.zshenv` → `ZDOTDIR/.zshenv` (sources `.config/bash/exports`) → `.zshrc` → sheldon
+- **init.d/ numbering**: numeric prefix sets load order (e.g., `002-prompt.bash`, `003-history.bash`); `d`-prefix disables a script (e.g., `dnvm.bash` skips nvm init since mise owns Node)
+- **local.d/**: gitignored except `.gitkeep`; sourced last for machine-specific overrides
+- **Helper functions** (defined in `exports`): `command_exists`, `ensure_dir`, `prepend_to_path`, `append_to_path`, `remove_from_path`
+- **Host detection**: `HOST_OS`, `HOST_MACHINE`, `HOST_VERSION`, `HOST_PLATFORM` derived from `uname`; `REMOTE=1` if `SSH_CONNECTION` is set
+
+### Tool Ownership
+
+- **Node**: mise (nvm explicitly disabled via `dnvm.bash`)
+- **Global npm packages**: bun (via `[settings.npm] bun = true` in mise config)
+- **Container runtime (macOS)**: Rancher Desktop (Docker Desktop is removed)
+- **macOS app inventory**: Brewfile (with `mas` for App Store apps)
 
 ### Git Config
 
 - GPG signing enabled (`commit.gpgSign = true`)
-- Rebase by default on branch setup
-- Fast-forward only merges
-- Auto-prune on fetch
+- Rebase by default on branch setup; fast-forward only merges
+- Auto-prune on fetch; auto-stash on rebase/pull
 
 ### XDG Compliance
 
-Configs respect XDG base directories:
-- `XDG_CONFIG_HOME`: `~/.config`
-- `XDG_DATA_HOME`: `~/.local/share`
-- `XDG_CACHE_HOME`: `~/.cache`
+- `XDG_CONFIG_HOME` = `~/.config`
+- `XDG_DATA_HOME` = `~/.local/share`
+- `XDG_CACHE_HOME` = `~/.cache`
+- `XDG_STATE_HOME` = `~/.local/state`
+
+## CI/CD
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `main.yaml` | push, PR | Builds devcontainer + tests mise install |
+| `renovate.yaml` | post-Main success, dispatch | Runs Renovate via `bfra-me/.github` reusable workflow |
+| `fro-bot.yaml` | daily 15:30 UTC, PR/issue events | Daily maintenance + autoheal via `fro-bot/agent` action |
+| `update-repo-settings.yaml` | push to main, daily 4:37 UTC | Syncs `.github/settings.yml` to repo settings |
+
+### Branch Protection (defined in `.github/settings.yml`)
+
+- main: strict status checks (`Devcontainer CI`, `Fro Bot`, `Install mise`, `Renovate / Renovate`)
+- enforce admins, linear history required
+
+### Bot Dynamics
+
+- **Renovate** (via `app/mrbro-bot`): dependency bumps; automerge enabled for safe updates
+- **Fro Bot** (`fro-bot` user): scheduled daily maintenance; uses `FRO_BOT_PAT` (classic PAT, collaborator on all repos)
+- **Copilot SWE agent** (`app/copilot-swe-agent`): handles complex tracking issues by opening fix PRs
 
 ## ANTI-PATTERNS (THIS PROJECT)
 
-- **DO NOT** add files to `.gitignore` without first checking if they're actually ignored (`git check-ignore -v <file>`)
-- **DO NOT** use `git` commands without `.dotfiles` env vars set
-- **NEVER** commit machine-specific config to main (use `*.local` files or `local.d/`)
+- **DO NOT** add files to `.gitignore` without first running `git check-ignore -v <file>`
+- **DO NOT** run `git` commands without `.dotfiles` env vars set
+- **NEVER** commit machine-specific values (use `*.local` files or `local.d/`)
 - **NEVER** commit secrets (SSH keys, API tokens, credentials)
+- **DO NOT** hardcode `~/` or `$HOME` in `.config/mise/config.toml` `task_config.includes` — mise doesn't expand them; relative paths (`tasks/dotfiles.toml`) resolve against the config dir
 
 ## DEVCONTAINER SETUP
 
@@ -136,42 +166,34 @@ Custom features in `.devcontainer/features/`:
 | `sheldon` | Installs sheldon zsh plugin manager |
 | `keychain` | SSH/GPG key agent management |
 
-Bootstrap process: `dotfiles-dev/install.sh` generates `post-create.sh` that runs on container start.
+Bootstrap: `dotfiles-dev/install.sh` generates `post-create.sh` that runs on container start.
 
 ## COMMANDS
 
 ```bash
-# Format dotfiles (prettier)
+# Format dotfiles (prettier, scoped to .devcontainer/.dotfiles/.github)
 mise run format
 
-# Install tools
+# Install all mise-managed tools
 mise run install
 
-# Check git status (dotfiles)
-.dotfiles git status
-
-# Add new file (after updating .gitignore)
-.dotfiles git add path/to/file
-
 # Inspect OpenCode configuration and health
-mise run opencode:doctor
+mise run opencode:doctor                      # Full diagnostic
+mise run opencode:doctor -- --only health     # Specific section
+mise run opencode:doctor -- --json            # Scriptable output
 
-# Specific sections only (health, config, providers, etc)
-mise run opencode:doctor -- --only health,config
-
-# JSON output for scripting
-mise run opencode:doctor -- --json
+# Dotfiles git operations (use the alias)
+.dotfiles git status
+.dotfiles git add path/to/file
+.dotfiles git push
 ```
-
-## CI/CD
-
-- **main.yaml**: Builds devcontainer, runs `devcontainer-info`, tests mise install
-- **renovate.yaml**: Automated dependency updates
-- **update-repo-settings.yaml**: Syncs repo settings
 
 ## NOTES
 
-- Zsh uses sheldon for plugin management with cached compilation
-- Starship prompt installed via devcontainer feature
-- `command_exists` function used for conditional tool setup in aliases/init scripts
-- Mise uses bun for npm packages (`settings.npm.bun = true`)
+- **Fro Bot security alerts (by design, not bug)**: `FRO_BOT_PAT` is a collaborator-level token. GitHub restricts `/vulnerability-alerts` and `/dependabot/alerts` endpoints to repo owners on personal (user-owned) repos, regardless of token scope or collaborator role. Personal repos have no granular collaborator roles (only "Collaborator", which is effectively write access — Admin/Maintain/Triage exist only for org-owned repos). Marcus receives Dependabot notifications directly as the owner; Fro Bot's daily report intentionally omits this section (PR #1442).
+- **mise `task_config.includes` portability**: this field doesn't expand `~`/`$HOME`/`{{config_root}}`/`{{xdg_config_home}}`. Use relative paths (`tasks/dotfiles.toml`); they resolve against the config file's directory.
+- **Broken cache-clean LaunchAgent**: `~/Library/LaunchAgents/dev.mrbro.cache-clean.plist` references a nonexistent path. Sunday 4AM cleanup does not run. Plist is not tracked in dotfiles. Manual cleanup: `brew cleanup --prune=all`, `uv cache clean`, `mise prune`.
+- **Disk monitoring**: macOS root FS occasionally hits ENOSPC (seen with <300MB free on a 926GB disk). pnpm rename errors are the canary. Run cleanup when tight.
+- **`command_exists` guard**: used throughout `.config/bash/init.d/` and `.config/bash/aliases` for conditional tool setup — required pattern.
+- **OpenCode AGENTS.md** at `.config/opencode/AGENTS.md` is NOT a structural index — it's the primary collaboration system prompt for OpenCode sessions. Don't repurpose it for directory documentation.
+- **`.agents/skills/` is the cross-platform skill bus**: skills here load into both Claude Code and OpenCode. Tracked via `.agents/.skill-lock.json`.


### PR DESCRIPTION
## Summary

Regenerates `~/AGENTS.md` via `/init-deep` after 2+ months of drift. The previous generation was stamped 2026-02-02 at commit `9631f9a`; HEAD is now 300+ commits ahead. Fro Bot has flagged this drift in every daily maintenance report since 2026-04-06.

## Scope

Single-file refresh of the root `AGENTS.md`. Hierarchical scan (4 parallel explore agents + bash/LSP structural analysis + existing-doc review) found no new sub-AGENTS.md warranted:

- `.config/opencode/AGENTS.md` already exists but serves as the OpenCode collaboration **system prompt**, not a structural index of the directory — leave alone.
- `.config/opencode/profiles/default/AGENTS.md` is an empty placeholder — leave alone.

## What changed

- **STRUCTURE**: Added `.agents/` (global skill bus), `.vscode/`, `.vim/`, `.ssh/`; clarified Brewfile scope and opencode-AGENTS.md purpose.
- **WHERE TO LOOK**: Added `.agents/` skill bus, `fro-bot.yaml`, `settings.yml` branch protection, machine-local override workflow, mise task file locations.
- **CONVENTIONS**: Documented `init.d/` numbering rules (numeric prefix = load order, `d`-prefix = disabled); tool-ownership boundaries (mise owns Node, bun is global npm mgr, Rancher Desktop is container runtime); host-detection globals.
- **CI/CD**: Added `fro-bot.yaml`; listed required branch-protection status checks; documented bot dynamics across Fro Bot / Renovate / Copilot SWE.
- **NOTES**: Captured the two constraints discovered this session:
  - `FRO_BOT_PAT` cannot see Dependabot alerts on personal repos — personal repos have no granular collaborator roles (Admin/Maintain/Write/Triage/Read exist only for org-owned repos). Architecture, not configuration.
  - `mise task_config.includes` does not expand `~`, `$HOME`, `{{config_root}}`, or `{{xdg_config_home}}`. Relative paths resolve against the config file's directory.
- Plus operational notes: broken `dev.mrbro.cache-clean.plist` LaunchAgent, pnpm/ENOSPC canary on `/`, `command_exists` guard pattern, cross-platform skill bus.

## Verification

- 162 tracked files enumerated via `git ls-files`
- Current file is 199 lines (prior was 177)
- No structural duplication against `.config/opencode/AGENTS.md`
- Reflects state at `90742fb` (current HEAD)

Fixes the standing AGENTS.md-drift complaint in Fro Bot's daily reports.
