### PR TITLE
feat(opencode): tune memory budget and bump plugins

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -30,7 +30,7 @@ ast-grep = "0.40.5"
 "npm:agent-browser" = "0.26.0"
 "npm:skills" = "1.5.1"
 "npm:ocx" = "2.0.7"
-"npm:@cortexkit/opencode-magic-context" = "0.14.2"
+"npm:@cortexkit/opencode-magic-context" = "0.15.0"
 "npm:@cortexkit/aft-opencode" = "0.15.1"
 "npm:@marcusrbrown/infra" = "latest"
 

--- a/.config/opencode/magic-context.jsonc
+++ b/.config/opencode/magic-context.jsonc
@@ -53,8 +53,11 @@
     },
     "temporal_awareness": true
   },
-  "history_budget_percentage": 0.1,
+  "history_budget_percentage": 0.15,
   "historian_timeout_ms": 420000,
+  "memory": {
+    "injection_budget_tokens": 6000
+  },
   "compaction_markers": true,
-  "auto_drop_tool_age": 15
+  "auto_drop_tool_age": 30
 }

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -2,10 +2,10 @@
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
     "@ex-machina/opencode-anthropic-auth@1.7.5",
-    "oh-my-openagent@3.17.4",
+    "oh-my-openagent@3.17.5",
     "@fro.bot/systematic@latest",
     "@franlol/opencode-md-table-formatter@latest",
-    "@cortexkit/opencode-magic-context@0.14.2",
+    "@cortexkit/opencode-magic-context@0.15.0",
     "@cortexkit/aft-opencode@0.15.1"
   ],
   "mcp": {

--- a/.config/opencode/tui.json
+++ b/.config/opencode/tui.json
@@ -2,7 +2,7 @@
   "$schema": "https://opencode.ai/tui.json",
   "theme": "catppuccin",
   "plugin": [
-    "@cortexkit/opencode-magic-context@0.14.2",
+    "@cortexkit/opencode-magic-context@0.15.0",
     "@cortexkit/aft-opencode@0.15.1"
   ]
 }


### PR DESCRIPTION
- bump @cortexkit/opencode-magic-context to 0.15.0 in mise, OpenCode, and TUI configs
- bump oh-my-openagent plugin from 3.17.4 to 3.17.5
- increase magic-context history budget percentage from 0.10 to 0.15
- add memory injection budget setting at 6000 tokens
- raise auto-drop tool age from 15 to 30