### PR TITLE
chore(opencode): add anthropic auth config

### DIFF
--- a/.config/opencode/anthropic-auth.json
+++ b/.config/opencode/anthropic-auth.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "main": {
+    "type": "opencode",
+    "provider": "anthropic"
+  },
+  "accounts": [],
+  "claudeCache": {
+    "enabled": true,
+    "mode": "hybrid"
+  }
+}

--- a/.config/opencode/systematic.json
+++ b/.config/opencode/systematic.json
@@ -19,7 +19,7 @@
   },
   "agents": {
     "systematic-implementer": {
-      "model": "anthropic/claude-sonnet-4-6"
+      "model": "github-copilot/claude-sonnet-4.6"
     }
   }
 }


### PR DESCRIPTION
- add .config/opencode/anthropic-auth.json with opencode anthropic provider settings
- enable claude cache in hybrid mode in the new auth config
- update systematic implementer model id to github-copilot/claude-sonnet-4.6