### PR TITLE
chore(opencode): update plugin pins and cleanup tools

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -32,9 +32,6 @@ ast-grep = "0.42.3"
 "npm:agent-browser" = "0.27.0"
 "npm:skills" = "1.5.7"
 "npm:ocx" = "2.0.11"
-"npm:@cortexkit/magic-context" = "0.21.4"
-"npm:@cortexkit/aft" = "0.26.4"
-"npm:@cortexkit/opencode-anthropic-auth" = "1.1.3"
 "npm:@marcusrbrown/infra" = "latest"
 
 # Language Servers

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
-    "@cortexkit/opencode-anthropic-auth@1.1.3",
+    "@cortexkit/opencode-anthropic-auth@1.2.0",
     "oh-my-opencode-slim@1.1.1",
-    "@cortexkit/opencode-magic-context@0.21.4",
+    "@cortexkit/opencode-magic-context@0.21.6",
     "@cortexkit/aft-opencode@0.26.4",
     "opencode-copilot-delegate@0.12.0",
     "@fro.bot/systematic@2.20.0"

--- a/.config/opencode/tui.json
+++ b/.config/opencode/tui.json
@@ -3,7 +3,7 @@
   "theme": "catppuccin",
   "plugin": [
     "oh-my-opencode-slim@1.1.1",
-    "@cortexkit/opencode-magic-context@0.21.4",
+    "@cortexkit/opencode-magic-context@0.21.6",
     "@cortexkit/aft-opencode@0.26.4",
     "opencode-copilot-delegate@0.12.0"
   ]


### PR DESCRIPTION
- bump @cortexkit/opencode-anthropic-auth from 1.1.3 to 1.2.0
- bump @cortexkit/opencode-magic-context from 0.21.4 to 0.21.6 in opencode and tui configs
- remove cortexkit npm tool pins from mise config