### PR TITLE
chore(mise): drop abandoned packages lolcrab + remark-language-server

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -39,10 +39,7 @@ ast-grep = "0.42.2"
 
 # Language Servers
 "npm:pyright" = "1.1.409"
-"npm:remark-language-server" = "3.0.0"
 "npm:typescript-language-server" = "5.2.0"
-
-"github:mazznoer/lolcrab" = "0.4.1"
 
 [env]
 UV_SYSTEM_CERTS = "true"

--- a/.config/mise/tasks/print/done
+++ b/.config/mise/tasks/print/done
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#MISE description="Print an animated DONE message"
+#MISE description="Print a DONE message"
 #MISE hide=true
 #MISE silent=true
-echo DONE | figlet | lolcrab -a --speed 1 --duration 1 --gradient warm
+echo DONE | figlet


### PR DESCRIPTION
Both packages surfaced as abandoned in the Renovate Dependency Dashboard (#444). Removing eliminates a CI flake source and a dead dep.

## What lands

- `.config/mise/config.toml` — drop two entries:
  - `github:mazznoer/lolcrab 0.4.1` (last release 2025-04-25, 1+ year ago)
  - `npm:remark-language-server 3.0.0` (last release 2024-04-12, 2 years ago)

- `.config/mise/tasks/print/done` — simplify from `echo DONE | figlet | lolcrab -a --speed 1 --duration 1 --gradient warm` to `echo DONE | figlet`. Removes the only consumer of lolcrab.

## Why

**lolcrab** was the source of a Devcontainer CI flake during PR #1665: mise's GitHub artifact-attestation verification for `mazznoer/lolcrab@0.4.1` hit an unauthenticated GitHub API rate-limit 403 on the runner. The job recovered via `gh run rerun` but the dependency itself adds no functional value (it just colorized the figlet DONE banner). Removing it eliminates the flake source.

**remark-language-server** was installed for a markdown-LSP experiment that never wired into any editor config or skill. Grep confirms zero references outside the mise config entry itself.

## Risk

Low. The only behavior change is the DONE banner is no longer rainbow-colorized — `figlet` still produces the ASCII art, just in the default terminal color. Plain `echo DONE` would be even simpler but I kept figlet because the visual marker has value at end-of-chain output.

## Plan / dashboard impact

Renovate's dependency dashboard issue #444 will lose both abandoned-package entries on its next refresh.