### PR TITLE
feat(skills): add copilot-cli skill for programmatic Copilot CLI delegation

### DIFF
--- a/.agents/skills/copilot-cli/SKILL.md
+++ b/.agents/skills/copilot-cli/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: copilot-cli
+description: Use when delegating coding work to GitHub Copilot CLI from another agent (OpenCode, Claude Code, scripts, CI), or when invoking `copilot` non-interactively with `-p`. Covers auth, permissions, model selection, tool filters, multi-repo `--add-dir`, JSONL output, and the bash-subprocess delegation pattern.
+---
+
+# GitHub Copilot CLI
+
+## Overview
+
+Two CLIs with confusingly similar names — never conflate:
+
+| Binary | Package | Purpose |
+|---|---|---|
+| `gh copilot` | `gh` extension | Legacy chat helper. **Not the CLI this skill covers.** Lazy-installs `copilot` on first interactive run, exits silently on non-TTY stdin. |
+| `copilot` | `@github/copilot` (npm), `copilot-cli` (brew), `gh.io/copilot-install` | The real agent. Standalone binary. **This skill is about `copilot`.** |
+
+Verify which you have: `which copilot && copilot --version`. If only `gh copilot` exists, install the standalone (see Install).
+
+## When to use this skill
+
+Load this skill when:
+- Delegating implementation work to `copilot -p` from OpenCode, Claude Code, or another orchestrator
+- Writing scripts or GitHub Actions that call `copilot` programmatically
+- Setting up auth/permissions for non-interactive Copilot runs
+- Invoking custom Copilot agents (`--agent`) or routing through MCP servers
+- Debugging silent failures (almost always missing `--allow-all-tools` or auth precedence)
+
+Do **not** load this skill for OpenCode subagent delegation (use the native `task` tool) or for `gh copilot suggest`/`explain` (different product).
+
+## Critical rules (cause silent failures)
+
+1. **`--allow-all-tools` is required for `-p`.** Without it, the agent prompts for tool approval and hangs because there's no TTY. The public "best practices" doc does not emphasize this — `copilot help` does. For tighter scopes, combine with `--deny-tool=` rather than omitting `--allow-all-tools`.
+2. **Auth precedence: `COPILOT_GITHUB_TOKEN` > `GH_TOKEN` > `GITHUB_TOKEN`.** A stale `GH_TOKEN` in your shell will silently override `~/.copilot/auth` even if you ran `copilot login`. When debugging "wrong account" issues, check `env | grep -iE 'github_token|gh_token'` first.
+3. **Always use `-s` (silent) for scripted output.** Without it, the response is wrapped in stats/decoration that breaks downstream parsing.
+4. **Use `--no-ask-user` for true non-interactive runs.** Otherwise the agent may hang on a clarifying question even with full tool permissions.
+5. **`COPILOT_GITHUB_TOKEN` is redacted from output by default.** Add other secrets via `--secret-env-vars=KEY1,KEY2` — values are stripped from the agent's shell environment AND redacted from output.
+
+## Install
+
+```bash
+# Preferred on macOS/Linux: npm via mise (matches dotfiles convention — bun-backed)
+npm install -g @github/copilot
+
+# Alternative: Homebrew
+brew install copilot-cli
+
+# Alternative: install script (good for CI)
+curl -fsSL https://gh.io/copilot-install | bash
+```
+
+Requires Node.js 22+ for the npm install. On `mise`-managed Node, install runs against the active version.
+
+## Auth
+
+**Interactive first time:** `copilot` → `/login` → device-code OAuth. Token stored at `~/.copilot/auth`.
+
+**Programmatic / CI:** Use a fine-grained PAT with the **"Copilot Requests"** permission (under user permissions, not repo). Visit https://github.com/settings/personal-access-tokens/new. Export as `COPILOT_GITHUB_TOKEN` (not `GH_TOKEN` — too easy to collide with `gh` CLI).
+
+```bash
+export COPILOT_GITHUB_TOKEN='github_pat_...'
+```
+
+The OAuth token in `~/.local/share/opencode/auth.json` (used by OpenCode for the Copilot model API) is **not** valid for `copilot` CLI auth — it has only `read:user` scope. Use a separate PAT for CLI use.
+
+## Programmatic invocation — minimal correct form
+
+```bash
+copilot \
+  -p "PROMPT" \
+  -s \
+  --allow-all-tools \
+  --no-ask-user \
+  --model gpt-5.3-codex
+```
+
+That's the floor. Drop `--model` to use the default (Claude Sonnet 4.5 in current Copilot CLI). Tighter permission examples follow.
+
+## Permissions — tool filter syntax
+
+`--allow-tool` and `--deny-tool` accept a `kind(argument)` pattern. Deny always beats allow.
+
+| Pattern | Effect |
+|---|---|
+| `shell` | All shell commands (rare; prefer `--allow-all-tools` if you need this) |
+| `shell(git:*)` | All `git` subcommands (`git push`, `git status`, etc.) |
+| `shell(npm:*)` | All `npm` subcommands |
+| `shell(npm test)` | Exactly `npm test`, no other npm commands |
+| `write` | Any file write (no path filter — use `--add-dir` to scope) |
+| `write(README.md)` | Write any file whose path ends in `/README.md` |
+| `write(.github/copilot-instructions.md)` | Write only that exact relative path |
+| `url(github.com)` | Fetch from `https://github.com` (HTTPS implied) |
+| `url(https://*.github.com)` | Any github.com subdomain over HTTPS |
+| `url(http://localhost:3000)` | HTTP+port required for non-HTTPS local servers |
+| `<mcp-name>` | All tools from named MCP server (e.g., `github`) |
+| `<mcp-name>(tool_name)` | Single tool from MCP server (e.g., `github(create_issue)`) |
+
+**Wildcards:** Only supported as `:*` suffix in `shell`, and as `*.host` prefix or `path/*` suffix in `url`. Not general glob.
+
+**Tool visibility vs approval:** `--available-tools=` and `--excluded-tools=` decide what the model can *see*; `--allow-tool`/`--deny-tool` decide what runs without prompting. They're orthogonal — denying a tool the model can't see does nothing.
+
+### Tightly-scoped delegation example
+
+```bash
+copilot -p "Run npm test, fix failures, commit with conventional message" \
+  -s --no-ask-user \
+  --add-dir "$PWD" \
+  --allow-tool='shell(git:*),shell(npm:*),shell(npx:*),write' \
+  --deny-tool='shell(git push),shell(rm:*)' \
+  --allow-url=github.com \
+  --model gpt-5.3-codex
+```
+
+Refuses `git push` and `rm` even though `git:*` and `write` are allowed (deny precedence). No autonomous push.
+
+## Multi-repo / multi-directory
+
+Default file access is restricted to `cwd` + subdirs + system tempdir. Two ways to expand:
+
+```bash
+# Add specific extra dirs (recommended for security)
+copilot -p "..." -s --allow-all-tools \
+  --add-dir /Users/me/projects/backend \
+  --add-dir /Users/me/projects/frontend
+
+# Disable path verification entirely (dangerous; only in sandboxes)
+copilot -p "..." -s --allow-all-tools --allow-all-paths
+```
+
+For coordinated cross-repo refactors, prefer running `copilot` from a parent directory containing all repos — its built-in repo discovery handles the rest.
+
+## Models
+
+`--model` and `COPILOT_MODEL` accept these strings (verified via `copilot help` 2026-04-20):
+
+| String | Notes |
+|---|---|
+| `claude-sonnet-4.5` | Default; fast, cheap, good for routine work |
+| `claude-opus-4.5` | Deep reasoning, complex refactors. Premium. |
+| `claude-haiku-4.5` | Fastest/cheapest; summaries, explanations |
+| `gpt-5.3-codex` | Code generation and review specialty |
+| `gpt-5.2` | General GPT |
+
+**Model namespace differs from Copilot API** — the CLI uses unprefixed strings (`claude-opus-4.5`), while the API/OpenCode uses `github-copilot/claude-opus-4.7`. Don't copy strings between contexts.
+
+`--effort low|medium|high|xhigh` controls reasoning effort on supported models.
+
+Persist a default in `~/.copilot/config.json`:
+
+```json
+{ "model": "gpt-5.3-codex", "reasoning_effort": "low" }
+```
+
+## Output formats
+
+```bash
+# Default: text (decorated with stats)
+copilot -p "..." 
+
+# Silent text (parseable; agent response only)
+copilot -p "..." -s
+
+# JSONL (one JSON object per line — best for structured parsing in scripts)
+copilot -p "..." --output-format json
+```
+
+`--output-format json` is undocumented in the public best-practices page but is in `copilot help`. Use it when you need structured event streams (tool calls, file edits, etc.) instead of just the final response.
+
+## Sharing / archiving sessions
+
+```bash
+copilot -p "Audit deps for vulnerabilities" -s --allow-all-tools \
+  --share=./audit-report.md          # Markdown transcript to local file
+
+copilot -p "Summarize architecture" -s --allow-all-tools \
+  --share-gist                        # Secret gist on github.com (not for EMUs / GHE.com)
+```
+
+Transcripts may contain secrets — review before sharing. `--secret-env-vars=KEY1,KEY2` redacts values from the transcript too.
+
+## Custom agents
+
+Create a custom agent at `~/.copilot/agents/<name>.md` with frontmatter + system prompt + optional tool restrictions. Then invoke:
+
+```bash
+copilot -p "Review the latest commit" -s --allow-all-tools --agent code-review
+```
+
+A custom agent's `model` field overrides `--model`. Use this for repeatable specialized workflows (security review, doc generation, etc.).
+
+## Hooks
+
+Place shell scripts in `~/.copilot/hooks/<event>` to run at lifecycle points (e.g., `pre-tool`, `post-edit`). Useful for forcing format/lint after every write or auditing tool calls. See `copilot help` and the "Using hooks" doc for event names.
+
+## Delegation pattern: calling `copilot` from OpenCode / another agent
+
+When you (an OpenCode agent) need to delegate a contained implementation task to Copilot CLI as a bash subprocess:
+
+```bash
+copilot \
+  -p "Implement X. Files Y and Z. Run tests after." \
+  -s --no-ask-user \
+  --add-dir "$PWD" \
+  --allow-tool='shell(git:*),shell(npm:*),shell(npx:*),shell(mise:*),write' \
+  --deny-tool='shell(git push)' \
+  --model gpt-5.3-codex \
+  --share=./.copilot-session.md
+```
+
+Then read `.copilot-session.md` for the transcript and verify the changes with `git diff` / `lsp_diagnostics`. **You** still own verification — `copilot` will report success even when tests don't pass unless the prompt explicitly demands proof.
+
+**Prompt structure for delegated runs (mandatory):**
+
+1. **Atomic goal** — one outcome, not a list of features
+2. **Files in scope** — explicit paths
+3. **Verification** — "run `npm test`; report pass/fail with output"
+4. **Constraints** — "do not modify package.json", "no commits"
+5. **Output expectation** — "summarize changes in ≤5 bullets at end"
+
+Vague prompts produce vague output, same as any agent.
+
+## Common failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Hangs forever, no output | Missing `--allow-all-tools` (or denied tool needed for task) | Add `--allow-all-tools` or expand `--allow-tool` |
+| Hangs after partial output | Missing `--no-ask-user` | Add `--no-ask-user` |
+| "Authentication required" despite `copilot login` | Stale `GH_TOKEN` or `GITHUB_TOKEN` in env | `unset GH_TOKEN GITHUB_TOKEN`; or `export COPILOT_GITHUB_TOKEN=...` |
+| Wrong account / org | Same — token precedence override | Same fix |
+| Output mangled in script | Missing `-s` | Add `-s`; or switch to `--output-format json` |
+| `gh copilot` exits silently in CI | `gh copilot` is a downloader; no TTY = no install prompt | Install standalone `copilot` directly |
+| Permission denied on file outside repo | Default path restriction to cwd | Add `--add-dir /path`; avoid `--allow-all-paths` outside sandboxes |
+| Network calls blocked | URL permission missing | Add `--allow-url=domain.com` |
+
+## CI pattern (GitHub Actions)
+
+```yaml
+- name: Run Copilot review
+  env:
+    COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT }}
+  run: |
+    npm install -g @github/copilot
+    copilot -p "Review changed files in this PR for bugs and security issues" \
+      -s --no-ask-user \
+      --allow-tool='shell(git:*)' \
+      --deny-tool='write' \
+      --model claude-opus-4.5 \
+      --share=./review.md
+```
+
+Auto-update is disabled in CI (detected via `CI`/`BUILD_NUMBER`/`RUN_ID`/`SYSTEM_COLLECTIONURI`). To pin a version, use the install script with `VERSION=`:
+
+```bash
+curl -fsSL https://gh.io/copilot-install | VERSION="v0.0.369" bash
+```
+
+## Reference
+
+- @reference/programmatic-flags.md — quick-reference table of every `-p`-relevant flag
+- @reference/permission-patterns.md — copy-paste filter patterns for common task shapes
+
+## Sources
+
+- https://docs.github.com/en/copilot/how-tos/copilot-cli/cli-best-practices
+- https://docs.github.com/en/copilot/how-tos/copilot-cli/automate-copilot-cli/run-cli-programmatically
+- https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-programmatic-reference
+- https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli
+- `copilot help`, `copilot help environment`, `copilot help permissions` (CLI v1.0.34, 2026-04-20)

--- a/.agents/skills/copilot-cli/reference/permission-patterns.md
+++ b/.agents/skills/copilot-cli/reference/permission-patterns.md
@@ -1,0 +1,107 @@
+# Permission pattern cookbook
+
+Copy-paste `--allow-tool` / `--deny-tool` combos for common delegation shapes. Pair with `--allow-all-tools` only when you cannot enumerate.
+
+## Read-only review (no writes, no network)
+
+```bash
+--allow-tool='shell(git:*),read' \
+--deny-tool='write,shell(git push),shell(git commit)'
+```
+
+## Implement + test, no push
+
+```bash
+--allow-tool='shell(git:*),shell(npm:*),shell(npx:*),write' \
+--deny-tool='shell(git push)'
+```
+
+## Implement + test + commit, no push (mise/Node project)
+
+```bash
+--allow-tool='shell(git:*),shell(npm:*),shell(npx:*),shell(mise:*),write' \
+--deny-tool='shell(git push),shell(rm:*)'
+```
+
+## Python project (uv/pytest)
+
+```bash
+--allow-tool='shell(git:*),shell(uv:*),shell(pytest:*),shell(python:*),write' \
+--deny-tool='shell(git push)'
+```
+
+## Rust project
+
+```bash
+--allow-tool='shell(git:*),shell(cargo:*),shell(rustup:*),write' \
+--deny-tool='shell(git push)'
+```
+
+## Documentation only (no code execution)
+
+```bash
+--allow-tool='shell(git:*),write(*.md),write(docs/**)' \
+--deny-tool='shell(npm:*),shell(node:*),shell(python:*)'
+```
+
+## Allow GitHub MCP for issue/PR ops, deny dangerous ones
+
+```bash
+--allow-tool='github(create_issue),github(add_issue_comment),github(get_pull_request),shell(git:*)' \
+--deny-tool='github(delete_repository),github(merge_pull_request)'
+```
+
+Or scope to read-only GitHub MCP tools by allowing the whole server then denying writes:
+
+```bash
+--allow-tool='github,shell(git:*)' \
+--deny-tool='github(delete_repository),github(merge_pull_request),github(create_or_update_file)'
+```
+
+## Network-restricted (only github + npm registry)
+
+```bash
+--allow-url='github.com,api.github.com,registry.npmjs.org' \
+--deny-tool='shell(curl:*),shell(wget:*)'
+```
+
+## Local dev server interaction
+
+```bash
+--allow-tool='shell(curl localhost:*)' \
+--allow-url='http://localhost:3000,http://127.0.0.1:3000'
+```
+
+## Multi-repo coordinated change
+
+```bash
+--add-dir /Users/me/projects/api \
+--add-dir /Users/me/projects/web \
+--add-dir /Users/me/projects/shared \
+--allow-tool='shell(git:*),write' \
+--deny-tool='shell(git push)'
+```
+
+Run from a parent directory to avoid `--add-dir` per repo.
+
+## Locked-down CI run (everything explicit)
+
+```bash
+copilot -p "..." \
+  -s --no-ask-user --no-auto-update \
+  --add-dir "$GITHUB_WORKSPACE" \
+  --allow-tool='shell(git:*),shell(npm:*),write' \
+  --deny-tool='shell(git push),shell(gh:*)' \
+  --allow-url='github.com,api.github.com,registry.npmjs.org' \
+  --secret-env-vars='NPM_TOKEN,SLACK_WEBHOOK' \
+  --model claude-sonnet-4.5 \
+  --share=./.copilot-session.md
+```
+
+## Notes
+
+- **Deny beats allow always.** Even `--allow-all-tools` cannot override an explicit `--deny-tool`.
+- **`shell(cmd:*)` matches first-level subcommands.** `shell(git:*)` allows `git push` *unless* you `--deny-tool='shell(git push)'`.
+- **`write` has no path filter natively.** Use `write(path)` for path-suffix matching or scope via `--add-dir`. `write(*.md)` matches any `.md` file.
+- **URL permissions are protocol-aware.** `url(github.com)` allows HTTPS only; HTTP requires explicit `url(http://...)`.
+- **Repeated flags are additive**, not last-wins. `--add-dir A --add-dir B` allows both.

--- a/.agents/skills/copilot-cli/reference/programmatic-flags.md
+++ b/.agents/skills/copilot-cli/reference/programmatic-flags.md
@@ -1,0 +1,53 @@
+# Programmatic flags quick-reference
+
+Flags most relevant when running `copilot -p` non-interactively. From `copilot help` (v1.0.34) plus the official programmatic reference.
+
+| Flag | Required for `-p`? | Purpose |
+|---|---|---|
+| `-p, --prompt <text>` | yes | Non-interactive prompt; exits when done |
+| `-s, --silent` | no but recommended | Strip stats/decoration; agent response only |
+| `--allow-all-tools` | **yes** (or scoped `--allow-tool`) | Required for non-interactive — without it, hangs waiting for tool approval |
+| `--no-ask-user` | usually | Disables `ask_user` tool; agent works without clarifying questions |
+| `--model <model>` | no | `claude-sonnet-4.5` (default), `claude-opus-4.5`, `claude-haiku-4.5`, `gpt-5.3-codex`, `gpt-5.2` |
+| `--effort low\|medium\|high\|xhigh` | no | Reasoning effort on supported models |
+| `--allow-tool=PATTERN` | no | Allow a specific tool (`shell(git:*)`, `write`, etc.) |
+| `--deny-tool=PATTERN` | no | Deny a specific tool — beats `--allow-all-tools` |
+| `--allow-url=DOMAIN` | no | Allow web access to a domain |
+| `--deny-url=DOMAIN` | no | Block a domain — beats `--allow-url` |
+| `--allow-all-urls` | no | All URL access |
+| `--add-dir <path>` | no | Extend file access beyond cwd; repeatable |
+| `--allow-all-paths` | no | Disable path verification (sandbox only) |
+| `--disallow-temp-dir` | no | Block automatic tempdir access |
+| `--available-tools=LIST` | no | Whitelist tools the model can see |
+| `--excluded-tools=LIST` | no | Hide specific tools from the model |
+| `--secret-env-vars=K1,K2` | no | Strip env vars from agent shell + redact from output |
+| `--share[=path]` | no | Save markdown transcript (default `./copilot-session-<id>.md`) |
+| `--share-gist` | no | Publish secret gist on github.com |
+| `--output-format text\|json` | no | `json` = JSONL event stream; `text` = default |
+| `--agent <name>` | no | Use a custom agent from `~/.copilot/agents/` |
+| `--add-github-mcp-tool <tool>` | no | Enable additional GitHub MCP tool beyond default subset |
+| `--add-github-mcp-toolset <set>` | no | Enable additional GitHub MCP toolset |
+| `--enable-all-github-mcp-tools` | no | Enable everything in built-in GitHub MCP server |
+| `--disable-mcp-server <name>` | no | Disable a configured MCP server for this run |
+| `--config-dir <dir>` | no | Override `~/.copilot` location |
+| `--no-custom-instructions` | no | Skip loading `AGENTS.md`/`copilot-instructions.md` |
+| `--no-auto-update` | no | Disable update check (auto-disabled in CI) |
+| `--no-color` | no | Disable color (also via `NO_COLOR` env) |
+| `--allow-all` / `--yolo` | no | All tools + paths + URLs (avoid outside sandbox) |
+| `--share-gist` redaction | n/a | `COPILOT_GITHUB_TOKEN` and `GITHUB_TOKEN` redacted by default |
+
+## Auth precedence (highest to lowest)
+
+1. `COPILOT_GITHUB_TOKEN`
+2. `GH_TOKEN`
+3. `GITHUB_TOKEN`
+4. Stored credentials at `~/.copilot/auth`
+
+## Useful env vars
+
+- `COPILOT_ALLOW_ALL=true` — equivalent to `--allow-all-tools`
+- `COPILOT_MODEL=<model>` — default model
+- `COPILOT_HOME=<dir>` — override `~/.copilot`
+- `COPILOT_OFFLINE=true` — skip all network; requires `COPILOT_PROVIDER_BASE_URL`
+- `COPILOT_AUTO_UPDATE=false` — disable update checks
+- `GH_HOST=<host>` — for GitHub Enterprise Cloud with data residency


### PR DESCRIPTION
Adds a reusable skill at `.agents/skills/copilot-cli/` covering GitHub Copilot CLI as a non-interactive delegation target — the path I'll reach for when calling `copilot -p` from OpenCode, scripts, or CI instead of re-deriving the flag soup each time.

## Why

Two binaries share the "Copilot CLI" name and behave nothing alike:

- `gh copilot` — gh extension wrapper. Lazy-installs the real CLI on first interactive run, exits silently on non-TTY stdin (which is exactly when you want it to work).
- `copilot` — the standalone agent (`@github/copilot` npm, `copilot-cli` brew). What you actually want.

Even with the right binary, `copilot -p` has silent-failure traps the public best-practices doc doesn't lead with. Most painful: **`--allow-all-tools` is required for `-p` mode** or the agent hangs forever waiting for tool approval that no TTY exists to give.

## What's in the skill

- **Critical rules** — the five things that cause silent hangs or wrong-account auth, surfaced at the top.
- **Auth precedence** — `COPILOT_GITHUB_TOKEN` > `GH_TOKEN` > `GITHUB_TOKEN`, with the CLI-vs-API token caveat (the OpenCode-stored OAuth token only has `read:user` and won't authenticate the CLI).
- **Permission filter syntax** — `shell(git:*)`, `write(path)`, `url(host)`, `<mcp>(tool)`, deny-beats-allow, wildcard limits.
- **Models** — verified strings from `copilot help` (`claude-sonnet-4.5` default, `gpt-5.3-codex`, etc.) with the namespace warning that CLI strings are unprefixed and don't match the API/OpenCode `github-copilot/*` namespace.
- **Multi-repo, JSONL output, custom agents, hooks, sharing** — quick reference for each.
- **OpenCode delegation pattern** — minimal correct invocation as a bash subprocess, plus the mandatory prompt structure (atomic goal, files in scope, verification, constraints, output expectation).
- **Failure-mode table** — symptom → cause → fix for the eight most common ways `-p` mode goes silently wrong.
- **CI pattern** — drop-in GitHub Actions step plus version-pin trick via the install script's `VERSION=` env var.

Two reference docs sit beside `SKILL.md` to keep the main file scannable:

- `reference/programmatic-flags.md` — every `-p`-relevant flag with required/optional column.
- `reference/permission-patterns.md` — copy-paste filter combos for common task shapes (read-only review, scoped npm/test runner, cross-repo refactor, etc.).

## Verification

Baseline-tested before commit by following only what's in the skill — minimal correct form (`copilot -p '...' -s --allow-all-tools --no-ask-user --model claude-haiku-4.5`) produced clean parseable output without hanging. Sources cited at the end of `SKILL.md` against current GitHub docs and live `copilot help` (CLI v1.0.34, 2026-04-20).