### PR TITLE
feat(opencode): tune magic-context thresholds against verified Copilot caps

### DIFF
--- a/.config/opencode/magic-context.jsonc
+++ b/.config/opencode/magic-context.jsonc
@@ -25,6 +25,12 @@
     "anthropic/claude-opus-4-6": 40,
     "anthropic/claude-opus-4-7": 40
   },
+  "execute_threshold_tokens": {
+    "github-copilot/claude-opus-4.7": 112000,
+    "github-copilot/claude-sonnet-4.6": 105000,
+    "github-copilot/gpt-5.4": 140000,
+    "github-copilot/gpt-5.3-codex": 210000
+  },
   "experimental": {
     "pin_key_files": {
       "enabled": true,
@@ -36,11 +42,11 @@
       "promotion_threshold": 3
     }
   },
-  "history_budget_percentage": 0.21,
+  "history_budget_percentage": 0.15,
   "historian_timeout_ms": 420000,
   "memory": {
-    "injection_budget_tokens": 20000
+    "injection_budget_tokens": 6000
   },
   "compaction_markers": true,
-  "auto_drop_tool_age": 50
+  "auto_drop_tool_age": 30
 }


### PR DESCRIPTION
## Summary

Set `execute_threshold_tokens` for Copilot-routed Claude/GPT models in `.config/opencode/magic-context.jsonc`, anchored to live capability data fetched from `https://api.githubcopilot.com/models` on 2026-04-20 against my Pro+ subscription.

## Verified caps (live API)

| Model | `max_context_window_tokens` | `max_prompt_tokens` | New threshold | Headroom vs prompt cap |
|---|---|---|---|---|
| `claude-opus-4.7` | 144000 | **128000** | 112000 | 16K |
| `claude-sonnet-4.6` | 200000 | **128000** | 105000 | 23K |
| `gpt-5.4` | 400000 | **272000** | 140000 | 132K (intentionally conservative — see below) |
| `gpt-5.3-codex` | 400000 | **272000** | 210000 | 62K |

## Why the earlier values were wrong

- All Copilot Claude/GPT models were previously set to `140000`, based on an assumed 168K Copilot Claude prompt cap that does not exist on Pro+. Real cap is 128K — 140K would have overrun on a single large turn.
- `gpt-5.3-codex` inherited a 40K threshold from the old `gpt-5.2-codex` entry. Real cap is 272K — 40K caused unnecessary early reduction on a model that has 6.8x more headroom.
- `gpt-5.4` is left conservative at 140K because opencode currently has a hardcoded 1M context-meter override for that family (see opencode#21564) that makes percentage-based reduction unreliable until fixed.

## History retention tightening

To compensate for tighter Copilot caps so reduction fires earlier rather than at emergency thresholds:

- `history_budget_percentage`: 0.21 -> **0.15**
- `memory.injection_budget_tokens`: 20000 -> **6000**
- `auto_drop_tool_age`: 50 -> **30**

## Verification

```
curl -sS -H "Authorization: Bearer <token>" \
  -H "Copilot-Integration-Id: vscode-chat" \
  -H "Editor-Version: vscode/1.95.0" \
  https://api.githubcopilot.com/models
```

Returned `max_prompt_tokens` values that match this PR exactly. No deviation from librarian's models.dev research.

## Out of scope

- `cache_ttl` overrides for direct Anthropic models — unchanged. Anthropic-direct on Max tier still gets ~1h prompt caching.
- `gpt-5-mini` thresholds — intentionally absent from main-session config (sidekick subagent only).

## Follow-ups

1. Validate in real Copilot Claude session via `/ctx-status`. If reduction fires too late, drop opus to 105K and sonnet to 100K.
2. Watch opencode#21564 — if user-config `limit` overrides for Copilot get fixed, thresholds can be raised.
3. Watch the gpt-5.4 1M-context-meter override. When it lands a fix, raise gpt-5.4 to ~210K.