### PR TITLE
feat(security): add gitignore defense-in-depth layers

### DIFF
--- a/.config/git/hooks/pre-commit
+++ b/.config/git/hooks/pre-commit
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Block commits containing detected secrets.
+# Bypass with `git commit --no-verify` when needed.
+#
+# Setup (one-time per machine):
+#   git --git-dir=$HOME/.dotfiles config core.hooksPath $HOME/.config/git/hooks
+#
+# Provided by `aqua:gitleaks/gitleaks` in ~/.config/mise/config.toml.
+
+set -euo pipefail
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "warning: gitleaks not found on PATH; skipping pre-commit secret scan" >&2
+  echo "         install via: mise install aqua:gitleaks/gitleaks" >&2
+  exit 0
+fi
+
+exec gitleaks protect --staged --redact --verbose

--- a/.config/git/ignore
+++ b/.config/git/ignore
@@ -45,3 +45,34 @@ tags
 .devcontainer/.*Marker
 
 **/.claude/settings.local.json
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Credential-shape safety net (cross-repo, applies via core.excludesfile).
+# The dotfiles bare repo overrides core.excludesfile to .dotfiles/.gitignore,
+# so these rules do NOT protect dotfiles itself — dotfiles relies on its
+# allowlist + gitleaks pre-commit hook for the same coverage.
+# Pair with `gitleaks detect --source <repo>` for content-based scanning.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Env file variants (plain `.env` already covered above; carve out documented examples)
+**/.env.*
+!**/.env.example
+!**/.env.template
+!**/.env.sample
+
+# Auth/credential by name
+**/*secret*
+**/*token*
+**/*credential*
+**/*password*
+**/auth.json
+
+# Common key file extensions
+**/*.pem
+**/*.key
+**/*.p12
+**/*.pfx
+**/id_rsa
+**/id_rsa.*
+**/id_ed25519
+**/id_ed25519.*

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -15,6 +15,7 @@ ast-grep = "0.42.1"
 
  # shfmt
 "aqua:mvdan/sh" = "3.13.1"
+"aqua:gitleaks/gitleaks" = "8.30.1"
 
 "npm:typescript" = "6.0.3"
 "npm:vibe-tools" = "0.63.3"

--- a/.dotfiles/.gitignore
+++ b/.dotfiles/.gitignore
@@ -22,6 +22,8 @@
 /.dotfiles/*
 !/.dotfiles/docs/
 !/.dotfiles/docs/*.md
+!/.dotfiles/docs/brainstorms/
+!/.dotfiles/docs/brainstorms/*.md
 !/.github/
 !/.ssh/
 /.ssh/*
@@ -49,3 +51,13 @@
 !/Library/LaunchAgents/
 /Library/LaunchAgents/*
 !/Library/LaunchAgents/dev.mrbro.environment.plist
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AI tool session/log/transcript dirs — dotfiles-specific noise.
+# Credential-shape names live in ~/.config/git/ignore (cross-repo). Patterns
+# here are project-shape names too false-positive-prone for global ignore
+# (e.g., Rails session stores, model dirs called `transcripts/`).
+# ─────────────────────────────────────────────────────────────────────────────
+**/sessions/
+**/transcripts/
+**/history.jsonl

--- a/.dotfiles/docs/brainstorms/2026-05-03-gitignore-defense-in-depth-requirements.md
+++ b/.dotfiles/docs/brainstorms/2026-05-03-gitignore-defense-in-depth-requirements.md
@@ -1,0 +1,171 @@
+# `.gitignore` Defense-in-Depth — Requirements
+
+**Date:** 2026-05-03
+**Status:** Requirements captured, ready for planning
+**Origin:** `@council` recommendation on `.gitignore` allowlist friction (3-councillor consensus, 2/3 quorum)
+
+## Problem
+
+The dotfiles repo (single-user, bare git, `GIT_WORK_TREE=$HOME`) uses a strict allowlist `.gitignore` — `/*` ignores everything, then explicit `!/path/to/file` un-ignores tracked files. Every new AI tool creates allowlist friction, and as more tools accumulate (`.claude/`, `.config/opencode/`, `.agents/`, future `.codex/`), the risk of accidentally tracking credentials, session state, or telemetry grows. The allowlist alone is the only defense — there is no name-based safety net for credential-shaped filenames and no by-content credential scanning.
+
+## Goals
+
+1. **Add a name-based safety net** — re-ignore patterns at the bottom of `.dotfiles/.gitignore` that catch credential-shaped names regardless of where they appear in the tree (last-match-wins semantics).
+2. **Add by-content credential scanning** — `gitleaks` installed via mise, wired as a local pre-commit hook that blocks any commit containing detected secrets.
+3. **Document the convention** — short addition to `~/AGENTS.md` explaining the layered defense (allowlist + safety net + scanner) so future tools and agents understand the model.
+4. **All four layers ship in a single PR** — safety net + mise install + pre-commit hook + AGENTS.md update.
+
+## Non-Goals
+
+1. **No restructure of the existing allowlist.** The repo is already mostly conformant to the council's "scoped bulk-allowlist for content subdirs, file-level for tool roots" principle. Adding the safety net is purely additive defense-in-depth, not a refactor.
+2. **No CI gitleaks integration.** Local pre-commit hook only. CI integration is explicitly deferred to a future PR if needed.
+
+## Success Criteria
+
+- Re-ignore safety net committed at the bottom of `.dotfiles/.gitignore`; verified with `git check-ignore -v` against test paths
+- `gitleaks` installed via mise (`~/.config/mise/config.toml`); `gitleaks version` resolves on shell reload
+- Pre-commit hook (`~/.dotfiles/hooks/pre-commit`) blocks commits containing a known-fake secret pattern; `git commit --no-verify` bypasses it as expected
+- `~/AGENTS.md` updated with a compact rule + safety net rationale under the existing CONVENTIONS section
+- Manually tested end-to-end: stage a file with a fake secret → commit blocked → bypass works → commit clean diff
+
+## Layer Specifications
+
+### Layer 1 — Re-ignore Safety Net
+
+Append to the bottom of `.dotfiles/.gitignore` (after all `!/path` allowlist rules so last-match-wins applies the re-ignore):
+
+```gitignore
+# Defense-in-depth: re-ignore credential-shaped filenames anywhere in the tree.
+# These patterns run AFTER the allowlist negations above, so they catch files
+# inside re-included directories regardless of bulk-allowlist scope.
+
+# Env files
+**/.env
+**/.env.*
+
+# Auth/credential by name
+**/*secret*
+**/*token*
+**/*credential*
+**/*password*
+**/auth.json
+
+# Common key file extensions
+**/*.pem
+**/*.key
+**/*.p12
+**/*.pfx
+**/id_rsa
+**/id_rsa.*
+**/id_ed25519
+**/id_ed25519.*
+
+# AI tool session/log/transcript dirs
+**/sessions/
+**/transcripts/
+**/history.jsonl
+```
+
+**Verification:**
+- `git check-ignore -v` against `.config/opencode/.env` returns the safety-net pattern as the matching rule
+- Existing tracked files (none currently match these patterns; `git ls-files | grep` confirmed empty before merge) remain unaffected
+
+### Layer 2 — gitleaks via mise
+
+Add to `~/.config/mise/config.toml` under `[tools]`:
+
+```toml
+"ubi:gitleaks/gitleaks" = "latest"
+```
+
+(or pinned version if other mise tools follow that convention — verify during planning)
+
+**Verification:**
+- `mise install` succeeds
+- `gitleaks version` resolves after shell reload
+- `gitleaks detect --source $HOME --no-git` runs against the working tree (smoke test, not a hard gate)
+
+### Layer 3 — Pre-commit Hook
+
+Create `~/.dotfiles/hooks/pre-commit`:
+
+```bash
+#!/usr/bin/env bash
+# Block commits containing detected secrets.
+# Bypass with `git commit --no-verify` when needed.
+set -euo pipefail
+exec gitleaks protect --staged --redact --verbose
+```
+
+Hook installation is **manual** — matches the existing dotfiles convention of declarative tools without auto-bootstrap. Document the install step in `AGENTS.md`:
+
+```bash
+chmod +x ~/.dotfiles/hooks/pre-commit
+git --git-dir=$HOME/.dotfiles config core.hooksPath $HOME/.dotfiles/hooks
+```
+
+**Policy:**
+- Block on any finding
+- `git commit --no-verify` bypasses (standard escape hatch)
+- No `.gitleaks.toml` allowlist file (defer until first false positive)
+
+**Verification:**
+- Stage a file containing `AKIA[A-Z0-9]{16}`-shaped fake AWS key → commit aborts with gitleaks output
+- `git commit --no-verify` succeeds against the same staged file
+- Stage a clean diff → commit succeeds normally
+
+### Layer 4 — AGENTS.md Convention
+
+Add a compact subsection under the existing `Allowlist .gitignore Pattern` block in `~/AGENTS.md`:
+
+```markdown
+### Defense-in-Depth Layers
+
+The allowlist is the primary defense, but two backstops catch what slips through:
+
+1. **Name-based safety net** — Re-ignore block at the bottom of `.dotfiles/.gitignore`
+   catches credential-shaped names (`*.env`, `*secret*`, `*.pem`, session dirs, etc.)
+   regardless of where they appear. Last-match-wins gitignore semantics.
+2. **By-content scanning** — `gitleaks` runs as a local pre-commit hook
+   (`~/.dotfiles/hooks/pre-commit`). Blocks commits with detected secrets.
+   Bypass with `git commit --no-verify` for known false positives.
+
+When adding a new AI tool: extend the allowlist for the tool's content dirs,
+trust the safety net to catch credential-shaped files, run `gitleaks detect`
+once on first commit to verify nothing leaked.
+```
+
+## Open Questions for Planning
+
+1. **mise version pinning** — does `~/.config/mise/config.toml` use `latest` or pinned semver for the existing AI/CLI tools? Match that convention.
+2. **Hook installation idempotency** — is there a one-shot install command worth scripting, or is the manual `chmod` + `core.hooksPath` setup acceptable as a one-time-per-machine task?
+3. **Does any currently tracked file match the safety net patterns?** Pre-merge audit: `git ls-files | grep -iE '\.env|secret|token|credential|password|\.pem|\.key|id_rsa|id_ed25519|sessions/|transcripts/|history\.jsonl'`. Expected: zero matches. If any match, decide per-file whether to delete-from-tracking, rename, or carve out an exception in the safety net.
+
+## Risks and Mitigations
+
+| Risk                                                 | Mitigation                                                                                                                          |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Safety net blocks a legitimate config file           | Audit `git ls-files` against the patterns before merge (open question 3). Carve out exceptions only with documented justification.  |
+| `gitleaks protect --staged` is slow on large diffs    | Acceptable — local-only, runs on commit not push. If it becomes a problem, switch to `--max-target-megabytes` or scope to changed files. |
+| Pre-commit hook bypassed and forgotten               | `gitleaks detect` available manually for periodic audits. CI integration deferred but available as a future safety upgrade.         |
+| Hook installation missed on a new machine            | Document the install command in `AGENTS.md`. Optionally add a `mise run security:setup` task in a future iteration.                  |
+| AGENTS.md drift relative to actual `.gitignore` state  | Fro Bot's daily AGENTS.md drift check catches this. Same mechanism that caught the lockfile-path drift on PR #1553.                  |
+
+## Out of Scope (Explicit)
+
+- Restructuring the existing root `.gitignore` allowlist (already mostly conformant to council's principle)
+- CI gitleaks integration (local hook only)
+- Per-tool-dir `.gitignore` standardization (only `.config/opencode/.gitignore` exists today; adding more is a separate decision)
+- gitleaks configuration tuning (`.gitleaks.toml`, custom rules) — defer until first false positive
+- Automated hook installation via dotfiles bootstrap
+
+## References
+
+- Council session: 2/3 quorum (alpha + beta), 4th-option proposal that beat both A (status quo) and B (bulk-allowlist tool roots)
+- PR #1440 — removed dead `.claude/skills/` allowlist entry (precedent for allowlist hygiene)
+- PR #1553 — pinned `oh-my-opencode-slim`, raised the `@latest` drift NBC pattern
+- Existing per-dir `.gitignore`: `~/.config/opencode/.gitignore` (precedent for the delegation model)
+
+---
+
+**Next step:** `ce:plan` against this document to produce the implementation plan.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,22 @@ Repo ignores EVERYTHING by default, allowlists tracked paths in `.dotfiles/.giti
 1. Try `git add -n <file>` first
 2. If ignored, add `!/path/to/file` to `.dotfiles/.gitignore` and retry
 
+### Defense-in-Depth Layers
+
+The dotfiles allowlist is the primary defense. Two cross-repo backstops catch what slips through anywhere on the machine:
+
+1. **Name-based safety net** — `~/.config/git/ignore` (XDG global gitignore) catches credential-shape names (`**/.env.*`, `**/*secret*`, `**/*.pem`, `**/id_rsa*`, etc.) in **every repo on the machine**. Carves out `**/.env.example`, `**/.env.template`, `**/.env.sample` so documented templates stay tracked. Note: the dotfiles bare repo overrides `core.excludesfile` to `.dotfiles/.gitignore`, so this file does NOT protect dotfiles itself — dotfiles relies on its allowlist + gitleaks for the same coverage. AI-tool noise dirs (`**/sessions/`, `**/transcripts/`, `**/history.jsonl`) stay in `.dotfiles/.gitignore` because they're too false-positive-prone globally.
+2. **By-content scanning** — `gitleaks` (installed via `aqua:gitleaks/gitleaks` in `~/.config/mise/config.toml`) runs as a local pre-commit hook at `~/.config/git/hooks/pre-commit`. Blocks commits containing detected secrets in any repo where the hook is activated. Bypass with `git commit --no-verify` for known false positives.
+
+**One-time hook activation** (per machine, dotfiles bare repo):
+```bash
+git --git-dir=$HOME/.dotfiles config core.hooksPath $HOME/.config/git/hooks
+```
+
+**When adding a new AI tool**: extend the allowlist for the tool's content dirs, trust the global ignore + gitleaks to catch credential-shaped files, run `gitleaks detect --source $HOME --no-git` once on first commit to verify nothing leaked.
+
+**False-positive workaround**: The global patterns `**/*secret*` and `**/*.key` are intentionally broad — they catch obvious credentials but also legitimately-named files (`secret.ts`, `secret-manager.ts`, registry/layout `.key` files, `gpg.key`, etc.). When working on a non-dotfiles repo where a legitimate file matches, add a project-local negation in that repo's `.gitignore`: `!secret.ts` or `!path/to/file.key`. Working-tree gitignore patterns take precedence over the global ignore, so the negation always wins.
+
 ### Shell Config Organization
 
 - **Bash entry**: `.bashrc` → `.config/bash/main` → `functions` → `aliases` → `init.d/*` (alphabetical) → `local.d/*`


### PR DESCRIPTION
## Summary

Adds two cross-repo backstops to the existing dotfiles allowlist for defense in depth against credential commits. The allowlist remains the primary defense for the dotfiles bare repo; these layers protect every other repo on the machine and add by-content scanning across all repos with the hook activated.

## Layers

### 1. Name-based safety net — `~/.config/git/ignore`

Cross-repo XDG global gitignore. Catches credential-shape names anywhere on the machine:

- `**/.env.*` (plain `.env` was already there)
- `**/*secret*`, `**/*token*`, `**/*credential*`, `**/*password*`, `**/auth.json`
- `**/*.pem`, `**/*.key`, `**/*.p12`, `**/*.pfx`
- `**/id_rsa`, `**/id_rsa.*`, `**/id_ed25519`, `**/id_ed25519.*`

Carve-outs (still tracked): `**/.env.example`, `**/.env.template`, `**/.env.sample`.

**Important:** The dotfiles bare repo overrides `core.excludesfile` to `.dotfiles/.gitignore`, so this file does **not** protect dotfiles itself. Dotfiles relies on its allowlist + gitleaks for the same coverage.

### 2. By-content scanning — gitleaks pre-commit hook

- `aqua:gitleaks/gitleaks = "8.30.1"` added to `~/.config/mise/config.toml`
- Hook at `~/.config/git/hooks/pre-commit` runs `gitleaks protect --staged --redact --verbose`
- Bypass with `git commit --no-verify` for known false positives

**One-time activation per machine for the dotfiles bare repo:**

```bash
git --git-dir=$HOME/.dotfiles config core.hooksPath $HOME/.config/git/hooks
```

### 3. AI tool noise — stays in dotfiles

`**/sessions/`, `**/transcripts/`, `**/history.jsonl` stay in `.dotfiles/.gitignore` because these names are too false-positive-prone for a global ignore (Rails session stores, model directories named `transcripts/`, etc.).

## Why this architecture

Considered (and rejected) putting the credential safety net in `.dotfiles/.gitignore` — that would only protect the dotfiles repo itself and miss the cross-repo concern. The XDG global gitignore is the canonical home for cross-repo name patterns. The dotfiles allowlist already provides equivalent name-level protection inside dotfiles via its strict `/*` + explicit allowlist model.

## Verification

Validated with isolated tests in a clean shell (no inherited `GIT_DIR`):

| Test | Result |
| ---- | ------ |
| `*.pem` in arbitrary repo | matches `~/.config/git/ignore:71:**/*.pem` |
| `my-secret-key.json` in arbitrary repo | matches `~/.config/git/ignore:64:**/*secret*` |
| `.env.example` carve-out | not ignored (negation hits) |
| Dotfiles allowlist still works | `.config/mise/.env.example` still tracked |
| AI tool dirs caught in dotfiles | `.claude/sessions/`, etc., still ignored |
| gitleaks hook executes | runs on commit; clean test shows no leaks |
| No tracked file newly ignored | full audit clean |

## Files Changed

- `.config/git/ignore` — credential-shape safety net
- `.config/git/hooks/pre-commit` — gitleaks invocation
- `.config/mise/config.toml` — pin gitleaks 8.30.1
- `.dotfiles/.gitignore` — AI tool noise patterns (kept), credential patterns NOT added here (that was the wrong location)
- `AGENTS.md` — Conventions > Defense-in-Depth Layers documentation
- `.dotfiles/docs/brainstorms/2026-05-03-gitignore-defense-in-depth-requirements.md` — ce:brainstorm requirements output

## Out of Scope

Per the brainstorm requirements doc, this PR intentionally does **not** include:

- Allowlist restructure (status quo + per-dir delegation explicitly out of scope)
- CI gitleaks integration (no test job, runs only locally)
- Allowlist audit for credential-shaped tracked files (none exist; only `.config/mise/.env.example` matched the audit and it is an intentional template)
