### PR TITLE
chore(opencode): upgrade cortexkit stack and auth plugin

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -32,8 +32,9 @@ ast-grep = "0.42.1"
 "npm:agent-browser" = "0.26.0"
 "npm:skills" = "1.5.3"
 "npm:ocx" = "2.0.8"
-"npm:@cortexkit/magic-context" = "0.16.2"
-"npm:@cortexkit/aft" = "0.19.3"
+"npm:@cortexkit/magic-context" = "0.17.1"
+"npm:@cortexkit/aft" = "0.19.6"
+"npm:@cortexkit/opencode-anthropic-auth" = "1.0.0"
 "npm:@marcusrbrown/infra" = "latest"
 
 # Language Servers

--- a/.config/opencode/aft.jsonc
+++ b/.config/opencode/aft.jsonc
@@ -1,5 +1,12 @@
 {
   "restrict_to_project_root": false,
   "search_index": true,
-  "semantic_search": true
+  "semantic_search": true,
+  "experimental": {
+    "bash": {
+      "rewrite": true,
+      "compress": true,
+      "background": true
+    }
+  }
 }

--- a/.config/opencode/magic-context.jsonc
+++ b/.config/opencode/magic-context.jsonc
@@ -30,9 +30,9 @@
   },
   "execute_threshold_percentage": {
     "default": 65,
-    "anthropic/claude-sonnet-4-6": 40,
-    "anthropic/claude-opus-4-6": 40,
-    "anthropic/claude-opus-4-7": 40
+    "anthropic/claude-sonnet-4-6": 55,
+    "anthropic/claude-opus-4-6": 55,
+    "anthropic/claude-opus-4-7": 55
   },
   "execute_threshold_tokens": {
     "github-copilot/claude-opus-4.7": 80000,

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
-    "@ex-machina/opencode-anthropic-auth@1.8.0",
+    "@cortexkit/opencode-anthropic-auth@1.0.0",
     "opencode-copilot-delegate@0.11.0",
     "@fro.bot/systematic@2.7.3",
     "@franlol/opencode-md-table-formatter@0.0.6",
-    "@cortexkit/opencode-magic-context@0.16.3",
-    "@cortexkit/aft-opencode@0.19.3",
+    "@cortexkit/opencode-magic-context@0.17.1",
+    "@cortexkit/aft-opencode@0.19.6",
     "oh-my-opencode-slim@1.0.6"
   ],
   "mcp": {

--- a/.config/opencode/tui.json
+++ b/.config/opencode/tui.json
@@ -3,8 +3,8 @@
   "theme": "catppuccin",
   "plugin": [
     "opencode-copilot-delegate@0.11.0",
-    "@cortexkit/opencode-magic-context@0.16.3",
-    "@cortexkit/aft-opencode@0.19.3",
+    "@cortexkit/opencode-magic-context@0.17.1",
+    "@cortexkit/aft-opencode@0.19.6",
     "oh-my-opencode-slim@1.0.6"
   ]
 }


### PR DESCRIPTION
- bump @cortexkit/magic-context from 0.16.2 to 0.17.1 in mise
- bump @cortexkit/aft from 0.19.3 to 0.19.6 in mise
- add @cortexkit/opencode-anthropic-auth@1.0.0 to mise tools
- switch auth plugin from @ex-machina/opencode-anthropic-auth@1.8.0 to @cortexkit/opencode-anthropic-auth@1.0.0
- bump @cortexkit/opencode-magic-context to 0.17.1 and @cortexkit/aft-opencode to 0.19.6 in opencode and tui
- enable AFT experimental bash rewrite/compress/background options
- raise Anthropic execute-threshold percentages from 40 to 55 in magic-context