### PR TITLE
docs(discord): verify Unit 10 #fro-bot webhook continuity through restructure

### DIFF
--- a/.dotfiles/docs/plans/2026-05-18-001-feat-discord-server-revival-plan.md
+++ b/.dotfiles/docs/plans/2026-05-18-001-feat-discord-server-revival-plan.md
@@ -498,7 +498,7 @@ Key flows:
 
 ---
 
-- [ ] **Unit 10: Migrate `#fro-bot` channel under the new layout (preserve webhook continuity)**
+- [x] **Unit 10: Migrate `#fro-bot` channel under the new layout (preserve webhook continuity)**
 
 **Goal:** R4. The `#fro-bot` GitHub Actions integration must keep working through the restructure.
 

--- a/.dotfiles/docs/runbooks/discord-admin-agent.md
+++ b/.dotfiles/docs/runbooks/discord-admin-agent.md
@@ -194,6 +194,10 @@ Historic collaboration roles inherited from the server's pre-revival state (posi
 
 Inherited from category overrides unless explicitly noted. As of the most recent restructure, no per-channel overrides exist above the category baseline.
 
+### `#fro-bot` placement
+
+`#fro-bot` is the GitHub Actions integration channel that receives webhook posts from `fro-bot/agent`. It lives under the `Cross-cutting` category (public-readable, inherits `@everyone` defaults), not `Operations`. This is intentional: the channel is an activity feed any collaborator should be able to read, not an admin-only surface. The Discord webhook bound to channel id `1496350231158063288` survives category moves (webhooks key on channel id, not name or parent), and was verified post-restructure by observing two webhook posts arriving in the channel after the move.
+
 ### Update protocol
 
 Every change to this table is paired with the matching Discord state mutation in the same PR. The drift detector halts and surfaces the delta when the live state diverges from this declared policy. If a mutation lands without updating this table, that's a process miss to catch in the next drift run.


### PR DESCRIPTION
Tiny doc-only PR after live verification of Unit 10 (preserve the `#fro-bot` GitHub Actions integration through the channel restructure done in Unit 3).

## Verification

Two webhook posts arrived in the channel after the Unit 3 category move completed (08:57:04Z and 08:59:09Z on 2026-05-18, both from the same webhook id, both with embeds). Channel id is unchanged across the move; Discord webhooks key on channel id, not name or parent, so the existing GitHub Actions config in `fro-bot/agent` needed no updates. R4 is satisfied.

## Changes

1. **Plan checkbox** for Unit 10 ticked.
2. **Runbook** gains a brief `#fro-bot placement` paragraph in the policy section. The channel ended up in the public-readable `Cross-cutting` category (not `Operations` as the earlier Unit 3 design discussion floated) because it is a public activity feed, not an admin-only surface. The paragraph records the rationale + the live channel id so future drift checks have explicit grounding.

No code, no API mutations, no scope creep.