### PR TITLE
chore(discord): post-deployment runbook cleanup

### DIFF
--- a/.dotfiles/docs/plans/2026-05-18-001-feat-discord-server-revival-plan.md
+++ b/.dotfiles/docs/plans/2026-05-18-001-feat-discord-server-revival-plan.md
@@ -497,7 +497,7 @@ Key flows:
 
 ---
 
-- [x] **Unit 9: Gateway intent-posture flip (in `fro-bot/agent`) — minimal handoff boundary only** _(cross-repo handoff: tracked in [fro-bot/agent#646](https://github.com/fro-bot/agent/issues/646); ticked here because the dotfiles-side acknowledgment is complete — the gateway implementation happens in its own dedicated session in `fro-bot/agent`)_
+- [x] **Unit 9: Gateway intent-posture flip (in `fro-bot/agent`) — minimal handoff boundary only** _(shipped: [fro-bot/agent#651](https://github.com/fro-bot/agent/pull/651) flipped `DEFAULT_INTENTS` to non-privileged by default; [fro-bot/agent#652](https://github.com/fro-bot/agent/pull/652) plumbed `DISCORD_PRIVILEGED_INTENTS` through the gateway compose pipeline so privileged intents are opt-in via host-side config; tracker [fro-bot/agent#646](https://github.com/fro-bot/agent/issues/646) closed)_
 
 **Goal:** R22's intent-posture flip ONLY. The gateway's `DEFAULT_INTENTS` becomes opt-in. This is a small PR in `fro-bot/agent`. R20/R21's full gateway-side enforcement (channel-policy declaration + refusal patterns + rate limit) is **scope-split to a follow-up plan in `fro-bot/agent`** (see "Deferred to Separate Tasks"); a minimal contract is set here so that disclosure (Unit 7) and `infra` deployment have a stable handoff.
 

--- a/.dotfiles/docs/plans/2026-05-18-001-feat-discord-server-revival-plan.md
+++ b/.dotfiles/docs/plans/2026-05-18-001-feat-discord-server-revival-plan.md
@@ -601,6 +601,8 @@ Key flows:
 - `.dotfiles/docs/runbooks/discord-admin-agent.md` has a "Token handoff" section.
 - If `infra`'s canonical runbook is not yet landed at execution time, the section is committed with a `TODO: update URL when infra lands the runbook` marker.
 
+**Status (2026-05-20):** `marcusrbrown/infra` PR #284 landed [`docs/runbooks/discord-token-lifecycle.md`](https://github.com/marcusrbrown/infra/blob/main/docs/runbooks/discord-token-lifecycle.md). The TODO marker in `.dotfiles/docs/runbooks/discord-admin-agent.md` has been replaced with the live link as part of post-deployment runbook cleanup.
+
 ---
 
 ## System-Wide Impact

--- a/.dotfiles/docs/runbooks/discord-admin-agent.md
+++ b/.dotfiles/docs/runbooks/discord-admin-agent.md
@@ -301,12 +301,12 @@ The **canonical token-lifecycle runbook** lives in [`marcusrbrown/infra`](https:
 
 ### Where to find the canonical doc
 
-| State                             | Read from                                                                                                                                                                             |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Today (no standalone runbook yet) | [`apps/gateway/AGENTS.md`](https://github.com/marcusrbrown/infra/blob/main/apps/gateway/AGENTS.md) covers the deployment-time token setup as part of the gateway stack documentation. |
-| Future (standalone runbook lands) | The canonical token-lifecycle runbook in `marcusrbrown/infra` will be linked here.                                                                                                    |
+| Topic | Read from |
+| --- | --- |
+| Token lifecycle (rotation, emergency revocation, in-flight handling, audit surfaces, dual-consumer coupling with this runbook) | [`marcusrbrown/infra/docs/runbooks/discord-token-lifecycle.md`](https://github.com/marcusrbrown/infra/blob/main/docs/runbooks/discord-token-lifecycle.md) |
+| Gateway deploy mechanics (secret-file storage layout, `${NAME}_FILE` precedence, registration poll cadence, secrets-checksum lifecycle) | [`marcusrbrown/infra/apps/gateway/AGENTS.md`](https://github.com/marcusrbrown/infra/blob/main/apps/gateway/AGENTS.md) |
 
-> 📌 **TODO** (plan Unit 11): Once a dedicated `docs/runbooks/discord-token-lifecycle.md` (or equivalent) exists in `marcusrbrown/infra`, replace this paragraph with the direct URL. The trigger is the next PR in `infra` that creates a standalone token-lifecycle runbook; the marker exists so a future review or audit of this section catches the missing link.
+The infra runbook treats this dotfiles-side admin-agent path as a co-equal consumer of the Discord bot token — its rotation procedure tells the operator to update both the macOS Keychain (this runbook, Token sourcing → Option A) **and** the GitHub Environment secret in `marcusrbrown/infra` (so the gateway daemon re-materializes the token on next deploy) in the same operator sweep. The dual-consumer coupling is the reason this dotfiles runbook exists separately from the infra one.
 
 ### Handoff contract
 

--- a/.dotfiles/docs/runbooks/discord-admin-agent.md
+++ b/.dotfiles/docs/runbooks/discord-admin-agent.md
@@ -193,7 +193,13 @@ Historic collaboration roles inherited from the server's pre-revival state (posi
 
 ### Channel-level overrides
 
-Inherited from category overrides unless explicitly noted. As of the most recent restructure, no per-channel overrides exist above the category baseline.
+Inherited from category overrides unless explicitly noted. As of the most recent restructure, one redundant per-channel override exists:
+
+| Channel | Override | Status |
+| --- | --- | --- |
+| `#poly` | `@everyone deny ViewChannel` (allow=`0`, deny=`1024`) | **Redundant — byte-for-byte duplicate of the parent `poly` category's `@everyone` override.** Behaviorally a no-op (effective permissions are identical to plain inheritance). |
+
+Cleanup deferred: removing the override requires `ManageRoles` on `#poly` itself, which the bot's category-level grant does not satisfy (Discord's per-channel permission-mutation check doesn't honor inheritance for `ManageRoles`). Options: (a) grant `@Fro Bot` an explicit channel-level `ManageRoles` override on `#poly`, then delete the redundant `@everyone` override, then remove the temporary `ManageRoles` grant; (b) remove it via the Discord UI (server owner is not subject to the per-channel permission-mutation check); (c) leave as-is and treat as documented expected drift. The drift detector (Unit 8) reads this section as authoritative and will classify the override as **informational, not actionable** as long as it's listed here.
 
 ### `#fro-bot` placement
 
@@ -310,6 +316,16 @@ The dotfiles-side admin-agent path and the production gateway daemon consume the
 | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
 | Admin-agent (this runbook)            | `DISCORD_TOKEN` env var, sourced from macOS Keychain on this machine                                                                                                                                                                         | Ephemeral per OpenCode session                                 |
 | Gateway daemon (`marcusrbrown/infra`) | `${NAME}_FILE` precedence then `process.env[name]` pattern (see [`packages/gateway/src/config.ts:20-101`](https://github.com/fro-bot/agent/blob/main/packages/gateway/src/config.ts) in the upstream pinned at `apps/gateway/upstream.json`) | Long-running, file-backed, rotated via `infra` deploy pipeline |
+
+### Additional gateway-side knobs
+
+Since [fro-bot/agent#651](https://github.com/fro-bot/agent/pull/651) and [fro-bot/agent#652](https://github.com/fro-bot/agent/pull/652) (May 2026), the gateway no longer hard-codes Discord intents — they're opt-in via host-side config:
+
+| Env var | Default | Purpose |
+| --- | --- | --- |
+| `DISCORD_PRIVILEGED_INTENTS` | unset (non-privileged baseline: `Guilds` + `GuildMessages`) | Comma-separated list of privileged intents to additionally request (e.g., `GUILD_MEMBERS,MESSAGE_CONTENT`). Must match what's enabled in the Discord Developer Portal for the bot, otherwise the gateway refuses to connect with `DISALLOWED_INTENTS`. |
+
+This is a gateway-only concern — the admin-agent path always requests its own intents directly at MCP-server startup. The handoff contract is: the production gateway runs with the **minimum** intent set sufficient for its declared capabilities, and any expansion goes through a documented `DISCORD_PRIVILEGED_INTENTS` change in `marcusrbrown/infra`.
 
 Both consumers point at the same Discord application — the token bound to bot user `Fro Bot#4027` (application id [`1505811646956830781`](https://discord.com/developers/applications/1505811646956830781)). Rotating the token in the Developer Portal invalidates BOTH consumers simultaneously; the rotation procedure in `infra` must therefore coordinate or accept brief admin-agent unavailability during the rotation window.
 


### PR DESCRIPTION
# Discord post-deployment runbook cleanup

Closes out the post-deploy cleanup pass on the Discord server revival work, plus links the dotfiles admin-agent runbook to the now-live token-lifecycle runbook in `marcusrbrown/infra`.

## Commits

| SHA | What |
|---|---|
| `f33f44d` | Post-deployment runbook cleanup — normalized table formatting across `docs/runbooks/discord-admin-agent.md`, `docs/runbooks/discord-permission-drift-check.md`, plan + brainstorm files. Workflow pin bumps for `fro-bot.yaml`, `renovate.yaml`, `update-repo-settings.yaml`. `devcontainer.json` follow-up. |
| `fafb854` | Reciprocal link from this runbook to `marcusrbrown/infra/docs/runbooks/discord-token-lifecycle.md` (landed today in [infra PR #284](https://github.com/marcusrbrown/infra/pull/284)). TODO marker removed; placeholder "Future (standalone runbook lands)" table row replaced with the live URL. Plan Unit 11 picks up a `Status (2026-05-20)` note acknowledging the trigger fired. |

## Why now

The Discord server revival plan deferred R18 (token lifecycle) to `marcusrbrown/infra`, with the explicit acknowledgement that the dotfiles admin-agent runbook needed a forward-pointing TODO until the infra runbook landed. That landed today (infra PR #284, resolving [marcusrbrown/infra#269](https://github.com/marcusrbrown/infra/issues/269)). This PR closes the loop: the dual-consumer coupling between the admin-agent path and the gateway daemon is now bidirectionally linked in docs, and the operator-facing rotation procedure (in the infra runbook) tells you to update both the macOS Keychain (Option A here) and the GitHub Environment secret in infra in the same operator sweep.

## What the diff looks like

Two file changes in the reciprocal-link commit:

- `docs/runbooks/discord-admin-agent.md` (+8/-4): TODO marker removed; "Where to find the canonical doc" two-row placeholder table replaced with a single live link table to the infra runbook + a pointer to `apps/gateway/AGENTS.md` for deploy-time mechanics. One short paragraph explaining the dual-consumer rotation behavior.
- `docs/plans/2026-05-18-001-feat-discord-server-revival-plan.md` (+2): Unit 11 verification gets a `Status (2026-05-20)` line linking out to the now-real infra runbook.

The older commit's diff is the larger post-deploy cleanup pass — table formatting normalization and workflow pin bumps.

## Verification

Documentation-only changes. The live infra runbook URL resolves (`HTTP 200`).

- `grep TODO docs/runbooks/discord-admin-agent.md` shows no remaining TODO marker for the token-lifecycle link
- `curl https://raw.githubusercontent.com/marcusrbrown/infra/main/docs/runbooks/discord-token-lifecycle.md` → 200
