### PR TITLE
feat(opencode): tighten magic-context compaction to outpace 80% emergency nudges

### DIFF
--- a/.config/opencode/magic-context.jsonc
+++ b/.config/opencode/magic-context.jsonc
@@ -43,11 +43,11 @@
     },
     "temporal_awareness": true
   },
-  "history_budget_percentage": 0.15,
+  "history_budget_percentage": 0.10,
   "historian_timeout_ms": 420000,
   "memory": {
     "injection_budget_tokens": 6000
   },
   "compaction_markers": true,
-  "auto_drop_tool_age": 30
+  "auto_drop_tool_age": 15
 }


### PR DESCRIPTION
## Why

Emergency-nudge toasts (`CONTEXT EMERGENCY — ~80%+`) keep firing in long Opus 4.7 sessions even with `execute_threshold_tokens` already lowered to 88K. Tracing the installed `@cortexkit/opencode-magic-context@0.13.0` source revealed the root cause is structural, not a denominator bug:

- **`FORCE_COMPARTMENT_PERCENTAGE = 80`** is a hardcoded constant in `dist/index.js:164633`, not user-configurable. The nudge fires whenever `usage.percentage >= 80%`, evaluated independently from `execute_threshold_tokens`.
- Proactive compaction (the path `execute_threshold_tokens` controls) gates on `tailInfo.isMeaningful` and `projectedPostDropPercentage <= relativePostDropTarget` (`dist/index.js:164730–164770`). When most context lives in already-compressed compartments and the droppable tail is small, compaction skips firing — but the nudge fires anyway.
- Result: long sessions where the historian has aggressively compressed history get nudged repeatedly with no remediation path, because there's nothing left for the compactor to drop.

## What changes

Two minimal compaction-budget tweaks to keep the compactor's `projectedPostDropPercentage` low enough to actually fire before usage climbs into the 80% nudge band:

| Setting | Before | After | Reason |
|---|---|---|---|
| `history_budget_percentage` | 0.15 | **0.10** | Tighter historian summaries → smaller compressed body → more headroom against real 128K Copilot Claude prompt cap |
| `auto_drop_tool_age` | 30 | **15** | More tags eligible for drop → larger `droppableBytes` → `projectedPostDropPercentage` actually meets the post-drop target → compactor fires |

`execute_threshold_tokens` values stay at the Copilot Claude evidence-based settings from #1460 (opus=88K, sonnet=95K).

## Verification plan

After restart with this config:
1. Run a long Opus 4.7 session that previously triggered emergency nudges.
2. Watch `/ctx-status` → "Proactive compartment evaluation" should fire below 80%.
3. If nudges still fire, the issue is structural in 0.13.0 (hardcoded 80% gate decoupled from `ctx_reduce_enabled`), and an upstream issue is the next step.

## Notes

- No threshold values changed; only the historian and tool-age budgets that feed into compaction's drop-eligibility math.
- Settings file is `~/.config/opencode/magic-context.jsonc` (this repo's path: `.config/opencode/magic-context.jsonc`).