### PR TITLE
chore(opencode): simplify thresholds and bump delegate

### DIFF
--- a/.config/opencode/magic-context.jsonc
+++ b/.config/opencode/magic-context.jsonc
@@ -32,14 +32,11 @@
     "default": 65,
     "anthropic/claude-sonnet-4-6": 40,
     "anthropic/claude-opus-4-6": 40,
-    "anthropic/claude-opus-4-7": 40,
-    "github-copilot/gpt-5.4": 35,
-    "github-copilot/gpt-5.5": 35
+    "anthropic/claude-opus-4-7": 40
   },
   "execute_threshold_tokens": {
     "github-copilot/claude-opus-4.7": 80000,
-    "github-copilot/claude-sonnet-4.6": 95000,
-    "github-copilot/gpt-5.3-codex": 210000
+    "github-copilot/claude-sonnet-4.6": 95000
   },
   "experimental": {
     "auto_search": {

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -2,7 +2,7 @@
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
     "@ex-machina/opencode-anthropic-auth@1.8.0",
-    "opencode-copilot-delegate@0.9.0",
+    "opencode-copilot-delegate@0.10.1",
     "@fro.bot/systematic@latest",
     "@franlol/opencode-md-table-formatter@latest",
     "@cortexkit/opencode-magic-context@0.15.7",


### PR DESCRIPTION
- bump opencode-copilot-delegate from 0.9.0 to 0.10.1
- remove github-copilot/gpt-5.4 and gpt-5.5 compression threshold overrides
- remove github-copilot/gpt-5.3-codex execute threshold override