### PR TITLE
chore(env): add local npm token flow

### DIFF
--- a/.config/mise/.env.example
+++ b/.config/mise/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to ~/.config/mise/.env.local and fill in real values.
+# Do not commit ~/.config/mise/.env.local.
+
+NPM_TOKEN=

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -47,6 +47,8 @@ includes = ["tasks/dotfiles.toml", "tasks/_mise.toml"]
 
 [env]
 UV_SYSTEM_CERTS = "true"
+NPM_TOKEN = "{{ env.NPM_TOKEN | default(value='') }}"
+_.file = [{ path = "{{ env.HOME }}/.config/mise/.env.local", redact = true }]
 
 [settings]
 idiomatic_version_file_enable_tools = ["node"]

--- a/.config/npm/npmrc
+++ b/.config/npm/npmrc
@@ -1,10 +1,8 @@
-#prefix=${XDG_DATA_HOME}/npm
 cache=${XDG_CACHE_HOME}/npm
-
 sign-git-tag=true
-
 init-author-name=Marcus R. Brown
 init-author-email=contact@marcusrbrown.com
 init-author-url=https://marcusrbrown.com/
 init-license=MIT
 init-version=0.1.0
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
## Summary
- load NPM_TOKEN from ~/.config/mise/.env.local when available
- default NPM_TOKEN to empty in mise to avoid unset warnings
- keep npm auth config in tracked ~/.config/npm/npmrc via ${NPM_TOKEN}
- add ~/.config/mise/.env.example to document required local env var

## Files
- .config/mise/config.toml
- .config/mise/.env.example
- .config/npm/npmrc