### PR TITLE
chore(opencode): enable sisyphus and tune defaults

### DIFF
--- a/.config/opencode/oh-my-openagent.json
+++ b/.config/opencode/oh-my-openagent.json
@@ -69,8 +69,7 @@
   },
   "disabled_agents": [
     "atlas",
-    "hephaestus",
-    "sisyphus"
+    "hephaestus"
   ],
   "disabled_hooks": [
     "context-window-monitor",
@@ -92,5 +91,10 @@
     "include_co_authored_by": false,
     "git_env_prefix": "GIT_MASTER=1"
   },
-  "hashline_edit": true
+  "hashline_edit": true,
+  "sisyphus_agent": {
+    "default_builder_enabled": true,
+    "planner_enabled": false,
+    "replace_plan": false
+  }
 }

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -3,7 +3,7 @@
   "plugin": [
     "@ex-machina/opencode-anthropic-auth@1.8.0",
     "oh-my-openagent@3.17.6",
-    "opencode-copilot-delegate@0.3.0",
+    "opencode-copilot-delegate@0.6.0",
     "@fro.bot/systematic@latest",
     "@franlol/opencode-md-table-formatter@latest",
     "@cortexkit/opencode-magic-context@0.15.7",


### PR DESCRIPTION
- remove sisyphus from disabled_agents in oh-my-openagent config
- add sisyphus_agent settings:
  - default_builder_enabled: true
  - planner_enabled: false
  - replace_plan: false
- bump opencode-copilot-delegate from 0.3.0 to 0.6.0