### PR TITLE
chore(opencode): upgrade aft plugins and config

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -30,7 +30,7 @@ ast-grep = "0.40.5"
 "npm:agent-browser" = "0.26.0"
 "npm:skills" = "1.5.1"
 "npm:ocx" = "2.0.7"
-"npm:@cortexkit/opencode-magic-context" = "0.15.3"
+"npm:@cortexkit/opencode-magic-context" = "0.15.5"
 "npm:@cortexkit/aft" = "0.16.1"
 "npm:@marcusrbrown/infra" = "latest"
 

--- a/.config/opencode/magic-context.jsonc
+++ b/.config/opencode/magic-context.jsonc
@@ -51,7 +51,10 @@
       "since_days": 365,
       "max_commits": 2000
     },
-    "temporal_awareness": true
+    "temporal_awareness": true,
+    "caveman_text_compression": {
+      "enabled": true
+    }
   },
   "history_budget_percentage": 0.15,
   "historian_timeout_ms": 420000,
@@ -59,5 +62,6 @@
     "injection_budget_tokens": 6000
   },
   "compaction_markers": true,
-  "auto_drop_tool_age": 30
+  "auto_drop_tool_age": 30,
+  "ctx_reduce_enabled": false
 }

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -5,7 +5,7 @@
     "oh-my-openagent@3.17.5",
     "@fro.bot/systematic@latest",
     "@franlol/opencode-md-table-formatter@latest",
-    "@cortexkit/opencode-magic-context@0.15.3",
+    "@cortexkit/opencode-magic-context@0.15.5",
     "@cortexkit/aft-opencode@0.16.1"
   ],
   "mcp": {

--- a/.config/opencode/tui.json
+++ b/.config/opencode/tui.json
@@ -2,7 +2,7 @@
   "$schema": "https://opencode.ai/tui.json",
   "theme": "catppuccin",
   "plugin": [
-    "@cortexkit/opencode-magic-context@0.15.3",
+    "@cortexkit/opencode-magic-context@0.15.5",
     "@cortexkit/aft-opencode@0.16.1"
   ]
 }


### PR DESCRIPTION
- bump npm:opencode-ai from 1.14.25 to 1.14.28 in mise
- bump npm:@cortexkit/aft from 0.15.5 to 0.16.1 in mise
- bump @cortexkit/aft-opencode from 0.15.5 to 0.16.1 in opencode and tui plugin lists
- set restrict_to_project_root to false in aft config