### PR TITLE
feat(opencode): lower Copilot Claude execute thresholds (opus=88K, sonnet=95K)

### DIFF
--- a/.config/opencode/magic-context.jsonc
+++ b/.config/opencode/magic-context.jsonc
@@ -26,8 +26,8 @@
     "anthropic/claude-opus-4-7": 40
   },
   "execute_threshold_tokens": {
-    "github-copilot/claude-opus-4.7": 112000,
-    "github-copilot/claude-sonnet-4.6": 105000,
+    "github-copilot/claude-opus-4.7": 88000,
+    "github-copilot/claude-sonnet-4.6": 95000,
     "github-copilot/gpt-5.4": 140000,
     "github-copilot/gpt-5.3-codex": 210000
   },


### PR DESCRIPTION
## Why

PR #1454 set Copilot Claude `execute_threshold_tokens` to 112K (opus-4.7) and 105K (sonnet-4.6) based on models.dev limits. In real Opus 4.7 sessions those values still triggered the plugin's `context_emergency` nudges before reduction completed.

## Root cause

Magic Context computes its percentage clamp against models.dev `limit.context` (opus=144K, sonnet=200K), **not** the provider's actual `max_prompt_tokens`. Copilot's real hard cap is **128K for both Claude models** (verified 2026-04-21 via `https://api.githubcopilot.com/models`). The plugin's clamp can mathematically never trigger at the right moment when models.dev and the provider disagree by 12-72K.

Old thresholds left input rising past Copilot's 128K wall before the plugin's execute-reduction band engaged, surfacing as repeated emergency-nudge user messages.

## Change

| Model | Old | New | % models.dev | % real cap | Real-cap headroom |
| --- | --- | --- | --- | --- | --- |
| github-copilot/claude-opus-4.7 | 112000 | **88000** | 61% | 69% | 40K |
| github-copilot/claude-sonnet-4.6 | 105000 | **95000** | 47.5% | 74% | 33K |

33-40K headroom accommodates response generation, pending tool calls, and the next user message before any emergency band can fire.

`gpt-5.4` (140K) and `gpt-5.3-codex` (210K) unchanged — their models.dev limits match real `max_prompt_tokens` (272K).

## Validation plan

- This session is running on Opus 4.7 with the new 88K threshold. If emergency nudges return, drop further (next stop: 80K).
- Sonnet-4.6 needs a heavy session to validate; if it consistently finishes well under threshold without reduction, raise to ~105K (still 23K real-cap headroom).

## Upstream paper-cut

Worth filing on cortexkit/opencode-magic-context: clamp should optionally use the provider's `max_prompt_tokens` (queryable via `/models` for Copilot) instead of models.dev when they diverge. Would obviate per-model overrides.