### PR TITLE
docs(discord): reconcile plan progress + document declared role/perm policy

### DIFF
--- a/.dotfiles/docs/plans/2026-05-18-001-feat-discord-server-revival-plan.md
+++ b/.dotfiles/docs/plans/2026-05-18-001-feat-discord-server-revival-plan.md
@@ -178,7 +178,7 @@ Key flows:
 
 ## Implementation Units
 
-- [ ] **Unit 1: Configure admin-agent MCP server (SaseQ/discord-mcp pinned)**
+- [x] **Unit 1: Configure admin-agent MCP server (SaseQ/discord-mcp pinned)**
 
 **Goal:** Make the Discord MCP server available in OpenCode sessions for one-shot server-admin tasks. Pin to a specific commit-SHA. Document fallback.
 
@@ -217,7 +217,7 @@ Key flows:
 
 ---
 
-- [ ] **Unit 2: Run the Phase 0 audit (read-only) + archive the 3 original channels**
+- [x] **Unit 2: Run the Phase 0 audit (read-only) + archive the 3 original channels**
 
 **Goal:** Produce the inventory report + offline archive that gates the restructure.
 
@@ -253,7 +253,7 @@ Key flows:
 
 ---
 
-- [ ] **Unit 3: Enable Community Mode + design + create new project-organized channel layout**
+- [x] **Unit 3: Enable Community Mode + design + create new project-organized channel layout**
 
 **Goal:** Restructure channels into the project-organized layout, per audit recommendations.
 
@@ -292,7 +292,7 @@ Key flows:
 
 ---
 
-- [ ] **Unit 4: Create per-project roles + apply channel permission overrides**
+- [x] **Unit 4: Create per-project roles + apply channel permission overrides**
 
 **Goal:** Implement R7's role hierarchy. Per-project access via channel overrides becomes the primary gate (R16).
 
@@ -388,7 +388,7 @@ Key flows:
 
 ---
 
-- [ ] **Unit 7: Draft + publish AI disclosure document (pinned)**
+- [x] **Unit 7: Draft + publish AI disclosure document (pinned)**
 
 **Goal:** R13 + R14. Disclosure-before-intent.
 

--- a/.dotfiles/docs/runbooks/discord-admin-agent.md
+++ b/.dotfiles/docs/runbooks/discord-admin-agent.md
@@ -130,7 +130,7 @@ The dotfiles' `.gitignore` allowlist + `~/.config/git/ignore` global-credential-
 
 ---
 
-## Capability surface (50 tools)
+## Capability surface (65 tools)
 
 SaseQ/discord-mcp v1.0.0 exposes these tool categories. Read-only-safe tools are marked ✅; write-capable tools are marked ⚠️.
 
@@ -165,6 +165,38 @@ The MCP server does not enforce typed confirmation independent of the OpenCode s
 When in doubt, do the dry-run version first. The agent can `list_channels` before `delete_channel`, `list_roles` before `delete_role`, etc.
 
 ---
+
+## Role + permission policy (declared)
+
+This section is the **declared policy** that the permission-drift detector (Unit 8) compares against the live Discord state. Every role or override mutation must update this section in the same PR; the drift detector reads this as its source of truth.
+
+### Roles
+
+| Role | Position | Members declared | Owner | Project status |
+| --- | --- | --- | --- | --- |
+| `@admin` | 9 | server owner only | server owner | active |
+| `Fro Bot` (managed) | 3 | applied automatically by Discord when the bot joins | server owner | active — admin-agent + future gateway-daemon paths |
+| `@<project>-collab` (e.g. `poly-collab`) | below `@admin`, above `@everyone` | every active collaborator on the named project | server owner (default) | active when the project is active; retired during drift cleanup when the project is archived |
+| `@<project>-viewer` (e.g. `poly-viewer`) | below the matching `-collab` role | optional; read-only outside collaborators | server owner (default) | tracks the matching `-collab` role's lifecycle |
+
+Historic collaboration roles inherited from the server's pre-revival state (positions 4-8 in this server) — 0 declared members; project status: retired. Removal deferred to drift cleanup.
+
+### Category overrides
+
+| Category | Override target | Effect |
+| --- | --- | --- |
+| `Server Info` | (none) | inherits `@everyone` defaults — public-readable |
+| `Cross-cutting` | (none) | inherits `@everyone` defaults — public-readable |
+| `Operations` | `@everyone` deny ViewChannel; `@Fro Bot` allow ViewChannel + ManageChannels + ManageRoles + ManageWebhooks + ReadMessageHistory | admin-only |
+| `<project>` | `@everyone` deny ViewChannel; `@<project>-collab` allow ViewChannel + SendMessages + ReadMessageHistory; `@<project>-viewer` allow ViewChannel + ReadMessageHistory and deny SendMessages; `@Fro Bot` allow ViewChannel + ManageChannels + ReadMessageHistory | per-project restricted |
+
+### Channel-level overrides
+
+Inherited from category overrides unless explicitly noted. As of the most recent restructure, no per-channel overrides exist above the category baseline.
+
+### Update protocol
+
+Every change to this table is paired with the matching Discord state mutation in the same PR. The drift detector halts and surfaces the delta when the live state diverges from this declared policy. If a mutation lands without updating this table, that's a process miss to catch in the next drift run.
 
 ## Token handoff (pointer to `marcusrbrown/infra`)
 


### PR DESCRIPTION
Two scoped doc changes after a long execution session covering Units 1, 2, 3, 4, and 7.

## Plan reconciliation

Five units are now done end-to-end. Checking the boxes in the plan so the progress reflects shipped reality:

- Unit 1 \u2014 admin-agent MCP wiring (merged earlier)
- Unit 2 \u2014 Phase 0 audit + offline archive
- Unit 3 \u2014 Community Mode + restructure (categories, channels, roles, overrides)
- Unit 4 \u2014 per-project roles + permission overrides (this PR is the verification artifact)
- Unit 7 \u2014 AI disclosure published in-server (merged earlier)

Remaining six units are unchanged.

## Declared role + permission policy (new runbook section)

Adds a `Role + permission policy (declared)` section to the admin-agent runbook. This is the source-of-truth table the future drift-detection unit (Unit 8) will diff against the live server state. Two sub-tables:

- **Roles** \u2014 declared members per role, owner, and project status (active / dormant / retired). Includes the historic roles inherited from the pre-revival server, marked retired.
- **Category overrides** \u2014 effect per category (`Server Info`, `Cross-cutting`, `Operations`, per-project).

An update protocol clause pairs every future role/override mutation with a table edit in the same PR.

## Bonus

Corrected a stale tool count in the runbook capability heading: 50 \u2192 65 (matches what `tools/list` returned during the live smoke test earlier this session).