### PR TITLE
chore(opencode): retune agent models and presets

### DIFF
--- a/.config/opencode/magic-context.jsonc
+++ b/.config/opencode/magic-context.jsonc
@@ -1,13 +1,25 @@
 {
   "$schema": "https://raw.githubusercontent.com/cortexkit/magic-context/master/assets/magic-context.schema.json",
   "historian": {
-    "model": "openai/gpt-5.4-fast",
-    "fallback_models": ["anthropic/claude-sonnet-4-6", "github-copilot/claude-sonnet-4.6"]
+    "model": "openai/gpt-5.4-mini",
+    "fallback_models": ["anthropic/claude-sonnet-4-6", "github-copilot/claude-sonnet-4.6"],
+    "temperature": 0.1,
+    "variant": "medium",
+    "tools": {
+      "bash": false,
+      "write": false,
+      "edit": false
+    },
+    "permission": {
+      "bash": "deny",
+      "webfetch": "deny",
+      "edit": "deny"
+    }
   },
   "dreamer": {
     "enabled": true,
-    "model": "anthropic/claude-sonnet-4-6",
-    "fallback_models": ["github-copilot/claude-sonnet-4.6"],
+    "model": "openai/gpt-5.4-mini",
+    "fallback_models": ["anthropic/claude-sonnet-4-6", "github-copilot/claude-sonnet-4.6"],
     "schedule": "00:00-08:00",
     "user_memories": {
       "enabled": true,
@@ -21,7 +33,11 @@
   },
   "sidekick": {
     "enabled": true,
-    "model": "openai/gpt-5.4-mini-fast"
+    "model": "openai/gpt-5.4-mini",
+    "fallback_models": ["anthropic/claude-haiku-4-5"],
+    "temperature": 0.1,
+    "variant": "low",
+    "timeout_ms": 30000
   },
   "cache_ttl": {
     "default": "5m",
@@ -33,7 +49,10 @@
     "default": 65,
     "anthropic/claude-sonnet-4-6": 55,
     "anthropic/claude-opus-4-6": 55,
-    "anthropic/claude-opus-4-7": 55
+    "anthropic/claude-opus-4-7": 55,
+    "openai/gpt-5.5": 50,
+    "openai/gpt-5.4": 60,
+    "openai/gpt-5.4-mini": 65
   },
   "execute_threshold_tokens": {
     "github-copilot/claude-opus-4.7": 80000,
@@ -52,7 +71,7 @@
     },
     "temporal_awareness": true,
     "caveman_text_compression": {
-      "enabled": false
+      "enabled": true
     }
   },
   "history_budget_percentage": 0.15,
@@ -62,6 +81,7 @@
   },
   "compaction_markers": true,
   "auto_drop_tool_age": 30,
+  "ctx_reduce_enabled": false,
   "system_prompt_injection": {
     "enabled": true,
     "skip_signatures": ["You are the Council agent — a multi-LLM"]

--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/oh-my-opencode-slim@1.0.6/oh-my-opencode-slim.schema.json",
-  "preset": "mixed",
+  "preset": "openai",
   "presets": {
     "copilot": {
       "orchestrator": {
@@ -92,7 +92,7 @@
         "skills": [],
         "mcps": ["websearch", "context7", "grep_app", "tavily"]
       },
-      "explorer": { "model": "openai/gpt-5.3-codex-spark", "variant": "low", "skills": [], "mcps": [] },
+      "explorer": { "model": "github-copilot/gpt-5.4-mini", "variant": "low", "skills": [], "mcps": [] },
       "designer": { "model": "github-copilot/gemini-3.1-pro-preview", "skills": ["agent-browser"], "mcps": [] },
       "fixer": { "model": "opencode-go/deepseek-v4-flash", "variant": "high", "skills": [], "mcps": [] }
     },


### PR DESCRIPTION
- switch the magic-context historian, dreamer, and sidekick roles to openai/gpt-5.4-mini
- tighten historian tool access and permissions, and add sidekick timeout/fallback settings
- add model-specific execute thresholds for openai/gpt-5.5, openai/gpt-5.4, and openai/gpt-5.4-mini
- enable caveman text compression and disable ctx-reduce
- switch oh-my-opencode-slim to the openai preset and update the explorer model