### PR TITLE
chore(opencode): update magic context model defaults

### DIFF
--- a/.config/opencode/magic-context.jsonc
+++ b/.config/opencode/magic-context.jsonc
@@ -20,7 +20,7 @@
   },
   "sidekick": {
     "enabled": true,
-    "model": "github-copilot/gpt-5-mini"
+    "model": "github-copilot/gpt-5.4-mini"
   },
   "cache_ttl": {
     "default": "5m",
@@ -32,7 +32,8 @@
     "default": 65,
     "anthropic/claude-sonnet-4-6": 40,
     "anthropic/claude-opus-4-6": 40,
-    "anthropic/claude-opus-4-7": 40
+    "anthropic/claude-opus-4-7": 40,
+    "github-copilot/gpt-5.5": 35
   },
   "execute_threshold_tokens": {
     "github-copilot/claude-opus-4.7": 80000,


### PR DESCRIPTION
## Summary

- Move the OpenCode sidekick model from `github-copilot/gpt-5-mini` to `github-copilot/gpt-5.4-mini`.
- Add a tighter `github-copilot/gpt-5.5` history budget for Magic Context.

## Verification

- Confirmed the branch contains only the Magic Context config change.