### PR TITLE
chore(fro-bot): auto-close daily reports older than 3 days

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -356,6 +356,26 @@ jobs:
         )
       )
     steps:
+      - name: Close stale daily reports
+        if: github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+        run: |
+          cutoff=$(date -u -d '3 days ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+                   || date -u -v-3d '+%Y-%m-%dT%H:%M:%SZ')
+          gh issue list -R "$GITHUB_REPOSITORY" \
+            --author fro-bot \
+            --state open \
+            --search "Daily Maintenance Report in:title" \
+            --json number,title,createdAt \
+            --jq ".[] | select(.createdAt < \"$cutoff\") | .number" \
+          | while read -r num; do
+              gh issue close "$num" -R "$GITHUB_REPOSITORY" \
+                --reason "not planned" \
+                --comment "Auto-closed: daily report older than 3 days."
+              echo "Closed #$num"
+            done
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary

- Adds a `Close stale daily reports` step to the Fro Bot workflow that runs only on `schedule` events, before checkout/agent execution.
- Closes open issues authored by `fro-bot` matching "Daily Maintenance Report" in the title when older than 3 days.
- Uses `--reason "not planned"` and leaves a short comment explaining the auto-close.

## Motivation

17 daily reports have piled up open since April 4. Keeps the 3 most recent visible for trend spotting while preventing unbounded issue accumulation.

## Details

- Date portability: tries GNU `date -d` first, falls back to BSD `date -v` (covers both Ubuntu CI runners and macOS).
- Uses `FRO_BOT_PAT` (not `GITHUB_TOKEN`) so the step has `issues:write` via PAT scope — the workflow's `permissions: contents: read` only restricts `GITHUB_TOKEN`.
- First run will close all 17 stale reports in one pass; subsequent runs close at most 1 per day.

## Verified

REST API dry-run confirmed: 17 issues correctly identified as stale, 3 most recent correctly retained.