### PR TITLE
chore(opencode): prefer Anthropic models in magic-context

### DIFF
--- a/.config/opencode/magic-context.jsonc
+++ b/.config/opencode/magic-context.jsonc
@@ -1,13 +1,13 @@
 {
   "$schema": "https://raw.githubusercontent.com/cortexkit/opencode-magic-context/refs/heads/master/assets/magic-context.schema.json",
   "historian": {
-    "model": "github-copilot/gpt-5.4",
-    "fallback_models": ["anthropic/claude-sonnet-4-6"]
+    "model": "anthropic/claude-sonnet-4-6",
+    "fallback_models": ["github-copilot/gpt-5.4"]
   },
   "dreamer": {
     "enabled": true,
-    "model": "github-copilot/claude-sonnet-4.6",
-    "fallback_models": ["anthropic/claude-sonnet-4-6"],
+    "model": "anthropic/claude-sonnet-4-6",
+    "fallback_models": ["github-copilot/claude-sonnet-4.6"],
     "user_memories": {
       "enabled": true,
       "promotion_threshold": 3


### PR DESCRIPTION
- swap historian primary model to anthropic/claude-sonnet-4-6 (was gpt-5.4) with gpt-5.4 as fallback
- swap dreamer primary model to anthropic/claude-sonnet-4-6 (was github-copilot/claude-sonnet-4.6) with github-copilot variant as fallback