### PR TITLE
chore(opencode): bump aft to v0.20.0 and tune models

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -33,7 +33,7 @@ ast-grep = "0.42.1"
 "npm:skills" = "1.5.3"
 "npm:ocx" = "2.0.9"
 "npm:@cortexkit/magic-context" = "0.17.2"
-"npm:@cortexkit/aft" = "0.19.6"
+"npm:@cortexkit/aft" = "0.20.0"
 "npm:@cortexkit/opencode-anthropic-auth" = "1.0.0"
 "npm:@marcusrbrown/infra" = "latest"
 

--- a/.config/opencode/magic-context.jsonc
+++ b/.config/opencode/magic-context.jsonc
@@ -1,13 +1,14 @@
 {
   "$schema": "https://raw.githubusercontent.com/cortexkit/magic-context/master/assets/magic-context.schema.json",
   "historian": {
-    "model": "openai/gpt-5.4",
+    "model": "openai/gpt-5.4-fast",
     "fallback_models": ["anthropic/claude-sonnet-4-6", "github-copilot/claude-sonnet-4.6"]
   },
   "dreamer": {
     "enabled": true,
     "model": "anthropic/claude-sonnet-4-6",
     "fallback_models": ["github-copilot/claude-sonnet-4.6"],
+    "schedule": "00:00-08:00",
     "user_memories": {
       "enabled": true,
       "promotion_threshold": 3

--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -83,7 +83,7 @@
       }
     },
     "openai": {
-      "orchestrator": { "model": "openai/gpt-5.5-fast", "skills": ["*"], "mcps": ["*", "!context7"] },
+      "orchestrator": { "model": "openai/gpt-5.5", "skills": ["*"], "mcps": ["*", "!context7"] },
       "oracle": { "model": "openai/gpt-5.5-fast", "variant": "high", "skills": [], "mcps": [] },
       "council": { "model": "openai/gpt-5.5-fast" },
       "librarian": {

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -4,9 +4,8 @@
     "@cortexkit/opencode-anthropic-auth@1.0.0",
     "opencode-copilot-delegate@0.11.0",
     "@fro.bot/systematic@2.7.3",
-    "@franlol/opencode-md-table-formatter@0.0.6",
     "@cortexkit/opencode-magic-context@0.17.2",
-    "@cortexkit/aft-opencode@0.19.6",
+    "@cortexkit/aft-opencode@0.20.0",
     "oh-my-opencode-slim@1.0.7"
   ],
   "mcp": {

--- a/.config/opencode/tui.json
+++ b/.config/opencode/tui.json
@@ -4,7 +4,7 @@
   "plugin": [
     "opencode-copilot-delegate@0.11.0",
     "@cortexkit/opencode-magic-context@0.17.2",
-    "@cortexkit/aft-opencode@0.19.6",
+    "@cortexkit/aft-opencode@0.20.0",
     "oh-my-opencode-slim@1.0.7"
   ]
 }


### PR DESCRIPTION
- bump @cortexkit/aft from 0.19.6 to 0.20.0 in mise, opencode, and tui
- switch historian model from openai/gpt-5.4 to openai/gpt-5.4-fast
- add dreamer schedule window (00:00-08:00)
- switch openai preset orchestrator from gpt-5.5-fast to gpt-5.5
- remove @franlol/opencode-md-table-formatter from opencode plugin list