### PR TITLE
docs(discord): close out Units 9 + 11 with cross-repo handoffs

### DIFF
--- a/.dotfiles/docs/plans/2026-05-18-001-feat-discord-server-revival-plan.md
+++ b/.dotfiles/docs/plans/2026-05-18-001-feat-discord-server-revival-plan.md
@@ -459,7 +459,7 @@ Key flows:
 
 ---
 
-- [ ] **Unit 9: Gateway intent-posture flip (in `fro-bot/agent`) — minimal handoff boundary only**
+- [x] **Unit 9: Gateway intent-posture flip (in `fro-bot/agent`) — minimal handoff boundary only** _(cross-repo handoff: tracked in [fro-bot/agent#646](https://github.com/fro-bot/agent/issues/646); ticked here because the dotfiles-side acknowledgment is complete — the gateway implementation happens in its own dedicated session in `fro-bot/agent`)_
 
 **Goal:** R22's intent-posture flip ONLY. The gateway's `DEFAULT_INTENTS` becomes opt-in. This is a small PR in `fro-bot/agent`. R20/R21's full gateway-side enforcement (channel-policy declaration + refusal patterns + rate limit) is **scope-split to a follow-up plan in `fro-bot/agent`** (see "Deferred to Separate Tasks"); a minimal contract is set here so that disclosure (Unit 7) and `infra` deployment have a stable handoff.
 
@@ -528,7 +528,7 @@ Key flows:
 
 ---
 
-- [ ] **Unit 11: Minimal token-handoff note (pointer to `infra`)**
+- [x] **Unit 11: Minimal token-handoff note (pointer to `infra`)**
 
 **Goal:** R18 is implemented in `marcusrbrown/infra`, not here. This dotfiles unit produces a thin pointer note so admin-agent sessions know where the canonical token-lifecycle runbook lives.
 

--- a/.dotfiles/docs/runbooks/discord-admin-agent.md
+++ b/.dotfiles/docs/runbooks/discord-admin-agent.md
@@ -286,16 +286,33 @@ Updates to this section follow the same protocol as the channel-permission polic
 ## Token handoff (pointer to `marcusrbrown/infra`)
 
 The **canonical token-lifecycle runbook** lives in [`marcusrbrown/infra`](https://github.com/marcusrbrown/infra), not here. That repo owns:
+
 - Host-side token-file storage path + ownership + filesystem permissions
 - Rotation procedure (Developer Portal regeneration → secret update → daemon reload)
 - Emergency revocation path
 - Handling of in-flight Discord interactions during rotation
 
-When `marcusrbrown/infra` lands the runbook, update this section with the URL:
+### Where to find the canonical doc
 
-> 📌 **TODO:** Update with the canonical token-lifecycle runbook URL once `marcusrbrown/infra` ships it. Reference: plan Unit 11.
+| State | Read from |
+| --- | --- |
+| Today (no standalone runbook yet) | [`apps/gateway/AGENTS.md`](https://github.com/marcusrbrown/infra/blob/main/apps/gateway/AGENTS.md) covers the deployment-time token setup as part of the gateway stack documentation. |
+| Future (standalone runbook lands) | The canonical token-lifecycle runbook in `marcusrbrown/infra` will be linked here. |
 
-The dotfiles-side admin-agent path uses the bot token only for read-mostly audit work; the production deploy (gateway daemon) consumes the same token via `infra`'s deploy pipeline. Same token, different consumers.
+> 📌 **TODO** (plan Unit 11): Once a dedicated `docs/runbooks/discord-token-lifecycle.md` (or equivalent) exists in `marcusrbrown/infra`, replace this paragraph with the direct URL. The trigger is the next PR in `infra` that creates a standalone token-lifecycle runbook; the marker exists so a future review or audit of this section catches the missing link.
+
+### Handoff contract
+
+The dotfiles-side admin-agent path and the production gateway daemon consume the **same Discord bot token** through different channels:
+
+| Consumer | Channel | Lifecycle |
+| --- | --- | --- |
+| Admin-agent (this runbook) | `DISCORD_TOKEN` env var, sourced from macOS Keychain on this machine | Ephemeral per OpenCode session |
+| Gateway daemon (`marcusrbrown/infra`) | `${NAME}_FILE` precedence then `process.env[name]` pattern (see [`packages/gateway/src/config.ts:20-101`](https://github.com/fro-bot/agent/blob/main/packages/gateway/src/config.ts) in the upstream pinned at `apps/gateway/upstream.json`) | Long-running, file-backed, rotated via `infra` deploy pipeline |
+
+Both consumers point at the same Discord application — the token bound to bot user `Fro Bot#4027` (application id [`1505811646956830781`](https://discord.com/developers/applications/1505811646956830781)). Rotating the token in the Developer Portal invalidates BOTH consumers simultaneously; the rotation procedure in `infra` must therefore coordinate or accept brief admin-agent unavailability during the rotation window.
+
+The dotfiles-side admin-agent path uses the bot token only for read-mostly audit work; the production deploy (gateway daemon) consumes the same token via `infra`'s deploy pipeline. Same token, different consumers, single source of truth (the Discord Developer Portal).
 
 ---
 


### PR DESCRIPTION
Closes the last two units of the Discord server-revival plan with cross-repo handoffs and a sharpened token-handoff section.

## Unit 9 — gateway intent-posture flip (cross-repo)

Unit 9 is a `fro-bot/agent` repo PR, not a dotfiles change. The plan author wrote it as an explicit cross-repo line item; this PR closes the dotfiles-side acknowledgment by ticking the checkbox and pointing at the durable trigger:

- Tracking issue: [fro-bot/agent#646](https://github.com/fro-bot/agent/issues/646) — opened with the full scope, files, test scenarios, and acceptance criteria so a future dedicated session in the gateway repo can pick it up without re-deriving context.

## Unit 11 — token-handoff pointer

The admin-agent runbook already had a 'Token handoff (pointer to `marcusrbrown/infra`)' section from Unit 1. This PR sharpens it:

- **Where to find the canonical doc** table — points at the closest current source ([`apps/gateway/AGENTS.md`](https://github.com/marcusrbrown/infra/blob/main/apps/gateway/AGENTS.md) in `marcusrbrown/infra`) for today and reserves the spot for the future standalone runbook.

- **Handoff contract** table — documents the real consumer/channel/lifecycle split. The dotfiles-side admin-agent reads `DISCORD_TOKEN` from Keychain per session. The gateway daemon reads via the `${NAME}_FILE` precedence pattern from `infra`'s deploy pipeline. Same token, two consumers, single source of truth (Developer Portal).

- **TODO marker** is now actionable: the trigger is the next `infra` PR that creates a standalone token-lifecycle runbook. The marker stays so a future review catches the missing link.

## Plan status after this PR

All 11 units now ticked. Eight ship as dotfiles-side work (1, 2, 3, 4, 5, 6, 7, 8, 10) plus the two cross-repo handoffs (9 + 11).