### PR TITLE
feat(shell): add `dotfiles-opencode` alias to launch OpenCode in bare-repo dir

### DIFF
--- a/.config/bash/aliases
+++ b/.config/bash/aliases
@@ -12,6 +12,11 @@ fi
 # ~/.dotfiles is a bare Git repo with the work directory set to ~
 alias .dotfiles='GIT_DIR=$HOME/.dotfiles GIT_WORK_TREE=$HOME'
 
+# Launch OpenCode rooted at the dotfiles bare-repo dir to avoid AFT plugin
+# `configure` timeouts caused by ripgrep walking macOS-sandboxed paths under
+# $HOME (~/Library/*, FileProvider iCloud mounts).
+alias dotfiles-opencode='cd "$HOME/.dotfiles" && GIT_DIR="$HOME/.dotfiles" GIT_WORK_TREE="$HOME" opencode'
+
 LSCMD='ls'
 if [[ "$HOST_OS" == "darwin" ]]; then
   # https://www.gnu.org/software/coreutils/


### PR DESCRIPTION
Adds a `dotfiles-opencode` alias that launches OpenCode with `cwd=~/.dotfiles` instead of `$HOME`, which works around an AFT plugin (`@cortexkit/aft-opencode`) startup hang specific to macOS dotfiles setups.

## Why

The AFT plugin's `configure` handshake walks the OpenCode project root with ripgrep — for formatter/checker auto-detection and source-file counting against `max_callgraph_files`. When cwd is `$HOME`, the walk enters macOS-sandboxed paths under `~/Library/*` (`Containers`, `Group Containers`, `Caches`, `CloudDocs`, FileProvider iCloud mounts). At least one of those returns `Operation timed out (os error 60)` (ETIMEDOUT) on network/sandboxed mounts, blocking the walk past the plugin's 30s timeout. Every subsequent tool call dies with:

```
[aft-plugin] Request "configure" timed out after 30000ms
```

Disabling `search_index` and `semantic_search` in `aft.jsonc` does not fix this — those gate post-configure indexing, not the handshake walk. AFT already has a guard for this shape (`max_callgraph_files: 20000` rejects OS-wide roots like `~/Work` for callgraph ops); the configure walk needs the same guard or a macOS sandboxed-path skip-list.

## Fix

Launching OpenCode rooted at `~/.dotfiles` (a small dir with no `Library/` or network mounts) makes the configure walk return instantly. Existing `.dotfiles` alias still works for git ops via per-command `GIT_DIR`/`GIT_WORK_TREE` env vars.

## Verification

- `bash -n .config/bash/aliases` — syntax OK
- Sourced the file in a subshell, alias resolves correctly
- Live-tested by restarting OpenCode in `~/.dotfiles`: `bash`, `read`, `glob` calls all return instantly with no `configure` timeouts