### PR TITLE
chore(opencode): add systematic config and bump systematic plugin

### DIFF
--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/oh-my-opencode-slim@1.0.6/oh-my-opencode-slim.schema.json",
-  "preset": "openai",
+  "preset": "mixed",
   "presets": {
     "copilot": {
       "orchestrator": {
@@ -87,7 +87,7 @@
       "oracle": { "model": "openai/gpt-5.5-fast", "variant": "high", "skills": [], "mcps": [] },
       "council": { "model": "openai/gpt-5.5-fast" },
       "librarian": {
-        "model": "openai/gpt-5.3-codex-spark",
+        "model": "openai/gpt-5.3-codex",
         "variant": "low",
         "skills": [],
         "mcps": ["websearch", "context7", "grep_app", "tavily"]

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -3,7 +3,7 @@
   "plugin": [
     "@cortexkit/opencode-anthropic-auth@1.0.0",
     "opencode-copilot-delegate@0.11.0",
-    "@fro.bot/systematic@2.10.0",
+    "@fro.bot/systematic@2.11.0",
     "@cortexkit/opencode-magic-context@0.17.2",
     "@cortexkit/aft-opencode@0.20.0",
     "oh-my-opencode-slim@1.0.7"

--- a/.config/opencode/systematic.json
+++ b/.config/opencode/systematic.json
@@ -1,0 +1,25 @@
+{
+  "categories": {
+    "design": {
+      "model": "github-copilot/gemini-3.1-pro-preview"
+    },
+    "docs": {
+      "model": "github-copilot/gemini-3.1-pro-preview"
+    },
+    "document-review": {
+      "model": "openai/gpt-5.4-mini"
+    },
+    "research": {
+      "model": "openai/gpt-5.4-mini"
+    },
+    "review": {
+      "model": "github-copilot/claude-sonnet-4.6"
+    }
+  },
+  "agents": {
+    "systematic-implementer": {
+      "model": "opencode-go/deepseek-v4-flash",
+      "variant": "high"
+    }
+  }
+}


### PR DESCRIPTION
- add .config/opencode/systematic.json with per-category and per-agent model overrides
  - design and docs: github-copilot/gemini-3.1-pro-preview
  - document-review and research: openai/gpt-5.4-mini
  - review: github-copilot/claude-sonnet-4.6
  - systematic-implementer agent: opencode-go/deepseek-v4-flash (high variant)
- bump @fro.bot/systematic from 2.10.0 to 2.11.0
- switch oh-my-opencode-slim preset back to mixed
- downgrade openai librarian model from gpt-5.3-codex-spark to gpt-5.3-codex