### PR TITLE
fix(renovate): link devcontainer feature releases

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,7 +32,7 @@
         Package: '[`{{{replace "^ghcr\\.io/devcontainers/features/" "" depName}}}`](https://github.com/devcontainers/features/tree/main/src/{{{replace "^ghcr\\.io/devcontainers/features/" "" depName}}})'
       },
       sourceUrl: 'https://github.com/devcontainers/features',
-      changelogUrl: 'https://github.com/devcontainers/features/blob/main/src/{{{replace "^ghcr\\.io/devcontainers/features/" "" depName}}}/NOTES.md'
+      changelogUrl: 'https://github.com/devcontainers/features/releases/tag/feature_{{{replace "^ghcr\\.io/devcontainers/features/" "" depName}}}_{{{newVersion}}}'
     },
     {
       description: 'Disable digest pinning for base images',


### PR DESCRIPTION
## Summary
- derive official devcontainer feature release links from the feature name and target version
- replace the `NOTES.md` reference with the GitHub release tag URL Renovate should show in `References`
- keep the existing local devcontainer PR-title and package cleanup intact

## Verification
- parsed `.github/renovate.json5`
- verified the rendered target shape matches `feature_node_2.0.0`