### PR TITLE
chore(opencode): bump systematic plugin and jsonc config

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -3,7 +3,7 @@
   "plugin": [
     "@cortexkit/opencode-anthropic-auth@1.0.0",
     "opencode-copilot-delegate@0.12.0",
-    "@fro.bot/systematic@2.14.0",
+    "@fro.bot/systematic@2.14.1",
     "@cortexkit/opencode-magic-context@0.18.0",
     "@cortexkit/aft-opencode@0.21.0",
     "oh-my-opencode-slim@1.1.0"

--- a/.config/opencode/systematic.jsonc
+++ b/.config/opencode/systematic.jsonc
@@ -8,10 +8,12 @@
       "model": "github-copilot/gemini-3.1-pro-preview"
     },
     "document-review": {
-      "model": "openai/gpt-5.4-mini"
+      "model": "openai/gpt-5.4-mini",
+      "variant": "low"
     },
     "research": {
-      "model": "openai/gpt-5.4-mini"
+      "model": "openai/gpt-5.4-mini",
+      "variant": "low"
     },
     "review": {
       "model": "openai/gpt-5.5-fast"


### PR DESCRIPTION
- bump @fro.bot/systematic from 2.14.0 to 2.14.1 in opencode plugin list
- rename systematic config from .json to .jsonc
- set low variant for document-review and research agent models