### PR TITLE
chore(opencode): bump plugin versions

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -31,8 +31,8 @@ ast-grep = "0.40.5"
 "npm:agent-browser" = "0.26.0"
 "npm:skills" = "1.5.1"
 "npm:ocx" = "2.0.7"
-"npm:@cortexkit/opencode-magic-context" = "0.15.5"
-"npm:@cortexkit/aft" = "0.17.0"
+"npm:@cortexkit/opencode-magic-context" = "0.15.7"
+"npm:@cortexkit/aft" = "0.17.3"
 "npm:@marcusrbrown/infra" = "latest"
 
 # Language Servers

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
-    "@ex-machina/opencode-anthropic-auth@1.7.5",
+    "@ex-machina/opencode-anthropic-auth@1.8.0",
     "oh-my-openagent@3.17.5",
     "opencode-copilot-delegate@latest",
     "@fro.bot/systematic@latest",
     "@franlol/opencode-md-table-formatter@latest",
-    "@cortexkit/opencode-magic-context@0.15.5",
-    "@cortexkit/aft-opencode@0.17.0"
+    "@cortexkit/opencode-magic-context@0.15.7",
+    "@cortexkit/aft-opencode@0.17.3"
   ],
   "mcp": {
     "context7": {

--- a/.config/opencode/tui.json
+++ b/.config/opencode/tui.json
@@ -2,7 +2,7 @@
   "$schema": "https://opencode.ai/tui.json",
   "theme": "catppuccin",
   "plugin": [
-    "@cortexkit/opencode-magic-context@0.15.5",
-    "@cortexkit/aft-opencode@0.17.0"
+    "@cortexkit/opencode-magic-context@0.15.7",
+    "@cortexkit/aft-opencode@0.17.3"
   ]
 }


### PR DESCRIPTION
- bump npm:@cortexkit/opencode-magic-context from 0.15.5 to 0.15.7 in mise
- bump npm:@cortexkit/aft from 0.17.0 to 0.17.3 in mise
- bump @ex-machina/opencode-anthropic-auth from 1.7.5 to 1.8.0 in opencode config
- bump @cortexkit/opencode-magic-context from 0.15.5 to 0.15.7 in opencode/tui
- bump @cortexkit/aft-opencode from 0.17.0 to 0.17.3 in opencode/tui