### PR TITLE
docs(discord): document AutoMod policy + verification approach

### DIFF
--- a/.dotfiles/docs/plans/2026-05-18-001-feat-discord-server-revival-plan.md
+++ b/.dotfiles/docs/plans/2026-05-18-001-feat-discord-server-revival-plan.md
@@ -455,6 +455,8 @@ Key flows:
 - Runbook is committed.
 - A test deviation is detected by the runbook procedure.
 
+**Deferred from Unit 5:** AutoMod end-to-end trigger verification was deferred from Unit 5 because Discord exempts server owners from AutoMod by design (see the AutoMod policy section of the admin-agent runbook). The drift-check runbook must include a one-time check that runs when the first non-Admin user joins the server: post a triggering message from that account, confirm the alert lands in `#mod-logs`, and record the verification date in the runbook. Without this hook, the deferred trigger test risks silently dropping.
+
 ---
 
 - [ ] **Unit 9: Gateway intent-posture flip (in `fro-bot/agent`) — minimal handoff boundary only**

--- a/.dotfiles/docs/plans/2026-05-18-001-feat-discord-server-revival-plan.md
+++ b/.dotfiles/docs/plans/2026-05-18-001-feat-discord-server-revival-plan.md
@@ -328,7 +328,7 @@ Key flows:
 
 ---
 
-- [ ] **Unit 5: Configure AutoMod baseline + alert routing**
+- [x] **Unit 5: Configure AutoMod baseline + alert routing**
 
 **Goal:** Enable Discord-native moderation. No third-party bot.
 

--- a/.dotfiles/docs/runbooks/discord-admin-agent.md
+++ b/.dotfiles/docs/runbooks/discord-admin-agent.md
@@ -202,6 +202,46 @@ Inherited from category overrides unless explicitly noted. As of the most recent
 
 Every change to this table is paired with the matching Discord state mutation in the same PR. The drift detector halts and surfaces the delta when the live state diverges from this declared policy. If a mutation lands without updating this table, that's a process miss to catch in the next drift run.
 
+---
+
+## AutoMod policy (declared)
+
+This section is the **declared AutoMod policy** that the drift detector (Unit 8) compares against the live Discord rule set. Every rule mutation must update this section in the same PR.
+
+### Active rules
+
+| Rule name | Trigger type | Configuration | Actions | Exempt roles | Exempt channels |
+| --- | --- | --- | --- | --- | --- |
+| `Block Mention Spam` | `MENTION_SPAM` (5) | `mention_total_limit=7`, `mention_raid_protection_enabled=true` | BLOCK with custom message `"Message blocked by Fronomenal AutoMod (mention spam)."`; SEND_ALERT to `#mod-logs` | `@admin` | `#mod-logs` |
+| `Commonly Flagged Words` | `KEYWORD_PRESET` (4) | `presets=[1,2,3]` (PROFANITY, SEXUAL_CONTENT, SLURS), `allow_list=[]` | BLOCK with custom message `"Message blocked by Fronomenal AutoMod (commonly-flagged words)."`; SEND_ALERT to `#mod-logs` | `@admin` | `#mod-logs` |
+
+The custom-keyword rule referenced in the Phase 2 plan is intentionally not yet created. It will be added when an actual keyword pattern needs to be blocked; the drift detector treats its absence as expected until then.
+
+### Action and trigger reference
+
+- BLOCK_MESSAGE (`type=1`): deletes the offending message before it's posted, optionally surfaces a custom message to the author (max 150 chars).
+- SEND_ALERT_MESSAGE (`type=2`): posts a `[message blocked]` event embed to the configured alert channel; metadata includes the original author, channel, and trigger phrase preview.
+- KEYWORD_PRESET (`trigger_type=4`) presets: `1`=PROFANITY, `2`=SEXUAL_CONTENT, `3`=SLURS.
+- MENTION_SPAM (`trigger_type=5`) counts **unique** role and user mentions per message (`@everyone` and `@here` count as one each).
+
+### Exemptions
+
+Server owners, members with the `Administrator` permission, members with the `Manage Server` permission, bots, and webhooks are **always** exempt from AutoMod evaluation. This is a Discord platform behavior, not a configuration choice. `exempt_roles` in this policy is additive on top of that platform baseline; in this server `@admin` is in `exempt_roles` to make the policy explicit when audited even though the holder is already implicitly exempt as the server owner.
+
+### Why alert-channel routing requires the Discord UI
+
+When creating an AutoMod rule with a `SEND_ALERT_MESSAGE` action via the API, Discord requires the requesting bot to have `ViewChannel` + `SendMessages` permissions on the target alert channel as **channel-level explicit overrides**. Category-level inheritance does not satisfy this check; the API returns `400 INVALID_AUTO_MODERATION_CHANNEL_FLAG_ACTION_ACCESS`. Since `#mod-logs` lives in the admin-only `Operations` category and `@Fro Bot`'s allow set is granted at the category level, alert routing must be configured via Server Settings → AutoMod → click into the rule → enable "Send Alert" → choose `#mod-logs`. The server owner's UI session is not subject to this constraint.
+
+### Verification approach
+
+The plan's literal acceptance criterion ("Marcus posts a triggering message; alert lands in `#mod-logs`") cannot be exercised by the server owner because Discord exempts owners from AutoMod by design. Unit 5 is verified instead by **configuration assertion**: each live rule's `trigger_type`, `trigger_metadata`, `actions`, `exempt_roles`, and `exempt_channels` are compared against the declared policy table above. End-to-end trigger verification is deferred to whenever a non-Admin user first joins the server (R7 onboarding path); the drift detector flags it as a one-time check during that onboarding.
+
+### Update protocol
+
+Every change to this table is paired with the matching Discord rule mutation in the same PR. The drift detector halts and surfaces the delta when the live rules diverge from this declared policy.
+
+---
+
 ## Token handoff (pointer to `marcusrbrown/infra`)
 
 The **canonical token-lifecycle runbook** lives in [`marcusrbrown/infra`](https://github.com/marcusrbrown/infra), not here. That repo owns:

--- a/.dotfiles/docs/runbooks/discord-admin-agent.md
+++ b/.dotfiles/docs/runbooks/discord-admin-agent.md
@@ -236,9 +236,7 @@ When creating an AutoMod rule with a `SEND_ALERT_MESSAGE` action via the API, Di
 
 The plan's literal acceptance criterion ("Marcus posts a triggering message; alert lands in `#mod-logs`") cannot be exercised by the server owner because Discord exempts owners from AutoMod by design. Unit 5 is verified instead by **configuration assertion**: each live rule's `trigger_type`, `trigger_metadata`, `actions`, `exempt_roles`, and `exempt_channels` are compared against the declared policy table above. End-to-end trigger verification is deferred to whenever a non-Admin user first joins the server (R7 onboarding path); the drift detector flags it as a one-time check during that onboarding.
 
-### Update protocol
-
-Every change to this table is paired with the matching Discord rule mutation in the same PR. The drift detector halts and surfaces the delta when the live rules diverge from this declared policy.
+Updates to this section follow the same protocol as the channel-permission policy above: every rule mutation is paired with the matching update here in the same PR. See ["Update protocol" under "Role + permission policy"](#update-protocol) for the canonical wording.
 
 ---
 


### PR DESCRIPTION
Adds the **AutoMod policy** section to the admin-agent runbook so the live AutoMod state has a single declared source of truth (Unit 8's drift detector reads this).

## What lands

- **Active rules table** — Block Mention Spam (threshold 7, raid protection on, BLOCK + SEND_ALERT to mod-logs, admin exempt) and Commonly Flagged Words (KEYWORD_PRESET with Profanity + Sexual Content + Slurs, BLOCK + SEND_ALERT to mod-logs, admin exempt).
- **Action and trigger reference** — exact semantics of BLOCK_MESSAGE, SEND_ALERT_MESSAGE, KEYWORD_PRESET, MENTION_SPAM as documented by Discord.
- **Exemptions** — documents the platform behavior that server owners, Administrator holders, Manage-Server holders, bots, and webhooks are always exempt from AutoMod, regardless of `exempt_roles`.
- **Why alert routing happens via UI** — the bot cannot create rules with SEND_ALERT_MESSAGE actions when only category-level inheritance grants View + Send on the alert channel; Discord returns `400 INVALID_AUTO_MODERATION_CHANNEL_FLAG_ACTION_ACCESS`. Documents the UI workaround the server owner used.
- **Verification approach** — the plan's literal test-message acceptance criterion cannot fire from the owner account by Discord design. Unit 5 is verified by configuration assertion against the declared table; end-to-end trigger verification is deferred to the first non-Admin user join (R7 onboarding).

## Plan checkbox

Unit 5 ticks.

## Implementation notes

API mutations applied during execution:
- PATCH on the existing mention-spam rule (originally Discord-managed, reclaimed by Marcus via UI toggle, then customized via API): tightened `mention_total_limit` from 20 to 7, added BLOCK action with custom message, exempted @admin.
- POST a new `Commonly Flagged Words` rule with KEYWORD_PRESET trigger (presets [1,2,3]), BLOCK action with custom message, @admin exempt.
- SEND_ALERT_MESSAGE routing to mod-logs added via the Discord UI by the server owner (bot cannot do this via API given the channel-level perm requirement).