### PR TITLE
chore(opencode): pin remaining plugin versions and add Renovate manager

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -3,8 +3,8 @@
   "plugin": [
     "@ex-machina/opencode-anthropic-auth@1.8.0",
     "opencode-copilot-delegate@0.10.1",
-    "@fro.bot/systematic@latest",
-    "@franlol/opencode-md-table-formatter@latest",
+    "@fro.bot/systematic@2.7.1",
+    "@franlol/opencode-md-table-formatter@0.0.6",
     "@cortexkit/opencode-magic-context@0.15.7",
     "@cortexkit/aft-opencode@0.18.4",
     "oh-my-opencode-slim@1.0.6"

--- a/.config/opencode/tui.json
+++ b/.config/opencode/tui.json
@@ -5,6 +5,6 @@
     "opencode-copilot-delegate@0.10.1",
     "@cortexkit/opencode-magic-context@0.15.7",
     "@cortexkit/aft-opencode@0.18.4",
-    "oh-my-opencode-slim"
+    "oh-my-opencode-slim@1.0.6"
   ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,19 @@
       ],
       depTypeTemplate: 'devDependencies',
       versioningTemplate: '{{#if versioning}}{{versioning}}{{else}}semver{{/if}}'
+    },
+    {
+      customType: 'regex',
+      description: 'Update pinned npm plugin versions in OpenCode config files.',
+      managerFilePatterns: [
+        '/(^|/)\\.config/opencode/opencode\\.json$/',
+        '/(^|/)\\.config/opencode/tui\\.json$/'
+      ],
+      matchStrings: [
+        '"(?<depName>(?:@[a-z0-9-~][a-z0-9-._~]*/)?[a-z0-9-~][a-z0-9-._~]*)@(?<currentValue>\\d+\\.\\d+\\.\\d+(?:[-+][a-z0-9.-]+)?)"'
+      ],
+      datasourceTemplate: 'npm',
+      versioningTemplate: 'npm'
     }
   ],
   ignorePresets: ['mergeConfidence:age-confidence-badges', 'mergeConfidence:all-badges'],
@@ -54,11 +67,14 @@
       matchPackageNames: [
         '@cortexkit/aft-opencode',
         '@cortexkit/opencode-magic-context',
+        '@ex-machina/opencode-anthropic-auth',
+        '@franlol/opencode-md-table-formatter',
         'agent-browser',
-        'opencode-anthropic-oauth'
+        'opencode-copilot-delegate'
       ],
       matchUpdateTypes: ['minor', 'patch'],
       extends: ['github>bfra-me/renovate-config:automerge.json5#5.2.1'],
+      groupName: null,
       dependencyDashboardApproval: false
     }
   ],


### PR DESCRIPTION
## Why

PR #1553 pinned `oh-my-opencode-slim` in response to Fro Bot's `@latest` drift NBC. This PR closes that gap for the remaining plugins and adds a Renovate manager so future drift is caught automatically instead of by review.

## Plugin Pins

| File                                         | Plugin                                  | Before     | After    |
| -------------------------------------------- | --------------------------------------- | ---------- | -------- |
| `~/.config/opencode/opencode.json`            | `@fro.bot/systematic`                   | `@latest`  | `2.7.1`  |
| `~/.config/opencode/opencode.json`            | `@franlol/opencode-md-table-formatter`  | `@latest`  | `0.0.6`  |
| `~/.config/opencode/tui.json`                 | `oh-my-opencode-slim`                   | unpinned   | `1.0.6`  |

After this PR all 7 plugins in `opencode.json` and all 4 plugins in `tui.json` are pinned to exact versions.

## Renovate Manager

New `customManager` in `.github/renovate.json5` scans `~/.config/opencode/opencode.json` and `~/.config/opencode/tui.json` for `package@semver` strings inside the `plugin` arrays and treats them as npm dependencies. Same pattern as the existing `_VERSION` manager for mise config.

```regex
"(?<depName>(?:@[a-z0-9-~][a-z0-9-._~]*/)?[a-z0-9-~][a-z0-9-._~]*)@(?<currentValue>\d+\.\d+\.\d+(?:[-+][a-z0-9.-]+)?)"
```

## Automerge Rule Update

Existing v0 automerge `packageRule` updated:

| Change                                                                                | Why                                                                                                            |
| ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
| Replace `opencode-anthropic-oauth` with `@ex-machina/opencode-anthropic-auth`          | The old name was stale; `@ex-machina` is what's actually installed.                                            |
| Add `@franlol/opencode-md-table-formatter` and `opencode-copilot-delegate`             | Both currently on v0.x — minor/patch bumps should auto-merge.                                                  |
| Add `groupName: null`                                                                 | Override the parent preset's `group:allNonMajor` so each plugin gets its own PR (diagnostic value > batching). |

The v0 `matchCurrentVersion` filter naturally excludes major bumps and v1+ packages from auto-merge — those still gate through the dependency dashboard.

## Verification

- `renovate.json5` parses cleanly (json5)
- `opencode.json` and `tui.json` parse cleanly (JSON)
- All three pinned versions resolve on the npm registry as of branch creation

After merge, the next Renovate run should produce the new opencode-plugin manager output in the dependency dashboard. Any pending plugin bumps will surface as individual PRs.