### PR TITLE
chore(pnpm): export PNPM_HOME after configuration

### DIFF
--- a/.config/bash/exports
+++ b/.config/bash/exports
@@ -184,7 +184,6 @@ if command_exists pnpm; then
             PNPM_HOME="$XDG_DATA_HOME"/pnpm
         fi
 
-        export PNPM_HOME
         prepend_to_path "$PNPM_HOME"/bin
 
         # See https://pnpm.io/npmrc
@@ -198,6 +197,8 @@ if command_exists pnpm; then
     if [ -z "$PNPM_HOME" ] || [ ! -d "$PNPM_HOME" ]; then
         configure_pnpm_dirs
     fi
+
+    export PNPM_HOME
 
     unset -f configure_pnpm_dirs
 fi


### PR DESCRIPTION
- Moved the export of PNPM_HOME to ensure it is set after configuration.
- This change improves the clarity of the script's flow.