### PR TITLE
feat(opencode): add local Ollama distillation (mise run distill)

### DIFF
--- a/.config/bash/exports
+++ b/.config/bash/exports
@@ -365,6 +365,10 @@ export OMO_DISABLE_POSTHOG=1
 
 export OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true
 
+# Ollama — short keep-alive so models unload after each on-demand run
+# (Default is 5m; on 16GB this holds a ~5GB model resident long after use.)
+export OLLAMA_KEEP_ALIVE=30s
+
 # ASDF
 
 if command_exists asdf; then

--- a/.config/mise/tasks/distill
+++ b/.config/mise/tasks/distill
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Run local Ollama distillation against recent OpenCode sessions; writes Markdown report to ~/.local/state/ollama-distill/reports/"
+#MISE dir="{{cwd}}"
+set -euo pipefail
+exec bun run "$HOME/.config/opencode/scripts/ollama-distill.ts" "$@"

--- a/.config/opencode/scripts/ollama-distill.test.ts
+++ b/.config/opencode/scripts/ollama-distill.test.ts
@@ -14,6 +14,9 @@ import {
   callOllama,
   writeReport,
   appendRunLog,
+  parseArgs,
+  checkOllamaReachable,
+  main,
   type ExtractStats,
   type RunRecord,
 } from "./ollama-distill.ts";
@@ -660,5 +663,359 @@ describe("appendRunLog", () => {
     expect(lines).toHaveLength(2);
     expect(JSON.parse(lines[1]).sessions_read).toBe(2);
     if (existsSync(logPath)) unlinkSync(logPath);
+  });
+});
+
+// ─── Unit 3 Tests ─────────────────────────────────────────────────────────────
+
+// ── Fixture helpers for main() integration tests ──────────────────────────────
+
+/** Create a file-based DB with valid schema + some sessions for main() tests. */
+function createFileDb(dbPath: string, sessions: Array<{ id: string; timeUpdated: number; text: string }>): void {
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE session (
+      id TEXT PRIMARY KEY,
+      project_id TEXT,
+      parent_id TEXT,
+      time_created INTEGER,
+      time_updated INTEGER
+    );
+    CREATE TABLE message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT,
+      time_created INTEGER,
+      data TEXT
+    );
+    CREATE TABLE part (
+      id TEXT PRIMARY KEY,
+      message_id TEXT,
+      session_id TEXT,
+      time_created INTEGER,
+      data TEXT
+    );
+  `);
+  for (const s of sessions) {
+    db.run(
+      "INSERT INTO session (id, project_id, parent_id, time_created, time_updated) VALUES (?, NULL, NULL, ?, ?)",
+      [s.id, s.timeUpdated, s.timeUpdated]
+    );
+    const msgId = s.id + "-msg";
+    db.run("INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)", [
+      msgId, s.id, s.timeUpdated, JSON.stringify({ role: "user" }),
+    ]);
+    db.run("INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?, ?, ?, ?, ?)", [
+      s.id + "-part", msgId, s.id, s.timeUpdated, JSON.stringify({ type: "text", text: s.text }),
+    ]);
+  }
+  db.close();
+}
+
+/** Mock fetch for Ollama: health OK + chat response. */
+function mockOllamaOk(content = "## Insight\n\nSome durable insight."): typeof globalThis.fetch {
+  return async (url: string | URL | Request, _init?: RequestInit) => {
+    const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+    if (urlStr.includes("/api/tags")) {
+      return new Response(JSON.stringify({ models: [] }), { status: 200 });
+    }
+    if (urlStr.includes("/api/chat")) {
+      return new Response(JSON.stringify({ message: { content } }), { status: 200 });
+    }
+    throw new Error(`Unexpected URL: ${urlStr}`);
+  };
+}
+
+/** Mock fetch for Ollama: health fails. */
+function mockOllamaDown(): typeof globalThis.fetch {
+  return async () => {
+    throw new Error("ECONNREFUSED");
+  };
+}
+
+// ── parseArgs tests ───────────────────────────────────────────────────────────
+
+describe("parseArgs", () => {
+  test("happy path: --since=ISO + --out parses correctly", () => {
+    const args = parseArgs(["--since=2026-05-15", "--out=/tmp/r.md"]);
+    expect(args.out).toBe("/tmp/r.md");
+    expect(args.since).toBeDefined();
+    // 2026-05-15T00:00:00Z in epoch ms
+    expect(args.since).toBe(new Date("2026-05-15T00:00:00.000Z").getTime());
+    expect(args.extractOnly).toBe(false);
+    expect(args.help).toBe(false);
+    expect(args.unknownFlag).toBeUndefined();
+  });
+
+  test("--since formats: 7d, ISO date, epoch ms all parse", () => {
+    const before = Date.now();
+    const rel = parseArgs(["--since=7d"]);
+    const after = Date.now();
+    expect(rel.since).toBeGreaterThanOrEqual(before - 7 * 24 * 3600 * 1000 - 100);
+    expect(rel.since).toBeLessThanOrEqual(after - 7 * 24 * 3600 * 1000 + 100);
+
+    const iso = parseArgs(["--since=2026-05-15"]);
+    expect(iso.since).toBe(new Date("2026-05-15T00:00:00.000Z").getTime());
+
+    const epochMs = parseArgs(["--since=1747267200000"]);
+    expect(epochMs.since).toBe(1747267200000);
+  });
+
+  test("--help flag sets help: true", () => {
+    const args = parseArgs(["--help"]);
+    expect(args.help).toBe(true);
+  });
+
+  test("unknown flag captured in unknownFlag", () => {
+    const args = parseArgs(["--foo=bar"]);
+    expect(args.unknownFlag).toBe("--foo=bar");
+  });
+
+  test("--session and --extract-only parse correctly", () => {
+    const args = parseArgs(["--session=ses_abc123", "--extract-only"]);
+    expect(args.session).toBe("ses_abc123");
+    expect(args.extractOnly).toBe(true);
+  });
+});
+
+// ── checkOllamaReachable tests ────────────────────────────────────────────────
+
+describe("checkOllamaReachable", () => {
+  test("returns ok: true when /api/tags responds 200", async () => {
+    globalThis.fetch = async () => new Response(JSON.stringify({ models: [] }), { status: 200 });
+    try {
+      const result = await checkOllamaReachable();
+      expect(result.ok).toBe(true);
+      expect(result.error).toBeUndefined();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("returns ok: false when fetch throws (connection refused)", async () => {
+    globalThis.fetch = async () => { throw new Error("ECONNREFUSED"); };
+    try {
+      const result = await checkOllamaReachable();
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("ECONNREFUSED");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+// ── main() integration tests ──────────────────────────────────────────────────
+
+describe("main", () => {
+  test("--help: returns 0 and prints usage to stdout", async () => {
+    const written: string[] = [];
+    const code = await main(["bun", "script.ts", "--help"], (s) => written.push(s), () => {});
+    expect(code).toBe(0);
+    expect(written.join("")).toContain("ollama-distill");
+    expect(written.join("")).toContain("--since");
+  });
+
+  test("unknown flag: returns 1 and prints usage to stderr", async () => {
+    const written: string[] = [];
+    const code = await main(["bun", "script.ts", "--unknown-flag=xyz"], () => {}, (s) => written.push(s));
+    expect(code).toBe(1);
+    expect(written.join("")).toContain("Unknown flag");
+  });
+
+  test("no ollama: normal mode returns 1 with actionable stderr message", async () => {
+    const stateDir = join(tmpdir(), "distill-test-noollama-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-test-noollama-" + Math.random().toString(36).slice(2) + ".db");
+    createFileDb(dbPath, [{ id: "sess-1", timeUpdated: 1000, text: "hello" }]);
+
+    const stderrLines: string[] = [];
+    globalThis.fetch = mockOllamaDown();
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(["bun", "script.ts"], () => {}, (s) => stderrLines.push(s));
+      expect(code).toBe(1);
+      const stderr = stderrLines.join("");
+      expect(stderr).toContain("ollama serve");
+      expect(stderr).toContain("127.0.0.1:11434");
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+
+  test("--session non-mutating: cursor file not created, output to stdout", async () => {
+    const stateDir = join(tmpdir(), "distill-test-session-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-test-session-" + Math.random().toString(36).slice(2) + ".db");
+    createFileDb(dbPath, [{ id: "ses_test123", timeUpdated: 2000, text: "session content here" }]);
+
+    const stdoutLines: string[] = [];
+    globalThis.fetch = mockOllamaOk();
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(["bun", "script.ts", "--session=ses_test123"], (s) => stdoutLines.push(s), () => {});
+      expect(code).toBe(0);
+
+      // Cursor must NOT be created (non-mutating)
+      expect(existsSync(join(stateDir, "cursor.json"))).toBe(false);
+
+      // Output should contain the session block
+      const stdout = stdoutLines.join("");
+      expect(stdout).toContain("ses_test123");
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+
+  test("--session + --out: writes to file, JSONL records mode: session", async () => {
+    const stateDir = join(tmpdir(), "distill-test-session-out-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-test-session-out-" + Math.random().toString(36).slice(2) + ".db");
+    const outPath = join(tmpdir(), "distill-session-out-" + Math.random().toString(36).slice(2) + ".md");
+    createFileDb(dbPath, [{ id: "ses_outtest", timeUpdated: 3000, text: "output test content" }]);
+
+    globalThis.fetch = mockOllamaOk("## Session Insight\n\nSpecific detail here.");
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(
+        ["bun", "script.ts", "--session=ses_outtest", `--out=${outPath}`],
+        () => {}, () => {}
+      );
+      expect(code).toBe(0);
+
+      // File written to --out path
+      expect(existsSync(outPath)).toBe(true);
+      const content = readFileSync(outPath, "utf8");
+      expect(content).toContain("ses_outtest");
+
+      // JSONL records mode: session
+      const logPath = join(stateDir, "run.jsonl");
+      if (existsSync(logPath)) {
+        const line = readFileSync(logPath, "utf8").trim().split("\n").pop()!;
+        const record = JSON.parse(line);
+        expect(record.mode).toBe("session");
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+      if (existsSync(outPath)) unlinkSync(outPath);
+    }
+  });
+
+  test("bootstrap on first run: cursor file created after normal mode success", async () => {
+    const stateDir = join(tmpdir(), "distill-test-bootstrap-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-test-bootstrap-" + Math.random().toString(36).slice(2) + ".db");
+    // Sessions with time_updated far in the past so they're selected by the default 7d cursor
+    const now = Date.now();
+    createFileDb(dbPath, [
+      { id: "ses_boot1", timeUpdated: now - 3 * 24 * 3600 * 1000, text: "bootstrap session" },
+    ]);
+
+    globalThis.fetch = mockOllamaOk();
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(["bun", "script.ts"], () => {}, () => {});
+      expect(code).toBe(0);
+
+      // Cursor file must be created
+      const cursorPath = join(stateDir, "cursor.json");
+      expect(existsSync(cursorPath)).toBe(true);
+      const cursor = JSON.parse(readFileSync(cursorPath, "utf8"));
+      expect(typeof cursor.last_run_timestamp).toBe("number");
+      expect(cursor.last_run_timestamp).toBeGreaterThan(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+
+  test("partial success: 2nd Ollama call fails → returns 1, JSONL errors has 1 entry", async () => {
+    const stateDir = join(tmpdir(), "distill-test-partial-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-test-partial-" + Math.random().toString(36).slice(2) + ".db");
+    const now = Date.now();
+    createFileDb(dbPath, [
+      { id: "ses_p1", timeUpdated: now - 5 * 24 * 3600 * 1000, text: "session one" },
+      { id: "ses_p2", timeUpdated: now - 4 * 24 * 3600 * 1000, text: "session two" },
+      { id: "ses_p3", timeUpdated: now - 3 * 24 * 3600 * 1000, text: "session three" },
+    ]);
+
+    let chatCallCount = 0;
+    globalThis.fetch = async (url: string | URL | Request, _init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : (url as Request).url;
+      if (urlStr.includes("/api/tags")) {
+        return new Response(JSON.stringify({ models: [] }), { status: 200 });
+      }
+      if (urlStr.includes("/api/chat")) {
+        chatCallCount++;
+        if (chatCallCount === 2) {
+          // 2nd call fails
+          return new Response("Internal Server Error", { status: 500, statusText: "Internal Server Error" });
+        }
+        return new Response(JSON.stringify({ message: { content: "## Insight\n\nGood content." } }), { status: 200 });
+      }
+      throw new Error(`Unexpected URL: ${urlStr}`);
+    };
+
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(["bun", "script.ts"], () => {}, () => {});
+      expect(code).toBe(1); // any error → non-zero
+
+      // JSONL should record the error
+      const logPath = join(stateDir, "run.jsonl");
+      expect(existsSync(logPath)).toBe(true);
+      const line = readFileSync(logPath, "utf8").trim().split("\n").pop()!;
+      const record = JSON.parse(line);
+      expect(record.success).toBe(false);
+      expect(record.errors.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+
+  test("schema error: DB missing column → main returns 1", async () => {
+    const stateDir = join(tmpdir(), "distill-test-schema-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-test-schema-" + Math.random().toString(36).slice(2) + ".db");
+
+    // Create DB missing session.parent_id
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT, time_created INTEGER, time_updated INTEGER);
+      CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+      CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+    `);
+    db.close();
+
+    globalThis.fetch = mockOllamaOk();
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(["bun", "script.ts"], () => {}, () => {});
+      expect(code).toBe(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
   });
 });

--- a/.config/opencode/scripts/ollama-distill.test.ts
+++ b/.config/opencode/scripts/ollama-distill.test.ts
@@ -17,6 +17,9 @@ import {
   parseArgs,
   checkOllamaReachable,
   main,
+  withSqliteBusyRetry,
+  acquireLock,
+  releaseLock,
   type ExtractStats,
   type RunRecord,
 } from "./ollama-distill.ts";
@@ -175,6 +178,29 @@ describe("extractTranscript", () => {
     db.close();
   });
 
+  // ─── Test 3b: Fix #3 — Truncation keeps prefix ─────────────────────────────
+
+  test("Fix #3: single 100K-char part yields prefix + marker (not just marker)", async () => {
+    const db = createFixtureDb();
+    const sid = "sess-3b";
+
+    const bigText = "A".repeat(100_000);
+    const m1 = insertMessage(db, sid, "user", 1000, "msg-1");
+    insertPart(db, m1, sid, "text", bigText, 1001, "p-1");
+
+    const { transcript, stats } = await extractTranscript(db, sid);
+
+    expect(stats.truncated).toBe(true);
+    expect(transcript).toContain("[... transcript truncated for context limit]");
+    // Should have substantial prefix content (not just the marker)
+    const markerIdx = transcript.indexOf("[... transcript truncated for context limit]");
+    expect(markerIdx).toBeGreaterThan(1000); // at least 1000 chars of original content
+    // Total length should be close to 60K (not 100K)
+    expect(transcript.length).toBeLessThanOrEqual(60_100); // 60K + marker length
+
+    db.close();
+  });
+
   // ─── Test 4: Read-only verification ────────────────────────────────────────
 
   test("read-only verification: openDatabase with mode=ro throws on CREATE TEMP TABLE", async () => {
@@ -313,6 +339,28 @@ describe("extractTranscript", () => {
 
     db.close();
   });
+
+  // ─── Test 10: Fix #10 — malformed part.data skipped, run succeeds ──────────
+
+  test("Fix #10: malformed part.data row is skipped; other rows still appear in transcript", async () => {
+    const db = createFixtureDb();
+    const sid = "sess-10";
+
+    const m1 = insertMessage(db, sid, "user", 1000, "msg-1");
+    insertPart(db, m1, sid, "text", "Valid content", 1001, "p-1");
+    // Insert a part with completely invalid JSON
+    insertPart(db, m1, sid, "text", null, 1002, "p-2", "not-json-at-all");
+    insertPart(db, m1, sid, "text", "Also valid", 1003, "p-3");
+
+    const { transcript, stats } = await extractTranscript(db, sid);
+
+    expect(transcript).toContain("Valid content");
+    expect(transcript).toContain("Also valid");
+    expect(stats.skipped_parts).toBe(1);
+    expect(stats.skipped_types).toContain("malformed_json");
+
+    db.close();
+  });
 });
 
 // ─── openDatabase tests ───────────────────────────────────────────────────────
@@ -347,6 +395,47 @@ describe("openDatabase", () => {
       db.exec("INSERT INTO session (id) VALUES ('x')");
     }).toThrow();
     db.close();
+  });
+});
+
+// ─── withSqliteBusyRetry tests ────────────────────────────────────────────────
+
+describe("withSqliteBusyRetry", () => {
+  // Fix #4: Test the extracted retry helper directly
+  test("Fix #4: retries on SQLITE_BUSY and succeeds on 3rd attempt", async () => {
+    let callCount = 0;
+    const result = await withSqliteBusyRetry(() => {
+      callCount++;
+      if (callCount < 3) {
+        throw new Error("SQLITE_BUSY: database is locked");
+      }
+      return "success";
+    }, 3, 0);
+
+    expect(result).toBe("success");
+    expect(callCount).toBe(3);
+  });
+
+  test("Fix #4: throws after exhausting all attempts", async () => {
+    let callCount = 0;
+    await expect(
+      withSqliteBusyRetry(() => {
+        callCount++;
+        throw new Error("SQLITE_BUSY: database is locked");
+      }, 3, 0)
+    ).rejects.toThrow("SQLITE_BUSY");
+    expect(callCount).toBe(3);
+  });
+
+  test("Fix #4: non-SQLITE_BUSY errors are not retried", async () => {
+    let callCount = 0;
+    await expect(
+      withSqliteBusyRetry(() => {
+        callCount++;
+        throw new Error("some other error");
+      }, 3, 0)
+    ).rejects.toThrow("some other error");
+    expect(callCount).toBe(1);
   });
 });
 
@@ -580,6 +669,39 @@ describe("callOllama", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  // Fix #9: malformed response shape
+  test("Fix #9: response missing message field → returns malformed-response error, not crash", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ choices: [{ text: "something" }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+    try {
+      const result = await callOllama("test transcript");
+      expect(result.output).toBe("");
+      expect(result.error).toContain("malformed-response");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("Fix #9: response with message but no content field → returns malformed-response error", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ message: { role: "assistant" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+    try {
+      const result = await callOllama("test transcript");
+      expect(result.output).toBe("");
+      expect(result.error).toContain("malformed-response");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 // ── Report writer tests ───────────────────────────────────────────────────────
@@ -612,6 +734,24 @@ describe("writeReport", () => {
     expect(content).toContain("## Run at");
     expect(content).toContain("### First (sess-1)");
     expect(content).toContain("### Second (sess-2)");
+    if (existsSync(reportPath)) unlinkSync(reportPath);
+  });
+
+  // Fix #8: atomic write preserves pre-existing content
+  test("Fix #8: pre-existing report content is preserved after atomic append", async () => {
+    const reportPath = join(tmpdir(), "ollama-distill-report-atomic-" + Math.random().toString(36).slice(2) + ".md");
+    // Pre-populate with known content
+    writeFileSync(reportPath, "# Pre-existing content\n\nOld data here.\n");
+
+    await writeReport(reportPath, [
+      { sessionId: "sess-new", title: "New Session", ollamaOutput: "## New insight." },
+    ]);
+
+    const content = readFileSync(reportPath, "utf8");
+    expect(content).toContain("Pre-existing content");
+    expect(content).toContain("Old data here");
+    expect(content).toContain("New Session");
+    expect(content).toContain("New insight");
     if (existsSync(reportPath)) unlinkSync(reportPath);
   });
 });
@@ -775,6 +915,59 @@ describe("parseArgs", () => {
     expect(args.session).toBe("ses_abc123");
     expect(args.extractOnly).toBe(true);
   });
+
+  // Fix #6: invalid --since
+  test("Fix #6: --since=7days (invalid format) → flagError set", () => {
+    const args = parseArgs(["--since=7days"]);
+    expect(args.flagError).toBeDefined();
+    expect(args.flagError).toContain("Invalid --since value");
+    expect(args.since).toBeUndefined();
+  });
+
+  test("Fix #6: --since= (empty) → flagError set", () => {
+    const args = parseArgs(["--since="]);
+    expect(args.flagError).toBeDefined();
+    expect(args.flagError).toContain("Empty value");
+  });
+
+  test("Fix #6: --since=notadate → flagError set", () => {
+    const args = parseArgs(["--since=notadate"]);
+    expect(args.flagError).toBeDefined();
+    expect(args.flagError).toContain("Invalid --since value");
+  });
+
+  // Fix #7: positional arguments rejected
+  test("Fix #7: positional argument → flagError set", () => {
+    const args = parseArgs(["somevalue"]);
+    expect(args.flagError).toBeDefined();
+    expect(args.flagError).toContain("positional argument");
+  });
+
+  // Fix #7: empty values rejected
+  test("Fix #7: --session= (empty value) → flagError set", () => {
+    const args = parseArgs(["--session="]);
+    expect(args.flagError).toBeDefined();
+    expect(args.flagError).toContain("Empty value");
+  });
+
+  test("Fix #7: --out= (empty value) → flagError set", () => {
+    const args = parseArgs(["--out="]);
+    expect(args.flagError).toBeDefined();
+    expect(args.flagError).toContain("Empty value");
+  });
+
+  // Fix #7: duplicate flags rejected
+  test("Fix #7: duplicate --session flag → flagError set", () => {
+    const args = parseArgs(["--session=ses_a", "--session=ses_b"]);
+    expect(args.flagError).toBeDefined();
+    expect(args.flagError).toContain("Duplicate flag");
+  });
+
+  test("Fix #7: duplicate --since flag → flagError set", () => {
+    const args = parseArgs(["--since=7d", "--since=30d"]);
+    expect(args.flagError).toBeDefined();
+    expect(args.flagError).toContain("Duplicate flag");
+  });
 });
 
 // ── checkOllamaReachable tests ────────────────────────────────────────────────
@@ -814,11 +1007,29 @@ describe("main", () => {
     expect(written.join("")).toContain("--since");
   });
 
+  // Fix #11: --help output should contain -- separator in examples
+  test("Fix #11: --help output contains -- separator in examples", async () => {
+    const written: string[] = [];
+    await main(["bun", "script.ts", "--help"], (s) => written.push(s), () => {});
+    const output = written.join("");
+    expect(output).toContain("-- --since=");
+    expect(output).toContain("-- --session=");
+    expect(output).toContain("-- --extract-only");
+  });
+
   test("unknown flag: returns 1 and prints usage to stderr", async () => {
     const written: string[] = [];
     const code = await main(["bun", "script.ts", "--unknown-flag=xyz"], () => {}, (s) => written.push(s));
     expect(code).toBe(1);
     expect(written.join("")).toContain("Unknown flag");
+  });
+
+  // Fix #6: invalid --since exits 1 with usage error
+  test("Fix #6: --since=7days → exit 1 with usage error", async () => {
+    const stderrLines: string[] = [];
+    const code = await main(["bun", "script.ts", "--since=7days"], () => {}, (s) => stderrLines.push(s));
+    expect(code).toBe(1);
+    expect(stderrLines.join("")).toContain("Invalid --since value");
   });
 
   test("no ollama: normal mode returns 1 with actionable stderr message", async () => {
@@ -1016,6 +1227,219 @@ describe("main", () => {
       delete process.env.OLLAMA_DISTILL_STATE_DIR;
       delete process.env.OPENCODE_DB_PATH;
       if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+
+  // Fix #1: Cursor advances only through contiguous successful prefix
+  test("Fix #1: middle session fails → cursor advances only to session-1's time_updated", async () => {
+    const stateDir = join(tmpdir(), "distill-test-cursor-fix1-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-test-cursor-fix1-" + Math.random().toString(36).slice(2) + ".db");
+    const now = Date.now();
+    const s1Time = now - 5 * 24 * 3600 * 1000;
+    const s2Time = now - 4 * 24 * 3600 * 1000;
+    const s3Time = now - 3 * 24 * 3600 * 1000;
+
+    createFileDb(dbPath, [
+      { id: "ses_c1", timeUpdated: s1Time, text: "session one" },
+      { id: "ses_c2", timeUpdated: s2Time, text: "session two" },
+      { id: "ses_c3", timeUpdated: s3Time, text: "session three" },
+    ]);
+
+    let chatCallCount = 0;
+    globalThis.fetch = async (url: string | URL | Request, _init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : (url as Request).url;
+      if (urlStr.includes("/api/tags")) {
+        return new Response(JSON.stringify({ models: [] }), { status: 200 });
+      }
+      if (urlStr.includes("/api/chat")) {
+        chatCallCount++;
+        if (chatCallCount === 2) {
+          // Middle session (ses_c2) fails
+          return new Response("Internal Server Error", { status: 500, statusText: "Internal Server Error" });
+        }
+        return new Response(JSON.stringify({ message: { content: "## Insight\n\nGood content." } }), { status: 200 });
+      }
+      throw new Error(`Unexpected URL: ${urlStr}`);
+    };
+
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(["bun", "script.ts"], () => {}, () => {});
+      expect(code).toBe(1); // partial failure
+
+      // Cursor should be at ses_c1's time_updated, NOT ses_c3's
+      const cursorPath = join(stateDir, "cursor.json");
+      expect(existsSync(cursorPath)).toBe(true);
+      const cursor = JSON.parse(readFileSync(cursorPath, "utf8"));
+      // Should be at s1Time (first session succeeded, second failed → stop there)
+      expect(cursor.last_run_timestamp).toBe(s1Time);
+      // Must NOT be at s3Time
+      expect(cursor.last_run_timestamp).not.toBe(s3Time);
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+
+  test("Fix #1: first session fails → cursor does not advance at all", async () => {
+    const stateDir = join(tmpdir(), "distill-test-cursor-fix1b-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-test-cursor-fix1b-" + Math.random().toString(36).slice(2) + ".db");
+    const now = Date.now();
+    const s1Time = now - 5 * 24 * 3600 * 1000;
+    const s2Time = now - 4 * 24 * 3600 * 1000;
+
+    createFileDb(dbPath, [
+      { id: "ses_f1", timeUpdated: s1Time, text: "session one" },
+      { id: "ses_f2", timeUpdated: s2Time, text: "session two" },
+    ]);
+
+    // Pre-write a cursor so we can verify it doesn't change
+    mkdirSync(stateDir, { recursive: true });
+    const initialCursorTs = s1Time - 1000;
+    writeFileSync(join(stateDir, "cursor.json"), JSON.stringify({ last_run_timestamp: initialCursorTs }));
+
+    let chatCallCount = 0;
+    globalThis.fetch = async (url: string | URL | Request, _init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : (url as Request).url;
+      if (urlStr.includes("/api/tags")) {
+        return new Response(JSON.stringify({ models: [] }), { status: 200 });
+      }
+      if (urlStr.includes("/api/chat")) {
+        chatCallCount++;
+        // ALL calls fail
+        return new Response("Internal Server Error", { status: 500, statusText: "Internal Server Error" });
+      }
+      throw new Error(`Unexpected URL: ${urlStr}`);
+    };
+
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(["bun", "script.ts"], () => {}, () => {});
+      expect(code).toBe(1);
+
+      // Cursor should NOT have advanced
+      const cursor = JSON.parse(readFileSync(join(stateDir, "cursor.json"), "utf8"));
+      expect(cursor.last_run_timestamp).toBe(initialCursorTs);
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+
+  // Fix #2: File lock prevents concurrent runs
+  test("Fix #2: lock file present → main exits 1 with 'another distill run' message", async () => {
+    const stateDir = join(tmpdir(), "distill-test-lock-" + Math.random().toString(36).slice(2));
+    mkdirSync(stateDir, { recursive: true });
+
+    // Write a sentinel lock file
+    const lockPath = join(stateDir, ".lock");
+    writeFileSync(lockPath, "99999\n2026-01-01T00:00:00.000Z\n");
+
+    const stderrLines: string[] = [];
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = "/nonexistent/path.db"; // won't be reached
+
+    try {
+      const code = await main(["bun", "script.ts"], () => {}, (s) => stderrLines.push(s));
+      expect(code).toBe(1);
+      expect(stderrLines.join("")).toContain("another distill run");
+    } finally {
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(lockPath)) unlinkSync(lockPath);
+    }
+  });
+
+  // Fix #5: Early failures write JSONL record
+  test("Fix #5: DB-not-found → JSONL record written with phase: db-not-found", async () => {
+    const stateDir = join(tmpdir(), "distill-test-early-fail-" + Math.random().toString(36).slice(2));
+
+    globalThis.fetch = mockOllamaOk();
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = "/nonexistent/path/opencode.db";
+
+    try {
+      const code = await main(["bun", "script.ts"], () => {}, () => {});
+      expect(code).toBe(1);
+
+      const logPath = join(stateDir, "runs.jsonl");
+      expect(existsSync(logPath)).toBe(true);
+      const line = readFileSync(logPath, "utf8").trim();
+      const record = JSON.parse(line);
+      expect(record.success).toBe(false);
+      expect(record.errors.length).toBeGreaterThan(0);
+      // db-not-found when env var not set; db-open-failure when path set but invalid
+      expect(["db-not-found", "db-open-failure"]).toContain(record.errors[0].phase);
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+    }
+  });
+
+  test("Fix #5: schema-invariant-violation → JSONL record written with phase: schema-invariant-violation", async () => {
+    const stateDir = join(tmpdir(), "distill-test-schema-fail-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-test-schema-fail-" + Math.random().toString(36).slice(2) + ".db");
+
+    // DB missing parent_id → schema error
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT, time_created INTEGER, time_updated INTEGER);
+      CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+      CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+    `);
+    db.close();
+
+    globalThis.fetch = mockOllamaOk();
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(["bun", "script.ts"], () => {}, () => {});
+      expect(code).toBe(1);
+
+      const logPath = join(stateDir, "runs.jsonl");
+      expect(existsSync(logPath)).toBe(true);
+      const line = readFileSync(logPath, "utf8").trim();
+      const record = JSON.parse(line);
+      expect(record.success).toBe(false);
+      // Schema error is caught during openDatabase (db-open-failure) or selectSessions
+      expect(["db-open-failure", "schema-invariant-violation"]).toContain(record.errors[0].phase);
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+});
+
+// ── acquireLock / releaseLock tests ───────────────────────────────────────────
+
+describe("acquireLock / releaseLock", () => {
+  test("Fix #2: acquireLock creates lock file with PID content", () => {
+    const stateDir = join(tmpdir(), "distill-lock-test-" + Math.random().toString(36).slice(2));
+    const lockPath = acquireLock(stateDir);
+    expect(existsSync(lockPath)).toBe(true);
+    releaseLock(lockPath);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  test("Fix #2: acquireLock throws when lock already held", () => {
+    const stateDir = join(tmpdir(), "distill-lock-test2-" + Math.random().toString(36).slice(2));
+    const lockPath = acquireLock(stateDir);
+    try {
+      expect(() => acquireLock(stateDir)).toThrow("another distill run");
+    } finally {
+      releaseLock(lockPath);
     }
   });
 });

--- a/.config/opencode/scripts/ollama-distill.test.ts
+++ b/.config/opencode/scripts/ollama-distill.test.ts
@@ -1,0 +1,338 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { Database } from "bun:sqlite";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { unlinkSync, existsSync } from "node:fs";
+import {
+  openDatabase,
+  extractTranscript,
+  SchemaError,
+  ReadOnlyVerificationError,
+  type ExtractStats,
+} from "./ollama-distill.ts";
+
+// ─── Fixture helpers ──────────────────────────────────────────────────────────
+
+/** Create a minimal in-memory DB with the required schema. */
+function createFixtureDb(): Database {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE session (
+      id TEXT PRIMARY KEY,
+      project_id TEXT,
+      parent_id TEXT,
+      time_created INTEGER,
+      time_updated INTEGER
+    );
+    CREATE TABLE message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT,
+      time_created INTEGER,
+      data TEXT
+    );
+    CREATE TABLE part (
+      id TEXT PRIMARY KEY,
+      message_id TEXT,
+      session_id TEXT,
+      time_created INTEGER,
+      data TEXT
+    );
+  `);
+  return db;
+}
+
+/** Insert a message row and return its id. */
+function insertMessage(
+  db: Database,
+  sessionId: string,
+  role: string,
+  timeCreated: number,
+  id: string
+): string {
+  db.run("INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)", [
+    id,
+    sessionId,
+    timeCreated,
+    JSON.stringify({ role }),
+  ]);
+  return id;
+}
+
+/** Insert a part row. */
+function insertPart(
+  db: Database,
+  messageId: string,
+  sessionId: string,
+  type: string,
+  text: string | null,
+  timeCreated: number,
+  id: string,
+  rawData?: string
+): void {
+  const data =
+    rawData !== undefined
+      ? rawData
+      : text !== null
+        ? JSON.stringify({ type, text })
+        : JSON.stringify({ type });
+  db.run(
+    "INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?, ?, ?, ?, ?)",
+    [id, messageId, sessionId, timeCreated, data]
+  );
+}
+
+// ─── Test 1: Happy path ───────────────────────────────────────────────────────
+
+describe("extractTranscript", () => {
+  test("happy path: 3 messages with one text part each → 3 labeled lines in order", async () => {
+    const db = createFixtureDb();
+    const sid = "sess-1";
+
+    const m1 = insertMessage(db, sid, "user", 1000, "msg-1");
+    const m2 = insertMessage(db, sid, "assistant", 2000, "msg-2");
+    const m3 = insertMessage(db, sid, "user", 3000, "msg-3");
+
+    insertPart(db, m1, sid, "text", "Hello there", 1001, "p-1");
+    insertPart(db, m2, sid, "text", "Hi! How can I help?", 2001, "p-2");
+    insertPart(db, m3, sid, "text", "Tell me about SQLite", 3001, "p-3");
+
+    const { transcript, stats } = await extractTranscript(db, sid);
+
+    const lines = transcript.split("\n");
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toBe("USER: Hello there");
+    expect(lines[1]).toBe("ASSISTANT: Hi! How can I help?");
+    expect(lines[2]).toBe("USER: Tell me about SQLite");
+
+    expect(stats.messages).toBe(3);
+    expect(stats.text_parts).toBe(3);
+    expect(stats.reasoning_parts).toBe(0);
+    expect(stats.skipped_parts).toBe(0);
+    expect(stats.truncated).toBe(false);
+
+    db.close();
+  });
+
+  // ─── Test 2: Mixed part types ───────────────────────────────────────────────
+
+  test("mixed part types: text + reasoning emit lines; tool/step-start are skipped", async () => {
+    const db = createFixtureDb();
+    const sid = "sess-2";
+
+    const m1 = insertMessage(db, sid, "assistant", 1000, "msg-1");
+    insertPart(db, m1, sid, "text", "Here is my answer", 1001, "p-1");
+    insertPart(db, m1, sid, "reasoning", "Let me think...", 1002, "p-2");
+    insertPart(db, m1, sid, "tool", null, 1003, "p-3");
+    insertPart(db, m1, sid, "step-start", null, 1004, "p-4");
+
+    const { transcript, stats } = await extractTranscript(db, sid);
+
+    const lines = transcript.split("\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe("ASSISTANT: Here is my answer");
+    expect(lines[1]).toBe("ASSISTANT [reasoning]: Let me think...");
+
+    expect(stats.text_parts).toBe(1);
+    expect(stats.reasoning_parts).toBe(1);
+    expect(stats.skipped_parts).toBe(2);
+    expect(stats.skipped_types).toContain("tool");
+    expect(stats.skipped_types).toContain("step-start");
+
+    db.close();
+  });
+
+  // ─── Test 3: Truncation ─────────────────────────────────────────────────────
+
+  test("truncation: content exceeding 60K chars is truncated with marker", async () => {
+    const db = createFixtureDb();
+    const sid = "sess-3";
+
+    // Create a message with text that exceeds 60K chars
+    const bigText = "x".repeat(61_000);
+    const m1 = insertMessage(db, sid, "user", 1000, "msg-1");
+    insertPart(db, m1, sid, "text", bigText, 1001, "p-1");
+
+    const { transcript, stats } = await extractTranscript(db, sid);
+
+    expect(stats.truncated).toBe(true);
+    expect(transcript).toContain("[... transcript truncated for context limit]");
+    // The transcript should be shorter than the original content
+    expect(transcript.length).toBeLessThan(bigText.length);
+
+    db.close();
+  });
+
+  // ─── Test 4: Read-only verification ────────────────────────────────────────
+
+  test("read-only verification: openDatabase with mode=ro throws on CREATE TEMP TABLE", async () => {
+    // Create a real file-based DB so we can open it with mode=ro URI
+    const dbPath = join(tmpdir(), `ollama-distill-test-ro-${Date.now()}.db`);
+
+    // Bootstrap the DB with required schema
+    const setup = new Database(dbPath);
+    setup.exec(`
+      CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT, parent_id TEXT, time_created INTEGER, time_updated INTEGER);
+      CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+      CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+    `);
+    setup.close();
+
+    // openDatabase should succeed (schema is valid) and the probe should throw internally
+    // but be caught — meaning the DB opens fine in read-only mode.
+    // The key assertion: if we manually try CREATE TEMP TABLE on the opened DB, it throws.
+    const db = openDatabase(dbPath);
+
+    // Verify the connection is truly read-only by attempting a write
+    expect(() => {
+      db.exec("INSERT INTO session (id) VALUES ('test')");
+    }).toThrow();
+
+    db.close();
+    if (existsSync(dbPath)) unlinkSync(dbPath);
+  });
+
+  // ─── Test 5: Schema missing column ─────────────────────────────────────────
+
+  test("schema missing column: SchemaError thrown with missing column name", async () => {
+    const dbPath = join(tmpdir(), `ollama-distill-test-schema-${Date.now()}.db`);
+
+    // Create DB missing session.parent_id
+    const setup = new Database(dbPath);
+    setup.exec(`
+      CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT, time_created INTEGER, time_updated INTEGER);
+      CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+      CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+    `);
+    setup.close();
+
+    expect(() => openDatabase(dbPath)).toThrow(SchemaError);
+
+    try {
+      openDatabase(dbPath);
+    } catch (err) {
+      expect(err).toBeInstanceOf(SchemaError);
+      expect((err as SchemaError).message).toContain("parent_id");
+    }
+
+    if (existsSync(dbPath)) unlinkSync(dbPath);
+  });
+
+  // ─── Test 6: SQLITE_BUSY retry ─────────────────────────────────────────────
+
+  test("SQLITE_BUSY retry: succeeds after 2 busy errors", async () => {
+    const db = createFixtureDb();
+    const sid = "sess-6";
+
+    const m1 = insertMessage(db, sid, "user", 1000, "msg-1");
+    insertPart(db, m1, sid, "text", "Hello", 1001, "p-1");
+
+    // Monkey-patch db.query to simulate SQLITE_BUSY twice then succeed
+    let callCount = 0;
+    const originalQuery = db.query.bind(db);
+
+    // We'll wrap extractTranscript by intercepting at the db.query level
+    // Since we can't easily mock bun:sqlite internals, we test the retry logic
+    // by creating a wrapper that tracks attempts via a counter in the closure.
+    let retryCount = 0;
+
+    // Create a proxy-like wrapper around the db that throws SQLITE_BUSY twice
+    const mockDb = new Proxy(db, {
+      get(target, prop) {
+        if (prop === "query") {
+          return (sql: string) => {
+            const stmt = originalQuery(sql);
+            const originalAll = stmt.all.bind(stmt);
+            return new Proxy(stmt, {
+              get(stmtTarget, stmtProp) {
+                if (stmtProp === "all") {
+                  return (...args: unknown[]) => {
+                    callCount++;
+                    if (callCount <= 2) {
+                      retryCount++;
+                      const err = new Error("SQLITE_BUSY: database is locked");
+                      throw err;
+                    }
+                    return originalAll(...(args as Parameters<typeof originalAll>));
+                  };
+                }
+                return (stmtTarget as Record<string | symbol, unknown>)[stmtProp];
+              },
+            });
+          };
+        }
+        return (target as Record<string | symbol, unknown>)[prop];
+      },
+    });
+
+    const { transcript, stats } = await extractTranscript(mockDb as unknown as Database, sid);
+
+    expect(retryCount).toBe(2);
+    expect(transcript).toContain("USER: Hello");
+    expect(stats.text_parts).toBe(1);
+
+    db.close();
+  });
+
+  // ─── Test 7: JSON decode failure ───────────────────────────────────────────
+
+  test("JSON decode failure: malformed part data is skipped, extraction continues", async () => {
+    const db = createFixtureDb();
+    const sid = "sess-7";
+
+    const m1 = insertMessage(db, sid, "user", 1000, "msg-1");
+    // Good part
+    insertPart(db, m1, sid, "text", "Good part", 1001, "p-1");
+    // Malformed JSON part
+    insertPart(db, m1, sid, "text", null, 1002, "p-2", "{ this is not valid json !!!");
+    // Another good part
+    insertPart(db, m1, sid, "text", "Another good part", 1003, "p-3");
+
+    const { transcript, stats } = await extractTranscript(db, sid);
+
+    const lines = transcript.split("\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe("USER: Good part");
+    expect(lines[1]).toBe("USER: Another good part");
+
+    expect(stats.text_parts).toBe(2);
+    expect(stats.skipped_parts).toBe(1);
+    expect(stats.skipped_types).toContain("malformed_json");
+
+    db.close();
+  });
+});
+
+// ─── openDatabase tests ───────────────────────────────────────────────────────
+
+describe("openDatabase", () => {
+  let dbPath: string;
+
+  beforeAll(() => {
+    dbPath = join(tmpdir(), `ollama-distill-test-open-${Date.now()}.db`);
+    const setup = new Database(dbPath);
+    setup.exec(`
+      CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT, parent_id TEXT, time_created INTEGER, time_updated INTEGER);
+      CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+      CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+    `);
+    setup.close();
+  });
+
+  afterAll(() => {
+    if (existsSync(dbPath)) unlinkSync(dbPath);
+  });
+
+  test("opens valid DB successfully", () => {
+    const db = openDatabase(dbPath);
+    expect(db).toBeDefined();
+    db.close();
+  });
+
+  test("opened DB rejects write operations", () => {
+    const db = openDatabase(dbPath);
+    expect(() => {
+      db.exec("INSERT INTO session (id) VALUES ('x')");
+    }).toThrow();
+    db.close();
+  });
+});

--- a/.config/opencode/scripts/ollama-distill.test.ts
+++ b/.config/opencode/scripts/ollama-distill.test.ts
@@ -2,14 +2,24 @@ import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import { Database } from "bun:sqlite";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { unlinkSync, existsSync } from "node:fs";
+import { unlinkSync, existsSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
 import {
   openDatabase,
   extractTranscript,
   SchemaError,
   ReadOnlyVerificationError,
+  loadCursor,
+  saveCursor,
+  selectSessions,
+  callOllama,
+  writeReport,
+  appendRunLog,
   type ExtractStats,
+  type RunRecord,
 } from "./ollama-distill.ts";
+
+// Save original fetch so we can restore it after each Ollama test
+const originalFetch = globalThis.fetch;
 
 // ─── Fixture helpers ──────────────────────────────────────────────────────────
 
@@ -334,5 +344,321 @@ describe("openDatabase", () => {
       db.exec("INSERT INTO session (id) VALUES ('x')");
     }).toThrow();
     db.close();
+  });
+});
+
+// ─── Unit 2 Tests ─────────────────────────────────────────────────────────────
+
+// ── Fixture helpers for session selection ────────────────────────────────────
+
+function createSelectionDb(): Database {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE session (
+      id TEXT PRIMARY KEY,
+      project_id TEXT,
+      parent_id TEXT,
+      time_created INTEGER,
+      time_updated INTEGER
+    );
+    CREATE TABLE message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT,
+      time_created INTEGER,
+      data TEXT
+    );
+    CREATE TABLE part (
+      id TEXT PRIMARY KEY,
+      message_id TEXT,
+      session_id TEXT,
+      time_created INTEGER,
+      data TEXT
+    );
+  `);
+  return db;
+}
+
+function insertSession(db: Database, id: string, timeUpdated: number, parentId: string | null = null): void {
+  db.run(
+    "INSERT INTO session (id, project_id, parent_id, time_created, time_updated) VALUES (?, NULL, ?, ?, ?)",
+    [id, parentId, timeUpdated, timeUpdated]
+  );
+}
+
+function insertSessionWithText(db: Database, id: string, timeUpdated: number, text: string): void {
+  insertSession(db, id, timeUpdated);
+  const msgId = id + "-msg";
+  db.run("INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)", [
+    msgId, id, timeUpdated, JSON.stringify({ role: "user" }),
+  ]);
+  db.run("INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?, ?, ?, ?, ?)", [
+    id + "-part", msgId, id, timeUpdated, JSON.stringify({ type: "text", text }),
+  ]);
+}
+
+// ── Cursor tests ─────────────────────────────────────────────────────────────
+
+describe("loadCursor / saveCursor", () => {
+  test("bootstrap: missing cursor file returns ~7 days ago timestamp", async () => {
+    const stateDir = join(tmpdir(), "ollama-distill-cursor-test-" + Math.random().toString(36).slice(2));
+    const before = Date.now();
+    const cursor = await loadCursor(stateDir);
+    const after = Date.now();
+
+    expect(cursor.last_run_timestamp).not.toBeNull();
+    const ts = cursor.last_run_timestamp!;
+    const sevenDaysMs = 7 * 24 * 3600 * 1000;
+    // Should be approximately now - 7d (within 5s tolerance)
+    expect(ts).toBeGreaterThanOrEqual(before - sevenDaysMs - 5000);
+    expect(ts).toBeLessThanOrEqual(after - sevenDaysMs + 5000);
+  });
+
+  test("round-trip: saveCursor then loadCursor returns exact value", async () => {
+    const stateDir = join(tmpdir(), "ollama-distill-cursor-rt-" + Math.random().toString(36).slice(2));
+    const cursor = { last_run_timestamp: 1234567890123 };
+    await saveCursor(stateDir, cursor);
+    const loaded = await loadCursor(stateDir);
+    expect(loaded.last_run_timestamp).toBe(1234567890123);
+  });
+
+  test("atomic write: .tmp file without rename → next load returns old cursor", async () => {
+    const stateDir = join(tmpdir(), "ollama-distill-cursor-atomic-" + Math.random().toString(36).slice(2));
+    mkdirSync(stateDir, { recursive: true });
+
+    // Write a known cursor first
+    await saveCursor(stateDir, { last_run_timestamp: 9999 });
+
+    // Simulate interrupted write: write .tmp but don't rename
+    writeFileSync(join(stateDir, "cursor.json.tmp"), JSON.stringify({ last_run_timestamp: 42 }) + "\n");
+
+    // Load should return the old cursor (9999), not the .tmp value (42)
+    const loaded = await loadCursor(stateDir);
+    expect(loaded.last_run_timestamp).toBe(9999);
+  });
+});
+
+// ── Session selection tests ───────────────────────────────────────────────────
+
+describe("selectSessions", () => {
+  test("count cap: 75 sessions → selectSessions returns 50", async () => {
+    const db = createSelectionDb();
+    for (let i = 0; i < 75; i++) {
+      insertSessionWithText(db, `sess-${i}`, 1000 + i, "short text");
+    }
+    const result = await selectSessions(db, 0, 50);
+    expect(result.sessions.length).toBe(50);
+    expect(result.max_processed_time_updated).toBe(1049); // 50th session time_updated
+    db.close();
+  });
+
+  test("byte cap: stops before accumulating byte cap of transcript chars", async () => {
+    const db = createSelectionDb();
+    // Each session ~40KB of text (under 60K truncation limit)
+    // With a 100KB cap, should stop after ~2-3 sessions
+    const chunkText = "x".repeat(40_000);
+    for (let i = 0; i < 10; i++) {
+      insertSessionWithText(db, `sess-${i}`, 1000 + i, chunkText);
+    }
+    const result = await selectSessions(db, 0, 50, 100_000);
+    // Should stop well before 10 sessions (40K chars each, cap 100K → stops at 2-3)
+    expect(result.sessions.length).toBeLessThan(10);
+    expect(result.sessions.length).toBeGreaterThan(0);
+    db.close();
+  });
+
+  test("cursor advance: second call with advanced cursor selects remaining sessions", async () => {
+    const db = createSelectionDb();
+    for (let i = 0; i < 75; i++) {
+      insertSessionWithText(db, `sess-${i}`, 1000 + i, "short text");
+    }
+
+    // First call: selects 50
+    const first = await selectSessions(db, 0, 50);
+    expect(first.sessions.length).toBe(50);
+
+    // Second call with advanced cursor: selects remaining 25
+    const second = await selectSessions(db, first.max_processed_time_updated, 50);
+    expect(second.sessions.length).toBe(25);
+
+    // No overlap
+    const firstIds = new Set(first.sessions.map((s) => s.id));
+    for (const s of second.sessions) {
+      expect(firstIds.has(s.id)).toBe(false);
+    }
+    db.close();
+  });
+
+  test("zero sessions: max_processed_time_updated returns lastRunTimestamp unchanged", async () => {
+    const db = createSelectionDb();
+    const result = await selectSessions(db, 5000, 50);
+    expect(result.sessions.length).toBe(0);
+    expect(result.max_processed_time_updated).toBe(5000);
+    db.close();
+  });
+});
+
+// ── Ollama client tests ───────────────────────────────────────────────────────
+
+describe("callOllama", () => {
+  test("happy path: mocked fetch returns content → callOllama returns output + duration", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ message: { content: "## Block\n\nSome insight." } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+    try {
+      const result = await callOllama("test transcript");
+      expect(result.output).toBe("## Block\n\nSome insight.");
+      expect(result.error).toBeUndefined();
+      expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("network error: mocked fetch throws → returns error string", async () => {
+    globalThis.fetch = async () => {
+      throw new Error("ECONNREFUSED");
+    };
+
+    try {
+      const result = await callOllama("test transcript");
+      expect(result.output).toBe("");
+      expect(result.error).toContain("ECONNREFUSED");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("empty response: Ollama returns 200 with empty content → error: 'empty response'", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ message: { content: "" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+    try {
+      const result = await callOllama("test transcript");
+      expect(result.output).toBe("");
+      expect(result.error).toBe("empty response");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("non-2xx response: returns HTTP error string", async () => {
+    globalThis.fetch = async () =>
+      new Response("Service Unavailable", { status: 503, statusText: "Service Unavailable" });
+
+    try {
+      const result = await callOllama("test transcript");
+      expect(result.output).toBe("");
+      expect(result.error).toContain("503");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("timeout: AbortSignal.timeout fires → returns timeout error", async () => {
+    // We can't easily test the 300s timeout, but we can verify the error path
+    // by mocking fetch to throw a TimeoutError
+    globalThis.fetch = async () => {
+      const err = new Error("The operation was aborted due to timeout");
+      err.name = "TimeoutError";
+      throw err;
+    };
+
+    try {
+      const result = await callOllama("test transcript");
+      expect(result.output).toBe("");
+      expect(result.error).toContain("timeout");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+// ── Report writer tests ───────────────────────────────────────────────────────
+
+describe("writeReport", () => {
+  test("new file: creates header + blocks", async () => {
+    const reportPath = join(tmpdir(), "ollama-distill-report-" + Math.random().toString(36).slice(2) + ".md");
+    await writeReport(reportPath, [
+      { sessionId: "sess-abc", title: "My Session", ollamaOutput: "## Insight\n\nSome text." },
+    ]);
+    const content = readFileSync(reportPath, "utf8");
+    expect(content).toContain("# Distillation Report");
+    expect(content).toContain("### My Session (sess-abc)");
+    expect(content).toContain("## Insight");
+    if (existsSync(reportPath)) unlinkSync(reportPath);
+  });
+
+  test("append: existing file gets separator + new blocks", async () => {
+    const reportPath = join(tmpdir(), "ollama-distill-report-append-" + Math.random().toString(36).slice(2) + ".md");
+    // First write
+    await writeReport(reportPath, [
+      { sessionId: "sess-1", title: "First", ollamaOutput: "## First insight." },
+    ]);
+    // Second write (append)
+    await writeReport(reportPath, [
+      { sessionId: "sess-2", title: "Second", ollamaOutput: "## Second insight." },
+    ]);
+    const content = readFileSync(reportPath, "utf8");
+    expect(content).toContain("---");
+    expect(content).toContain("## Run at");
+    expect(content).toContain("### First (sess-1)");
+    expect(content).toContain("### Second (sess-2)");
+    if (existsSync(reportPath)) unlinkSync(reportPath);
+  });
+});
+
+// ── JSONL run log tests ───────────────────────────────────────────────────────
+
+describe("appendRunLog", () => {
+  test("partial failure: RunRecord with errors[] writes valid JSON with success: false", async () => {
+    const logPath = join(tmpdir(), "ollama-distill-log-" + Math.random().toString(36).slice(2) + ".jsonl");
+    const record: RunRecord = {
+      ts: new Date().toISOString(),
+      ts_ms: Date.now(),
+      duration_ms: 1234,
+      mode: "normal",
+      model: "qwen3:8b",
+      sessions_read: 3,
+      report_blocks_generated: 2,
+      report_path: "/tmp/report.md",
+      success: false,
+      errors: [{ session_id: "sess-x", phase: "ollama", message: "ECONNREFUSED" }],
+    };
+    await appendRunLog(logPath, record);
+    const line = readFileSync(logPath, "utf8").trim();
+    const parsed = JSON.parse(line);
+    expect(parsed.success).toBe(false);
+    expect(parsed.errors).toHaveLength(1);
+    expect(parsed.errors[0].session_id).toBe("sess-x");
+    expect(parsed.model).toBe("qwen3:8b");
+    if (existsSync(logPath)) unlinkSync(logPath);
+  });
+
+  test("multiple appends: each call adds a new line", async () => {
+    const logPath = join(tmpdir(), "ollama-distill-log-multi-" + Math.random().toString(36).slice(2) + ".jsonl");
+    const base: RunRecord = {
+      ts: new Date().toISOString(),
+      ts_ms: Date.now(),
+      duration_ms: 100,
+      mode: "normal",
+      model: "qwen3:8b",
+      sessions_read: 1,
+      report_blocks_generated: 1,
+      report_path: "/tmp/r.md",
+      success: true,
+      errors: [],
+    };
+    await appendRunLog(logPath, base);
+    await appendRunLog(logPath, { ...base, sessions_read: 2 });
+    const lines = readFileSync(logPath, "utf8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[1]).sessions_read).toBe(2);
+    if (existsSync(logPath)) unlinkSync(logPath);
   });
 });

--- a/.config/opencode/scripts/ollama-distill.test.ts
+++ b/.config/opencode/scripts/ollama-distill.test.ts
@@ -896,7 +896,7 @@ describe("main", () => {
       expect(content).toContain("ses_outtest");
 
       // JSONL records mode: session
-      const logPath = join(stateDir, "run.jsonl");
+      const logPath = join(stateDir, "runs.jsonl");
       if (existsSync(logPath)) {
         const line = readFileSync(logPath, "utf8").trim().split("\n").pop()!;
         const record = JSON.parse(line);
@@ -977,7 +977,7 @@ describe("main", () => {
       expect(code).toBe(1); // any error → non-zero
 
       // JSONL should record the error
-      const logPath = join(stateDir, "run.jsonl");
+      const logPath = join(stateDir, "runs.jsonl");
       expect(existsSync(logPath)).toBe(true);
       const line = readFileSync(logPath, "utf8").trim().split("\n").pop()!;
       const record = JSON.parse(line);

--- a/.config/opencode/scripts/ollama-distill.ts
+++ b/.config/opencode/scripts/ollama-distill.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
 import { Database } from "bun:sqlite";
 import { mkdirSync, renameSync, existsSync, appendFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -543,4 +544,411 @@ export async function appendRunLog(logPath: string, record: RunRecord): Promise<
   mkdirSync(dirname(logPath), { recursive: true });
   const line = JSON.stringify(record) + "\n";
   appendFileSync(logPath, line, "utf8");
+}
+
+// ─── CLI: Flag Parser ─────────────────────────────────────────────────────────
+
+export type ParsedArgs = {
+  since?: number;       // epoch ms
+  session?: string;
+  out?: string;
+  extractOnly: boolean;
+  help: boolean;
+  unknownFlag?: string;
+};
+
+/**
+ * Parse CLI argv (pass Bun.argv.slice(2) or the raw Bun.argv — we skip the
+ * first two elements internally).
+ */
+export function parseArgs(argv: string[]): ParsedArgs {
+  // Skip interpreter + script path if argv looks like Bun.argv (starts with bun path)
+  const args = argv[0]?.includes("bun") || argv[0]?.endsWith(".ts") || argv[0]?.endsWith(".js")
+    ? argv.slice(2)
+    : argv;
+
+  const result: ParsedArgs = { extractOnly: false, help: false };
+
+  for (const arg of args) {
+    if (arg === "--help" || arg === "-h") {
+      result.help = true;
+      continue;
+    }
+    if (arg === "--extract-only") {
+      result.extractOnly = true;
+      continue;
+    }
+    if (arg.startsWith("--since=")) {
+      result.since = parseSince(arg.slice("--since=".length));
+      continue;
+    }
+    if (arg.startsWith("--session=")) {
+      result.session = arg.slice("--session=".length);
+      continue;
+    }
+    if (arg.startsWith("--out=")) {
+      result.out = arg.slice("--out=".length);
+      continue;
+    }
+    if (arg.startsWith("--")) {
+      result.unknownFlag = arg;
+      break;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Parse --since value. Accepts:
+ * - "7d", "30d" → relative days
+ * - "2026-05-15" → ISO date (start of day UTC)
+ * - "1747267200000" → epoch ms (>1_000_000_000_000)
+ */
+function parseSince(value: string): number {
+  // Relative: Nd
+  const relMatch = /^(\d+)d$/.exec(value);
+  if (relMatch) {
+    const days = parseInt(relMatch[1], 10);
+    return Date.now() - days * 24 * 3600 * 1000;
+  }
+
+  // Epoch ms: large integer
+  const asNum = Number(value);
+  if (!isNaN(asNum) && asNum > 1_000_000_000_000) {
+    return asNum;
+  }
+
+  // ISO date: YYYY-MM-DD
+  const isoMatch = /^\d{4}-\d{2}-\d{2}$/.exec(value);
+  if (isoMatch) {
+    return new Date(value + "T00:00:00.000Z").getTime();
+  }
+
+  // Fallback: try Date.parse
+  const parsed = Date.parse(value);
+  if (!isNaN(parsed)) return parsed;
+
+  // Can't parse — return 0 (will select all sessions)
+  return 0;
+}
+
+// ─── CLI: Usage Text ──────────────────────────────────────────────────────────
+
+const USAGE = `ollama-distill — Distill recent OpenCode sessions into a Markdown report.
+
+USAGE:
+  ollama-distill [OPTIONS]
+  mise run distill [OPTIONS]
+
+OPTIONS:
+  --since=<value>     Recency filter override. Accepts: '7d', '2026-05-15', or epoch ms.
+                      Cursor still advances after success.
+  --session=<id>      Process exactly one session (non-mutating: skips cursor read/write,
+                      writes to stdout unless --out provided).
+  --out=<path>        Override report destination (or stdout target in --session mode).
+  --extract-only      Print extracted transcript(s) to stdout; skip Ollama call.
+                      Useful for debugging the extractor.
+  --help              Show this message.
+
+EXAMPLES:
+  mise run distill                          # normal run; reads cursor, writes today's report
+  mise run distill --since=7d               # backfill the last 7 days
+  mise run distill --session=ses_xxx        # debug one session, output to stdout
+  mise run distill --session=ses_xxx --out=/tmp/x.md
+  mise run distill --extract-only --session=ses_xxx  # see extracted transcript only
+
+OLLAMA REQUIREMENTS:
+  - \`ollama serve\` must be running locally at 127.0.0.1:11434
+  - \`qwen3:8b\` model must be pulled (ollama pull qwen3:8b)
+`;
+
+// ─── CLI: Ollama Health Check ─────────────────────────────────────────────────
+
+const OLLAMA_TAGS_URL = "http://127.0.0.1:11434/api/tags";
+
+export async function checkOllamaReachable(): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const response = await fetch(OLLAMA_TAGS_URL, {
+      signal: AbortSignal.timeout(2000),
+    });
+    if (response.ok) {
+      return { ok: true };
+    }
+    return { ok: false, error: `HTTP ${response.status}: ${response.statusText}` };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: msg };
+  }
+}
+
+// ─── CLI: Main Entry ──────────────────────────────────────────────────────────
+
+const MODEL = "qwen3:8b";
+
+type WriteStream = (s: string) => void;
+
+export async function main(
+  argv: string[] = Bun.argv,
+  stdout: WriteStream = (s) => process.stdout.write(s),
+  stderr: WriteStream = (s) => process.stderr.write(s)
+): Promise<number> {
+  const startMs = Date.now();
+
+  try {
+    const args = parseArgs(argv);
+
+    // --help
+    if (args.help) {
+      stdout(USAGE);
+      return 0;
+    }
+
+    // Unknown flag
+    if (args.unknownFlag) {
+      stderr(`Unknown flag: ${args.unknownFlag}\n\n${USAGE}`);
+      return 1;
+    }
+
+    const stateDir =
+      process.env.OLLAMA_DISTILL_STATE_DIR ??
+      join(homedir(), ".local/state/ollama-distill");
+
+    const logPath = join(stateDir, "run.jsonl");
+
+    // ── --session mode (non-mutating) ────────────────────────────────────────
+    if (args.session) {
+      const sessionId = args.session;
+
+      // Find the OpenCode DB
+      const dbPath = findOpenCodeDb();
+      if (!dbPath) {
+        stderr("Could not locate OpenCode SQLite database.\n");
+        return 1;
+      }
+
+      let db: Database;
+      try {
+        db = openDatabase(dbPath);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        stderr(`Failed to open database: ${msg}\n`);
+        return 1;
+      }
+
+      let extractResult: { transcript: string; stats: ExtractStats };
+      try {
+        extractResult = await extractTranscript(db, sessionId);
+      } catch (err) {
+        db.close();
+        const msg = err instanceof Error ? err.message : String(err);
+        stderr(`Failed to extract transcript for ${sessionId}: ${msg}\n`);
+        return 1;
+      }
+      db.close();
+
+      const { transcript } = extractResult;
+
+      // --extract-only: skip Ollama
+      if (args.extractOnly) {
+        if (args.out) {
+          await Bun.write(args.out, transcript + "\n");
+        } else {
+          stdout(transcript + "\n");
+        }
+        return 0;
+      }
+
+      // Health check (unless --extract-only)
+      const health = await checkOllamaReachable();
+      if (!health.ok) {
+        stderr(
+          `ollama serve not reachable at 127.0.0.1:11434. Start it with: ollama serve &\n(${health.error})\n`
+        );
+        return 1;
+      }
+
+      const ollamaResult = await callOllama(transcript, MODEL);
+      const durationMs = Date.now() - startMs;
+
+      const record: RunRecord = {
+        ts: new Date().toISOString(),
+        ts_ms: Date.now(),
+        duration_ms: durationMs,
+        mode: "session",
+        model: MODEL,
+        sessions_read: 1,
+        report_blocks_generated: ollamaResult.error ? 0 : 1,
+        report_path: args.out ?? "stdout",
+        success: !ollamaResult.error,
+        errors: ollamaResult.error
+          ? [{ session_id: sessionId, phase: "ollama", message: ollamaResult.error }]
+          : [],
+      };
+
+      await appendRunLog(logPath, record);
+
+      if (ollamaResult.error) {
+        stderr(`Ollama error for ${sessionId}: ${ollamaResult.error}\n`);
+        return 1;
+      }
+
+      const output = `### Session ${sessionId}\n\n${ollamaResult.output}\n`;
+      if (args.out) {
+        await Bun.write(args.out, output);
+      } else {
+        stdout(output);
+      }
+
+      return 0;
+    }
+
+    // ── Normal mode ──────────────────────────────────────────────────────────
+
+    // Health check (always in normal mode)
+    const health = await checkOllamaReachable();
+    if (!health.ok) {
+      stderr(
+        `ollama serve not reachable at 127.0.0.1:11434. Start it with: ollama serve &\n(${health.error})\n`
+      );
+      return 1;
+    }
+
+    // Load cursor
+    const cursor = await loadCursor(stateDir);
+    // --since overrides cursor for this run only (cursor still advances after success)
+    const effectiveTimestamp = args.since !== undefined ? args.since : cursor.last_run_timestamp;
+
+    // Open DB
+    const dbPath = findOpenCodeDb();
+    if (!dbPath) {
+      stderr("Could not locate OpenCode SQLite database.\n");
+      return 1;
+    }
+
+    let db: Database;
+    try {
+      db = openDatabase(dbPath);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      stderr(`Failed to open database: ${msg}\n`);
+      return 1;
+    }
+
+    let selectionResult: SelectionResult;
+    try {
+      selectionResult = await selectSessions(db, effectiveTimestamp);
+    } catch (err) {
+      db.close();
+      const msg = err instanceof Error ? err.message : String(err);
+      stderr(`Failed to select sessions: ${msg}\n`);
+      return 1;
+    }
+    db.close();
+
+    const { sessions, max_processed_time_updated } = selectionResult;
+
+    // 0 sessions: no-op success
+    if (sessions.length === 0) {
+      stderr("no new sessions to distill\n");
+      const durationMs = Date.now() - startMs;
+      const record: RunRecord = {
+        ts: new Date().toISOString(),
+        ts_ms: Date.now(),
+        duration_ms: durationMs,
+        mode: "normal",
+        model: MODEL,
+        sessions_read: 0,
+        report_blocks_generated: 0,
+        report_path: "",
+        success: true,
+        errors: [],
+      };
+      await appendRunLog(logPath, record);
+      return 0;
+    }
+
+    // --extract-only: emit transcripts to stdout, skip Ollama
+    if (args.extractOnly) {
+      for (const s of sessions) {
+        stdout(`=== Session ${s.id} ===\n${s.transcript}\n\n`);
+      }
+      return 0;
+    }
+
+    // Process sessions through Ollama
+    const sessionResults: SessionResult[] = [];
+    const errors: RunError[] = [];
+
+    for (const s of sessions) {
+      const ollamaResult = await callOllama(s.transcript, MODEL);
+      if (ollamaResult.error) {
+        errors.push({ session_id: s.id, phase: "ollama", message: ollamaResult.error });
+        stderr(`Warning: Ollama error for ${s.id}: ${ollamaResult.error}\n`);
+        continue;
+      }
+      sessionResults.push({
+        sessionId: s.id,
+        title: `Session ${s.id.slice(0, 20)}`,
+        ollamaOutput: ollamaResult.output,
+      });
+    }
+
+    // Write report
+    const dateStr = new Date().toISOString().slice(0, 10);
+    const reportPath = args.out ?? join(stateDir, "reports", `${dateStr}.md`);
+
+    if (sessionResults.length > 0) {
+      await writeReport(reportPath, sessionResults);
+    }
+
+    const durationMs = Date.now() - startMs;
+    const success = errors.length === 0;
+
+    const record: RunRecord = {
+      ts: new Date().toISOString(),
+      ts_ms: Date.now(),
+      duration_ms: durationMs,
+      mode: "normal",
+      model: MODEL,
+      sessions_read: sessions.length,
+      report_blocks_generated: sessionResults.length,
+      report_path: sessionResults.length > 0 ? reportPath : "",
+      success,
+      errors,
+    };
+
+    await appendRunLog(logPath, record);
+
+    // Advance cursor (only in normal mode, only on at least partial success)
+    await saveCursor(stateDir, { last_run_timestamp: max_processed_time_updated });
+
+    return success ? 0 : 1;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    stderr(`Fatal error: ${msg}\n`);
+    return 1;
+  }
+}
+
+// ─── DB Path Discovery ────────────────────────────────────────────────────────
+
+/**
+ * Locate the OpenCode SQLite database.
+ * Checks OPENCODE_DB_PATH env first (for testability), then the default XDG location.
+ */
+function findOpenCodeDb(): string | null {
+  if (process.env.OPENCODE_DB_PATH) {
+    return process.env.OPENCODE_DB_PATH;
+  }
+  const xdgData = process.env.XDG_DATA_HOME ?? join(homedir(), ".local/share");
+  const candidate = join(xdgData, "opencode", "db.sqlite");
+  if (existsSync(candidate)) return candidate;
+  return null;
+}
+
+// ─── Entry Point ──────────────────────────────────────────────────────────────
+
+if (import.meta.main) {
+  main().then((code) => process.exit(code));
 }

--- a/.config/opencode/scripts/ollama-distill.ts
+++ b/.config/opencode/scripts/ollama-distill.ts
@@ -1,0 +1,280 @@
+#!/usr/bin/env bun
+import { Database } from "bun:sqlite";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ExtractStats = {
+  messages: number;
+  text_parts: number;
+  reasoning_parts: number;
+  skipped_parts: number;
+  skipped_types: string[];
+  transcript_chars: number;
+  truncated: boolean;
+};
+
+export type ExtractResult = {
+  transcript: string;
+  stats: ExtractStats;
+};
+
+// Envelope JSON stored in message.data
+type MessageEnvelope = {
+  role: string;
+  [key: string]: unknown;
+};
+
+// Part data JSON stored in part.data
+type PartData =
+  | { type: "text"; text: string; [key: string]: unknown }
+  | { type: "reasoning"; text: string; [key: string]: unknown }
+  | { type: string; [key: string]: unknown };
+
+// Raw row from the JOIN query
+type TranscriptRow = {
+  message_id: string;
+  message_data: string;
+  part_data: string | null;
+  part_id: string | null;
+};
+
+// ─── Custom Errors ────────────────────────────────────────────────────────────
+
+export class SchemaError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SchemaError";
+  }
+}
+
+export class ReadOnlyVerificationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReadOnlyVerificationError";
+  }
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const TRUNCATION_LIMIT = 60_000;
+const TRUNCATION_MARKER = "\n\n[... transcript truncated for context limit]";
+const BUSY_RETRY_ATTEMPTS = 3;
+const BUSY_RETRY_DELAY_MS = 100;
+
+// Expected columns per table (schema invariant)
+const EXPECTED_COLUMNS: Record<string, string[]> = {
+  session: ["id", "project_id", "parent_id", "time_created", "time_updated"],
+  message: ["id", "session_id", "time_created", "data"],
+  part: ["id", "message_id", "session_id", "time_created", "data"],
+};
+
+// ─── SQLite Reader ────────────────────────────────────────────────────────────
+
+/**
+ * Open a read-only SQLite connection with R17 hardening:
+ * - URI mode with `mode=ro`
+ * - PRAGMA query_only=ON
+ * - PRAGMA busy_timeout=5000
+ * - Read-only verification probe (CREATE TEMP TABLE must throw)
+ * - Schema invariant check (fail-closed on missing columns)
+ */
+export function openDatabase(dbPath: string): Database {
+  const uri = "file:" + dbPath + "?mode=ro";
+  const db = new Database(uri, { readonly: true });
+
+  db.exec("PRAGMA query_only=ON");
+  db.exec("PRAGMA busy_timeout=5000");
+
+  // Read-only verification probe: CREATE TEMP TABLE must throw SQLITE_READONLY.
+  // If it succeeds, the connection is not truly read-only — abort immediately.
+  try {
+    db.exec("CREATE TEMP TABLE _verify(x)");
+    db.close();
+    throw new ReadOnlyVerificationError(
+      "Read-only verification failed: CREATE TEMP TABLE succeeded — connection is not read-only"
+    );
+  } catch (err) {
+    if (err instanceof ReadOnlyVerificationError) {
+      throw err;
+    }
+    // Expected: SQLite error (SQLITE_READONLY or similar). Continue.
+  }
+
+  checkSchema(db);
+
+  return db;
+}
+
+/**
+ * Verify that all expected columns exist in each required table.
+ * Throws SchemaError (fail-closed) if any column is missing.
+ */
+function checkSchema(db: Database): void {
+  for (const [table, expectedCols] of Object.entries(EXPECTED_COLUMNS)) {
+    type TableInfoRow = { name: string };
+    const rows = db.query<TableInfoRow, []>(`PRAGMA table_info(${table})`).all();
+    const actualCols = new Set(rows.map((r) => r.name));
+
+    for (const col of expectedCols) {
+      if (!actualCols.has(col)) {
+        throw new SchemaError(
+          `Schema invariant violated: table '${table}' is missing column '${col}'`
+        );
+      }
+    }
+  }
+}
+
+// ─── Transcript Extraction ────────────────────────────────────────────────────
+
+/**
+ * Extract a role-labeled transcript from a session.
+ *
+ * SQL groups message rows with their parts via LEFT JOIN. Parts are ordered
+ * chronologically. Each text/reasoning part emits a labeled line; other types
+ * are counted as skipped. Truncates at 60K chars.
+ *
+ * Retries on SQLITE_BUSY/SQLITE_LOCKED up to 3 times with 100ms backoff.
+ */
+export async function extractTranscript(
+  db: Database,
+  sessionId: string
+): Promise<ExtractResult> {
+  const sql = `
+    SELECT
+      m.id        AS message_id,
+      m.data      AS message_data,
+      p.id        AS part_id,
+      p.data      AS part_data
+    FROM message m
+    LEFT JOIN part p ON p.message_id = m.id
+    WHERE m.session_id = ?
+    ORDER BY m.time_created ASC, p.time_created ASC, p.id ASC
+  `;
+
+  let rows: TranscriptRow[];
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < BUSY_RETRY_ATTEMPTS; attempt++) {
+    try {
+      rows = db.query<TranscriptRow, [string]>(sql).all(sessionId);
+      lastError = undefined;
+      break;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("SQLITE_BUSY") || msg.includes("SQLITE_LOCKED")) {
+        lastError = err;
+        if (attempt < BUSY_RETRY_ATTEMPTS - 1) {
+          await new Promise((r) => setTimeout(r, BUSY_RETRY_DELAY_MS));
+        }
+        continue;
+      }
+      if (msg.includes("SQLITE_SCHEMA")) {
+        throw new SchemaError(`Schema changed during query: ${msg}`);
+      }
+      throw err;
+    }
+  }
+
+  if (lastError !== undefined) {
+    throw lastError;
+  }
+
+  // rows is guaranteed assigned here (either set or lastError thrown)
+  return buildTranscript(rows!);
+}
+
+function buildTranscript(rows: TranscriptRow[]): ExtractResult {
+  const stats: ExtractStats = {
+    messages: 0,
+    text_parts: 0,
+    reasoning_parts: 0,
+    skipped_parts: 0,
+    skipped_types: [],
+    transcript_chars: 0,
+    truncated: false,
+  };
+
+  // Group rows by message_id preserving insertion order
+  const messageOrder: string[] = [];
+  const messageMap = new Map<string, { envelope: MessageEnvelope; partRows: TranscriptRow[] }>();
+
+  for (const row of rows) {
+    if (!messageMap.has(row.message_id)) {
+      messageOrder.push(row.message_id);
+
+      let envelope: MessageEnvelope;
+      try {
+        envelope = JSON.parse(row.message_data) as MessageEnvelope;
+      } catch {
+        envelope = { role: "unknown" };
+      }
+
+      messageMap.set(row.message_id, { envelope, partRows: [] });
+    }
+
+    if (row.part_id !== null) {
+      messageMap.get(row.message_id)!.partRows.push(row);
+    }
+  }
+
+  const skippedTypesSet = new Set<string>();
+  const lines: string[] = [];
+  let totalChars = 0;
+  let truncated = false;
+
+  for (const msgId of messageOrder) {
+    const { envelope, partRows } = messageMap.get(msgId)!;
+    const role = String(envelope.role ?? "unknown").toUpperCase();
+    stats.messages++;
+
+    for (const row of partRows) {
+      let partData: PartData;
+      try {
+        partData = JSON.parse(row.part_data!) as PartData;
+      } catch {
+        // Malformed JSON — skip this part
+        stats.skipped_parts++;
+        skippedTypesSet.add("malformed_json");
+        continue;
+      }
+
+      let line: string;
+      if (partData.type === "text") {
+        line = `${role}: ${(partData as { type: "text"; text: string }).text}`;
+        stats.text_parts++;
+      } else if (partData.type === "reasoning") {
+        line = `${role} [reasoning]: ${(partData as { type: "reasoning"; text: string }).text}`;
+        stats.reasoning_parts++;
+      } else {
+        stats.skipped_parts++;
+        skippedTypesSet.add(partData.type ?? "unknown");
+        continue;
+      }
+
+      const lineWithNewline = lines.length === 0 ? line : "\n" + line;
+      const newTotal = totalChars + lineWithNewline.length;
+
+      if (newTotal > TRUNCATION_LIMIT) {
+        truncated = true;
+        break;
+      }
+
+      lines.push(line);
+      totalChars = newTotal;
+    }
+
+    if (truncated) break;
+  }
+
+  let transcript = lines.join("\n");
+  if (truncated) {
+    transcript += TRUNCATION_MARKER;
+  }
+
+  stats.skipped_types = Array.from(skippedTypesSet);
+  stats.transcript_chars = transcript.length;
+  stats.truncated = truncated;
+
+  return { transcript, stats };
+}

--- a/.config/opencode/scripts/ollama-distill.ts
+++ b/.config/opencode/scripts/ollama-distill.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { Database } from "bun:sqlite";
-import { mkdirSync, renameSync, existsSync, appendFileSync } from "node:fs";
+import { mkdirSync, renameSync, existsSync, appendFileSync, openSync, closeSync, unlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 
@@ -71,6 +71,39 @@ const EXPECTED_COLUMNS: Record<string, string[]> = {
   part: ["id", "message_id", "session_id", "time_created", "data"],
 };
 
+// ─── SQLite Busy Retry Helper ─────────────────────────────────────────────────
+
+/**
+ * Wrap a synchronous SQLite call with SQLITE_BUSY/SQLITE_LOCKED retry logic.
+ * Retries up to `attempts` times with `backoffMs` delay between attempts.
+ */
+export async function withSqliteBusyRetry<T>(
+  fn: () => T,
+  attempts = BUSY_RETRY_ATTEMPTS,
+  backoffMs = BUSY_RETRY_DELAY_MS
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      return fn();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("SQLITE_BUSY") || msg.includes("SQLITE_LOCKED")) {
+        lastError = err;
+        if (attempt < attempts - 1) {
+          await new Promise((r) => setTimeout(r, backoffMs));
+        }
+        continue;
+      }
+      if (msg.includes("SQLITE_SCHEMA")) {
+        throw new SchemaError(`Schema changed during query: ${msg}`);
+      }
+      throw err;
+    }
+  }
+  throw lastError;
+}
+
 // ─── SQLite Reader ────────────────────────────────────────────────────────────
 
 /**
@@ -135,7 +168,7 @@ function checkSchema(db: Database): void {
  *
  * SQL groups message rows with their parts via LEFT JOIN. Parts are ordered
  * chronologically. Each text/reasoning part emits a labeled line; other types
- * are counted as skipped. Truncates at 60K chars.
+ * are counted as skipped. Truncates at 60K chars (keeping prefix + marker).
  *
  * Retries on SQLITE_BUSY/SQLITE_LOCKED up to 3 times with 100ms backoff.
  */
@@ -155,36 +188,51 @@ export async function extractTranscript(
     ORDER BY m.time_created ASC, p.time_created ASC, p.id ASC
   `;
 
-  let rows: TranscriptRow[];
-  let lastError: unknown;
+  const rows = await withSqliteBusyRetry(() =>
+    db.query<TranscriptRow, [string]>(sql).all(sessionId)
+  );
 
-  for (let attempt = 0; attempt < BUSY_RETRY_ATTEMPTS; attempt++) {
-    try {
-      rows = db.query<TranscriptRow, [string]>(sql).all(sessionId);
-      lastError = undefined;
-      break;
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes("SQLITE_BUSY") || msg.includes("SQLITE_LOCKED")) {
-        lastError = err;
-        if (attempt < BUSY_RETRY_ATTEMPTS - 1) {
-          await new Promise((r) => setTimeout(r, BUSY_RETRY_DELAY_MS));
-        }
-        continue;
-      }
-      if (msg.includes("SQLITE_SCHEMA")) {
-        throw new SchemaError(`Schema changed during query: ${msg}`);
-      }
-      throw err;
+  // rows is guaranteed assigned here (either set or exception thrown)
+  return buildTranscript(rows);
+}
+
+// Fix #10: Type-narrowing parse helpers for stored JSON rows
+
+/**
+ * Parse a part.data JSON string with type narrowing.
+ * Returns null on malformed JSON or unexpected shape.
+ */
+function parsePartData(raw: string): PartData | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed === "object" && parsed !== null && "type" in parsed) {
+      return parsed as PartData;
     }
+    return null;
+  } catch {
+    return null;
   }
+}
 
-  if (lastError !== undefined) {
-    throw lastError;
+/**
+ * Parse a message.data JSON string with type narrowing.
+ * Returns null on malformed JSON or missing role field.
+ */
+function parseMessageEnvelope(raw: string): MessageEnvelope | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "role" in parsed &&
+      typeof (parsed as { role: unknown }).role === "string"
+    ) {
+      return parsed as MessageEnvelope;
+    }
+    return null;
+  } catch {
+    return null;
   }
-
-  // rows is guaranteed assigned here (either set or lastError thrown)
-  return buildTranscript(rows!);
 }
 
 function buildTranscript(rows: TranscriptRow[]): ExtractResult {
@@ -206,14 +254,16 @@ function buildTranscript(rows: TranscriptRow[]): ExtractResult {
     if (!messageMap.has(row.message_id)) {
       messageOrder.push(row.message_id);
 
-      let envelope: MessageEnvelope;
-      try {
-        envelope = JSON.parse(row.message_data) as MessageEnvelope;
-      } catch {
-        envelope = { role: "unknown" };
+      // Fix #10: Use type-narrowing parse helper; skip malformed rows with warning
+      const envelope = parseMessageEnvelope(row.message_data);
+      if (envelope === null) {
+        process.stderr.write(
+          `Warning: malformed message.data for message_id=${row.message_id}, skipping\n`
+        );
+        messageMap.set(row.message_id, { envelope: { role: "unknown" }, partRows: [] });
+      } else {
+        messageMap.set(row.message_id, { envelope, partRows: [] });
       }
-
-      messageMap.set(row.message_id, { envelope, partRows: [] });
     }
 
     if (row.part_id !== null) {
@@ -232,11 +282,12 @@ function buildTranscript(rows: TranscriptRow[]): ExtractResult {
     stats.messages++;
 
     for (const row of partRows) {
-      let partData: PartData;
-      try {
-        partData = JSON.parse(row.part_data!) as PartData;
-      } catch {
-        // Malformed JSON — skip this part
+      // Fix #10: Use type-narrowing parse helper; skip malformed parts with warning
+      const partData = parsePartData(row.part_data!);
+      if (partData === null) {
+        process.stderr.write(
+          `Warning: malformed part.data for part_id=${row.part_id}, skipping\n`
+        );
         stats.skipped_parts++;
         skippedTypesSet.add("malformed_json");
         continue;
@@ -255,11 +306,18 @@ function buildTranscript(rows: TranscriptRow[]): ExtractResult {
         continue;
       }
 
+      // Fix #3: Keep prefix up to (CAP - markerLength) chars, then append marker
       const lineWithNewline = lines.length === 0 ? line : "\n" + line;
       const newTotal = totalChars + lineWithNewline.length;
 
       if (newTotal > TRUNCATION_LIMIT) {
         truncated = true;
+        // Keep as much of the current line as fits before the marker
+        const available = TRUNCATION_LIMIT - totalChars - (lines.length === 0 ? 0 : 1); // account for "\n"
+        if (available > 0) {
+          const prefix = lines.length === 0 ? line.slice(0, available) : line.slice(0, available);
+          lines.push(prefix);
+        }
         break;
       }
 
@@ -340,14 +398,17 @@ export async function selectSessions(
   const since = lastRunTimestamp ?? 0;
   const fetchCap = Math.ceil(maxSessions * 1.5);
 
-  const rows = db
-    .query<SessionRow, [number, number]>(
-      `SELECT id, time_updated FROM session
-       WHERE time_updated > ? AND parent_id IS NULL
-       ORDER BY time_updated ASC
-       LIMIT ?`
-    )
-    .all(since, fetchCap);
+  // Fix #4: Wrap session-list SELECT with SQLITE_BUSY retry helper
+  const rows = await withSqliteBusyRetry(() =>
+    db
+      .query<SessionRow, [number, number]>(
+        `SELECT id, time_updated FROM session
+         WHERE time_updated > ? AND parent_id IS NULL
+         ORDER BY time_updated ASC
+         LIMIT ?`
+      )
+      .all(since, fetchCap)
+  );
 
   const sessions: SelectedSession[] = [];
   let cumulativeBytes = 0;
@@ -468,9 +529,10 @@ export async function callOllama(
     };
   }
 
-  let body: { message?: { content?: string } };
+  // Fix #9: Parse and narrow the Ollama response shape instead of asserting
+  let rawBody: unknown;
   try {
-    body = await response.json() as typeof body;
+    rawBody = await response.json();
   } catch (err) {
     return {
       output: "",
@@ -479,7 +541,24 @@ export async function callOllama(
     };
   }
 
-  const content = body?.message?.content ?? "";
+  // Narrow: expect { message: { content: string } }
+  if (
+    typeof rawBody !== "object" ||
+    rawBody === null ||
+    !("message" in rawBody) ||
+    typeof (rawBody as { message: unknown }).message !== "object" ||
+    (rawBody as { message: unknown }).message === null ||
+    !("content" in (rawBody as { message: object }).message) ||
+    typeof ((rawBody as { message: { content: unknown } }).message.content) !== "string"
+  ) {
+    return {
+      output: "",
+      durationMs,
+      error: "malformed-response: missing message.content string in Ollama response",
+    };
+  }
+
+  const content = (rawBody as { message: { content: string } }).message.content;
   if (!content) {
     return { output: "", durationMs, error: "empty response" };
   }
@@ -495,6 +574,13 @@ export type SessionResult = {
   ollamaOutput: string;
 };
 
+// Fix #8: Atomic write helper
+async function atomicWrite(path: string, content: string): Promise<void> {
+  const tmpPath = path + ".tmp";
+  await Bun.write(tmpPath, content);
+  renameSync(tmpPath, path);
+}
+
 export async function writeReport(
   reportPath: string,
   runs: SessionResult[]
@@ -509,13 +595,14 @@ export async function writeReport(
     .map((r) => `### ${r.title} (${r.sessionId})\n\n${r.ollamaOutput}\n\n`)
     .join("");
 
+  // Fix #8: Use atomic write for report (read + concat + atomic write)
   if (existsSync(reportPath)) {
     const existing = await Bun.file(reportPath).text();
     const separator = `\n\n---\n\n## Run at ${timeStr}\n\n`;
-    await Bun.write(reportPath, existing + separator + blocks);
+    await atomicWrite(reportPath, existing + separator + blocks);
   } else {
     const header = `# Distillation Report — ${dateStr}\n\n`;
-    await Bun.write(reportPath, header + blocks);
+    await atomicWrite(reportPath, header + blocks);
   }
 }
 
@@ -555,6 +642,7 @@ export type ParsedArgs = {
   extractOnly: boolean;
   help: boolean;
   unknownFlag?: string;
+  flagError?: string;   // Fix #6: validation error for invalid flag values
 };
 
 /**
@@ -569,25 +657,78 @@ export function parseArgs(argv: string[]): ParsedArgs {
 
   const result: ParsedArgs = { extractOnly: false, help: false };
 
+  // Fix #7: Track seen flags to detect duplicates
+  const seenFlags = new Set<string>();
+
   for (const arg of args) {
+    // Fix #7: Reject positional arguments (anything not starting with --)
+    if (!arg.startsWith("--") && arg !== "-h") {
+      result.flagError = `Unexpected positional argument: '${arg}'. Use --flag=value syntax.`;
+      return result;
+    }
+
     if (arg === "--help" || arg === "-h") {
       result.help = true;
       continue;
     }
     if (arg === "--extract-only") {
+      if (seenFlags.has("--extract-only")) {
+        result.flagError = `Duplicate flag: --extract-only`;
+        return result;
+      }
+      seenFlags.add("--extract-only");
       result.extractOnly = true;
       continue;
     }
     if (arg.startsWith("--since=")) {
-      result.since = parseSince(arg.slice("--since=".length));
+      if (seenFlags.has("--since")) {
+        result.flagError = `Duplicate flag: --since`;
+        return result;
+      }
+      seenFlags.add("--since");
+      const value = arg.slice("--since=".length);
+      // Fix #7: Reject empty values
+      if (value === "") {
+        result.flagError = `Empty value for --since. Use --since=<value>.`;
+        return result;
+      }
+      // Fix #6: parseSince returns null on unparseable input
+      const parsed = parseSince(value);
+      if (parsed === null) {
+        result.flagError = `Invalid --since value: '${value}'. Accepted formats: epoch ms (e.g. 1779438773648), ISO date (e.g. 2026-05-21), relative days (e.g. 7d).`;
+        return result;
+      }
+      result.since = parsed;
       continue;
     }
     if (arg.startsWith("--session=")) {
-      result.session = arg.slice("--session=".length);
+      if (seenFlags.has("--session")) {
+        result.flagError = `Duplicate flag: --session`;
+        return result;
+      }
+      seenFlags.add("--session");
+      const value = arg.slice("--session=".length);
+      // Fix #7: Reject empty values
+      if (value === "") {
+        result.flagError = `Empty value for --session. Use --session=<id>.`;
+        return result;
+      }
+      result.session = value;
       continue;
     }
     if (arg.startsWith("--out=")) {
-      result.out = arg.slice("--out=".length);
+      if (seenFlags.has("--out")) {
+        result.flagError = `Duplicate flag: --out`;
+        return result;
+      }
+      seenFlags.add("--out");
+      const value = arg.slice("--out=".length);
+      // Fix #7: Reject empty values
+      if (value === "") {
+        result.flagError = `Empty value for --out. Use --out=<path>.`;
+        return result;
+      }
+      result.out = value;
       continue;
     }
     if (arg.startsWith("--")) {
@@ -604,8 +745,10 @@ export function parseArgs(argv: string[]): ParsedArgs {
  * - "7d", "30d" → relative days
  * - "2026-05-15" → ISO date (start of day UTC)
  * - "1747267200000" → epoch ms (>1_000_000_000_000)
+ *
+ * Fix #6: Returns null on unparseable input (instead of 0).
  */
-function parseSince(value: string): number {
+function parseSince(value: string): number | null {
   // Relative: Nd
   const relMatch = /^(\d+)d$/.exec(value);
   if (relMatch) {
@@ -625,12 +768,12 @@ function parseSince(value: string): number {
     return new Date(value + "T00:00:00.000Z").getTime();
   }
 
-  // Fallback: try Date.parse
+  // ISO datetime: try Date.parse for full ISO strings like 2026-05-21T00:00:00Z
   const parsed = Date.parse(value);
-  if (!isNaN(parsed)) return parsed;
+  if (!isNaN(parsed) && value.includes("T")) return parsed;
 
-  // Can't parse — return 0 (will select all sessions)
-  return 0;
+  // Fix #6: Can't parse — return null (caller will emit error)
+  return null;
 }
 
 // ─── CLI: Usage Text ──────────────────────────────────────────────────────────
@@ -652,11 +795,11 @@ OPTIONS:
   --help              Show this message.
 
 EXAMPLES:
-  mise run distill                          # normal run; reads cursor, writes today's report
-  mise run distill --since=7d               # backfill the last 7 days
-  mise run distill --session=ses_xxx        # debug one session, output to stdout
-  mise run distill --session=ses_xxx --out=/tmp/x.md
-  mise run distill --extract-only --session=ses_xxx  # see extracted transcript only
+  mise run distill                                          # normal run; reads cursor, writes today's report
+  mise run distill -- --since=7d                           # backfill the last 7 days
+  mise run distill -- --session=ses_xxx                    # debug one session, output to stdout
+  mise run distill -- --session=ses_xxx --out=/tmp/x.md
+  mise run distill -- --extract-only --session=ses_xxx     # see extracted transcript only
 
 OLLAMA REQUIREMENTS:
   - \`ollama serve\` must be running locally at 127.0.0.1:11434
@@ -682,6 +825,44 @@ export async function checkOllamaReachable(): Promise<{ ok: boolean; error?: str
   }
 }
 
+// ─── File Lock ────────────────────────────────────────────────────────────────
+
+/**
+ * Acquire a file-based lock using O_EXCL semantics.
+ * Returns the lock path on success, throws if already held.
+ *
+ * Fix #2: Prevents concurrent normal-mode runs.
+ */
+export function acquireLock(stateDir: string): string {
+  const lockPath = join(stateDir, ".lock");
+  mkdirSync(stateDir, { recursive: true });
+  try {
+    const fd = openSync(lockPath, "wx");
+    closeSync(fd);
+    // Write PID + timestamp as lock content
+    Bun.write(lockPath, `${process.pid}\n${new Date().toISOString()}\n`);
+    return lockPath;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("EEXIST")) {
+      throw new Error(
+        `another distill run is in progress (lock at ${lockPath}); remove it manually if stale`
+      );
+    }
+    throw err;
+  }
+}
+
+export function releaseLock(lockPath: string): void {
+  try {
+    if (existsSync(lockPath)) {
+      unlinkSync(lockPath);
+    }
+  } catch {
+    // Best-effort cleanup
+  }
+}
+
 // ─── CLI: Main Entry ──────────────────────────────────────────────────────────
 
 const MODEL = "qwen3:8b";
@@ -704,6 +885,12 @@ export async function main(
       return 0;
     }
 
+    // Fix #6/#7: Flag validation errors
+    if (args.flagError) {
+      stderr(`Error: ${args.flagError}\n\n${USAGE}`);
+      return 1;
+    }
+
     // Unknown flag
     if (args.unknownFlag) {
       stderr(`Unknown flag: ${args.unknownFlag}\n\n${USAGE}`);
@@ -715,6 +902,16 @@ export async function main(
       join(homedir(), ".local/state/ollama-distill");
 
     const logPath = join(stateDir, "runs.jsonl");
+
+    // Fix #5: finalize helper — writes JSONL record then returns exit code
+    async function finalize(record: RunRecord, exitCode: 0 | 1): Promise<number> {
+      try {
+        await appendRunLog(logPath, record);
+      } catch {
+        // Best-effort: don't mask the original error
+      }
+      return exitCode;
+    }
 
     // ── --session mode (non-mutating) ────────────────────────────────────────
     if (args.session) {
@@ -805,125 +1002,216 @@ export async function main(
 
     // ── Normal mode ──────────────────────────────────────────────────────────
 
-    // Health check (always in normal mode)
-    const health = await checkOllamaReachable();
-    if (!health.ok) {
-      stderr(
-        `ollama serve not reachable at 127.0.0.1:11434. Start it with: ollama serve &\n(${health.error})\n`
-      );
-      return 1;
-    }
-
-    // Load cursor
-    const cursor = await loadCursor(stateDir);
-    // --since overrides cursor for this run only (cursor still advances after success)
-    const effectiveTimestamp = args.since !== undefined ? args.since : cursor.last_run_timestamp;
-
-    // Open DB
-    const dbPath = findOpenCodeDb();
-    if (!dbPath) {
-      stderr("Could not locate OpenCode SQLite database.\n");
-      return 1;
-    }
-
-    let db: Database;
+    // Fix #2: Acquire file lock for normal mode
+    let lockPath: string | null = null;
     try {
-      db = openDatabase(dbPath);
+      lockPath = acquireLock(stateDir);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      stderr(`Failed to open database: ${msg}\n`);
+      stderr(`${msg}\n`);
       return 1;
     }
 
-    let selectionResult: SelectionResult;
+    // Register cleanup handlers for lock release
+    const cleanupLock = () => {
+      if (lockPath) releaseLock(lockPath);
+    };
+    process.on("exit", cleanupLock);
+    process.on("SIGINT", () => { cleanupLock(); process.exit(130); });
+    process.on("SIGTERM", () => { cleanupLock(); process.exit(143); });
+
     try {
-      selectionResult = await selectSessions(db, effectiveTimestamp);
-    } catch (err) {
+      // Health check (always in normal mode)
+      const health = await checkOllamaReachable();
+      if (!health.ok) {
+        stderr(
+          `ollama serve not reachable at 127.0.0.1:11434. Start it with: ollama serve &\n(${health.error})\n`
+        );
+        return 1;
+      }
+
+      // Load cursor
+      const cursor = await loadCursor(stateDir);
+      // --since overrides cursor for this run only (cursor still advances after success)
+      const effectiveTimestamp = args.since !== undefined ? args.since : cursor.last_run_timestamp;
+
+      // Open DB
+      const dbPath = findOpenCodeDb();
+      if (!dbPath) {
+        stderr("Could not locate OpenCode SQLite database.\n");
+        // Fix #5: Write JSONL record for early failures
+        return await finalize({
+          ts: new Date().toISOString(),
+          ts_ms: Date.now(),
+          duration_ms: Date.now() - startMs,
+          mode: "normal",
+          model: MODEL,
+          sessions_read: 0,
+          report_blocks_generated: 0,
+          report_path: "",
+          success: false,
+          errors: [{ session_id: "", phase: "db-not-found", message: "Could not locate OpenCode SQLite database" }],
+        }, 1);
+      }
+
+      let db: Database;
+      try {
+        db = openDatabase(dbPath);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        stderr(`Failed to open database: ${msg}\n`);
+        // Fix #5: Write JSONL record for DB open failure
+        return await finalize({
+          ts: new Date().toISOString(),
+          ts_ms: Date.now(),
+          duration_ms: Date.now() - startMs,
+          mode: "normal",
+          model: MODEL,
+          sessions_read: 0,
+          report_blocks_generated: 0,
+          report_path: "",
+          success: false,
+          errors: [{ session_id: "", phase: "db-open-failure", message: msg }],
+        }, 1);
+      }
+
+      let selectionResult: SelectionResult;
+      try {
+        selectionResult = await selectSessions(db, effectiveTimestamp);
+      } catch (err) {
+        db.close();
+        const msg = err instanceof Error ? err.message : String(err);
+        stderr(`Failed to select sessions: ${msg}\n`);
+        // Fix #5: Write JSONL record for session-select failure
+        const phase = err instanceof SchemaError ? "schema-invariant-violation" : "session-select-failure";
+        return await finalize({
+          ts: new Date().toISOString(),
+          ts_ms: Date.now(),
+          duration_ms: Date.now() - startMs,
+          mode: "normal",
+          model: MODEL,
+          sessions_read: 0,
+          report_blocks_generated: 0,
+          report_path: "",
+          success: false,
+          errors: [{ session_id: "", phase, message: msg }],
+        }, 1);
+      }
       db.close();
-      const msg = err instanceof Error ? err.message : String(err);
-      stderr(`Failed to select sessions: ${msg}\n`);
-      return 1;
-    }
-    db.close();
 
-    const { sessions, max_processed_time_updated } = selectionResult;
+      const { sessions } = selectionResult;
 
-    // 0 sessions: no-op success
-    if (sessions.length === 0) {
-      stderr("no new sessions to distill\n");
+      // 0 sessions: no-op success
+      if (sessions.length === 0) {
+        stderr("no new sessions to distill\n");
+        const durationMs = Date.now() - startMs;
+        const record: RunRecord = {
+          ts: new Date().toISOString(),
+          ts_ms: Date.now(),
+          duration_ms: durationMs,
+          mode: "normal",
+          model: MODEL,
+          sessions_read: 0,
+          report_blocks_generated: 0,
+          report_path: "",
+          success: true,
+          errors: [],
+        };
+        await appendRunLog(logPath, record);
+        return 0;
+      }
+
+      // --extract-only: emit transcripts to stdout, skip Ollama
+      if (args.extractOnly) {
+        for (const s of sessions) {
+          stdout(`=== Session ${s.id} ===\n${s.transcript}\n\n`);
+        }
+        return 0;
+      }
+
+      // Fix #1: Process sessions through Ollama, tracking per-session success
+      // for cursor advancement (only advance through contiguous successful prefix)
+      const sessionResults: SessionResult[] = [];
+      const errors: RunError[] = [];
+      // Track which sessions succeeded (by index, in time order)
+      const sessionSucceeded: boolean[] = [];
+
+      for (const s of sessions) {
+        // Fix #3: Truncated sessions are treated as failures for cursor purposes
+        if (s.stats.truncated) {
+          errors.push({
+            session_id: s.id,
+            phase: "truncation",
+            message: `Transcript truncated at ${TRUNCATION_LIMIT} chars; session excluded from cursor advance`,
+          });
+          stderr(`Warning: transcript truncated for ${s.id}; treating as failure for cursor\n`);
+          sessionSucceeded.push(false);
+          continue;
+        }
+
+        const ollamaResult = await callOllama(s.transcript, MODEL);
+        if (ollamaResult.error) {
+          errors.push({ session_id: s.id, phase: "ollama", message: ollamaResult.error });
+          stderr(`Warning: Ollama error for ${s.id}: ${ollamaResult.error}\n`);
+          sessionSucceeded.push(false);
+          continue;
+        }
+        sessionResults.push({
+          sessionId: s.id,
+          title: `Session ${s.id.slice(0, 20)}`,
+          ollamaOutput: ollamaResult.output,
+        });
+        sessionSucceeded.push(true);
+      }
+
+      // Fix #1: Advance cursor only through the longest contiguous successful prefix
+      // Walk sessions in time order; stop at first failure
+      let cursorAdvanceTo: number = cursor.last_run_timestamp ?? 0;
+      for (let i = 0; i < sessions.length; i++) {
+        if (sessionSucceeded[i]) {
+          cursorAdvanceTo = sessions[i].time_updated;
+        } else {
+          // First failure breaks the contiguous prefix
+          break;
+        }
+      }
+
+      // Write report
+      const dateStr = new Date().toISOString().slice(0, 10);
+      const reportPath = args.out ?? join(stateDir, "reports", `${dateStr}.md`);
+
+      if (sessionResults.length > 0) {
+        await writeReport(reportPath, sessionResults);
+      }
+
       const durationMs = Date.now() - startMs;
+      const success = errors.length === 0;
+
       const record: RunRecord = {
         ts: new Date().toISOString(),
         ts_ms: Date.now(),
         duration_ms: durationMs,
         mode: "normal",
         model: MODEL,
-        sessions_read: 0,
-        report_blocks_generated: 0,
-        report_path: "",
-        success: true,
-        errors: [],
+        sessions_read: sessions.length,
+        report_blocks_generated: sessionResults.length,
+        report_path: sessionResults.length > 0 ? reportPath : "",
+        success,
+        errors,
       };
+
       await appendRunLog(logPath, record);
-      return 0;
-    }
 
-    // --extract-only: emit transcripts to stdout, skip Ollama
-    if (args.extractOnly) {
-      for (const s of sessions) {
-        stdout(`=== Session ${s.id} ===\n${s.transcript}\n\n`);
+      // Fix #1: Advance cursor only to the end of the contiguous successful prefix
+      if (cursorAdvanceTo > (cursor.last_run_timestamp ?? 0)) {
+        await saveCursor(stateDir, { last_run_timestamp: cursorAdvanceTo });
       }
-      return 0;
+
+      return success ? 0 : 1;
+    } finally {
+      // Fix #2: Always release lock
+      if (lockPath) releaseLock(lockPath);
     }
-
-    // Process sessions through Ollama
-    const sessionResults: SessionResult[] = [];
-    const errors: RunError[] = [];
-
-    for (const s of sessions) {
-      const ollamaResult = await callOllama(s.transcript, MODEL);
-      if (ollamaResult.error) {
-        errors.push({ session_id: s.id, phase: "ollama", message: ollamaResult.error });
-        stderr(`Warning: Ollama error for ${s.id}: ${ollamaResult.error}\n`);
-        continue;
-      }
-      sessionResults.push({
-        sessionId: s.id,
-        title: `Session ${s.id.slice(0, 20)}`,
-        ollamaOutput: ollamaResult.output,
-      });
-    }
-
-    // Write report
-    const dateStr = new Date().toISOString().slice(0, 10);
-    const reportPath = args.out ?? join(stateDir, "reports", `${dateStr}.md`);
-
-    if (sessionResults.length > 0) {
-      await writeReport(reportPath, sessionResults);
-    }
-
-    const durationMs = Date.now() - startMs;
-    const success = errors.length === 0;
-
-    const record: RunRecord = {
-      ts: new Date().toISOString(),
-      ts_ms: Date.now(),
-      duration_ms: durationMs,
-      mode: "normal",
-      model: MODEL,
-      sessions_read: sessions.length,
-      report_blocks_generated: sessionResults.length,
-      report_path: sessionResults.length > 0 ? reportPath : "",
-      success,
-      errors,
-    };
-
-    await appendRunLog(logPath, record);
-
-    // Advance cursor (only in normal mode, only on at least partial success)
-    await saveCursor(stateDir, { last_run_timestamp: max_processed_time_updated });
-
-    return success ? 0 : 1;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     stderr(`Fatal error: ${msg}\n`);

--- a/.config/opencode/scripts/ollama-distill.ts
+++ b/.config/opencode/scripts/ollama-distill.ts
@@ -714,7 +714,7 @@ export async function main(
       process.env.OLLAMA_DISTILL_STATE_DIR ??
       join(homedir(), ".local/state/ollama-distill");
 
-    const logPath = join(stateDir, "run.jsonl");
+    const logPath = join(stateDir, "runs.jsonl");
 
     // ── --session mode (non-mutating) ────────────────────────────────────────
     if (args.session) {
@@ -942,7 +942,7 @@ function findOpenCodeDb(): string | null {
     return process.env.OPENCODE_DB_PATH;
   }
   const xdgData = process.env.XDG_DATA_HOME ?? join(homedir(), ".local/share");
-  const candidate = join(xdgData, "opencode", "db.sqlite");
+  const candidate = join(xdgData, "opencode", "opencode.db");
   if (existsSync(candidate)) return candidate;
   return null;
 }

--- a/.config/opencode/scripts/ollama-distill.ts
+++ b/.config/opencode/scripts/ollama-distill.ts
@@ -639,7 +639,7 @@ const USAGE = `ollama-distill — Distill recent OpenCode sessions into a Markdo
 
 USAGE:
   ollama-distill [OPTIONS]
-  mise run distill [OPTIONS]
+  mise run distill -- [OPTIONS]                # note: -- separator forwards flags through mise
 
 OPTIONS:
   --since=<value>     Recency filter override. Accepts: '7d', '2026-05-15', or epoch ms.

--- a/.config/opencode/scripts/ollama-distill.ts
+++ b/.config/opencode/scripts/ollama-distill.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
 import { Database } from "bun:sqlite";
+import { mkdirSync, renameSync, existsSync, appendFileSync } from "node:fs";
+import { dirname } from "node:path";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -277,4 +279,268 @@ function buildTranscript(rows: TranscriptRow[]): ExtractResult {
   stats.truncated = truncated;
 
   return { transcript, stats };
+}
+
+// ─── Cursor ───────────────────────────────────────────────────────────────────
+
+export type Cursor = {
+  last_run_timestamp: number | null;
+};
+
+const CURSOR_FILENAME = "cursor.json";
+const CURSOR_TMP_FILENAME = "cursor.json.tmp";
+const SEVEN_DAYS_MS = 7 * 24 * 3600 * 1000;
+
+export async function loadCursor(stateDir: string): Promise<Cursor> {
+  const cursorPath = stateDir + "/" + CURSOR_FILENAME;
+  if (existsSync(cursorPath)) {
+    try {
+      return await Bun.file(cursorPath).json() as Cursor;
+    } catch {
+      // Corrupted file — bootstrap
+    }
+  }
+  return { last_run_timestamp: Date.now() - SEVEN_DAYS_MS };
+}
+
+export async function saveCursor(stateDir: string, cursor: Cursor): Promise<void> {
+  mkdirSync(stateDir, { recursive: true });
+  const tmpPath = stateDir + "/" + CURSOR_TMP_FILENAME;
+  const finalPath = stateDir + "/" + CURSOR_FILENAME;
+  await Bun.write(tmpPath, JSON.stringify(cursor) + "\n");
+  renameSync(tmpPath, finalPath);
+}
+
+// ─── Session Selection ────────────────────────────────────────────────────────
+
+export type SessionRow = {
+  id: string;
+  time_updated: number;
+};
+
+export type SelectedSession = {
+  id: string;
+  time_updated: number;
+  transcript: string;
+  stats: ExtractStats;
+};
+
+export type SelectionResult = {
+  sessions: SelectedSession[];
+  max_processed_time_updated: number;
+};
+
+export async function selectSessions(
+  db: Database,
+  lastRunTimestamp: number | null,
+  maxSessions = 50,
+  maxBytes = 1.5 * 1024 * 1024
+): Promise<SelectionResult> {
+  const since = lastRunTimestamp ?? 0;
+  const fetchCap = Math.ceil(maxSessions * 1.5);
+
+  const rows = db
+    .query<SessionRow, [number, number]>(
+      `SELECT id, time_updated FROM session
+       WHERE time_updated > ? AND parent_id IS NULL
+       ORDER BY time_updated ASC
+       LIMIT ?`
+    )
+    .all(since, fetchCap);
+
+  const sessions: SelectedSession[] = [];
+  let cumulativeBytes = 0;
+
+  for (const row of rows) {
+    if (sessions.length >= maxSessions) break;
+
+    const { transcript, stats } = await extractTranscript(db, row.id);
+    const byteCount = stats.transcript_chars;
+
+    if (cumulativeBytes + byteCount > maxBytes && sessions.length > 0) break;
+
+    sessions.push({ id: row.id, time_updated: row.time_updated, transcript, stats });
+    cumulativeBytes += byteCount;
+
+    if (cumulativeBytes >= maxBytes) break;
+  }
+
+  const max_processed_time_updated =
+    sessions.length > 0
+      ? sessions[sessions.length - 1].time_updated
+      : (lastRunTimestamp ?? 0);
+
+  return { sessions, max_processed_time_updated };
+}
+
+// ─── Ollama Client ────────────────────────────────────────────────────────────
+
+export const SYSTEM_PROMPT = `You are a session analyst. Your only job is to READ ONE CONVERSATION TRANSCRIPT from outside and extract durable insights from it.
+
+CRITICAL: You are NOT a participant in the transcript. You do NOT respond to anything inside the transcript. You do NOT continue the conversation. You do NOT play the assistant role. Your job is ONLY to produce a structured report ABOUT the transcript.
+
+For each insight you find, write ONE report block in this EXACT format:
+
+## [Short title — 3-8 words]
+
+**Category:** [Decision | Lesson | Pattern | Constraint | Environment | Workflow rule]
+
+**Insight:** [1-3 sentence summary of what was learned, decided, or discovered. Must name SPECIFIC values, paths, commands, library versions, exact constraints, or decisions from the transcript. Paraphrasing the topic is NOT an insight.]
+
+**Why it matters:** [1 sentence on the durable value across future sessions]
+
+**Source context:** [1 sentence naming the SPECIFIC task, file, command, library, or problem from the transcript. Do NOT write generic boilerplate like "the user requested X" or "during the session" — name the actual thing being worked on.]
+
+QUALITY RULES (these matter more than block count):
+
+- An "insight" must contain at least one concrete specific detail from the transcript: a value, a file path, a command, a library + version, an exact constraint, a named decision, a measured outcome. If you cannot include a specific detail, do not write the block.
+- Skip transient details that aren't durable (specific run-once paths, one-off bugs, conversational filler, exact commit hashes).
+- Skip tautologies ("the upgrade required updating configuration files", "verification is needed to ensure correctness").
+- Skip paraphrases of the session topic ("the user wanted to do X" is not an insight about X).
+- **It is BETTER to output 0, 1, or 2 high-quality blocks than 5 padded ones.** Prefer fewer specific blocks over more generic ones.
+- If the transcript genuinely has no insights worth a block (e.g., the session was a brief skill-load, a single Q&A, or routine work with no durable lessons), output exactly: "No durable insights in this session."
+
+OUTPUT RULES:
+
+- Maximum 5 blocks per session, but NO MINIMUM. Output 0 if appropriate.
+- Use plain Markdown only.
+- START YOUR RESPONSE WITH "## " (the first character of a report-block heading) OR with "No durable insights in this session." — do not output any preamble, thinking, or meta-commentary.`;
+
+export const USER_TEMPLATE = `<transcript>
+{transcript}
+</transcript>
+
+Extract up to 5 report blocks from the transcript above. Start your response with "## ".`;
+
+const OLLAMA_URL = "http://127.0.0.1:11434/api/chat";
+const OLLAMA_TIMEOUT_MS = 300_000;
+
+export type OllamaResult = {
+  output: string;
+  durationMs: number;
+  error?: string;
+};
+
+export async function callOllama(
+  transcript: string,
+  model = "qwen3:8b"
+): Promise<OllamaResult> {
+  const start = Date.now();
+
+  const payload = {
+    model,
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: USER_TEMPLATE.replace("{transcript}", transcript) },
+    ],
+    stream: false,
+    think: false,
+    options: { temperature: 0.3, num_ctx: 32768 },
+  };
+
+  let response: Response;
+  try {
+    response = await fetch(OLLAMA_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(OLLAMA_TIMEOUT_MS),
+    });
+  } catch (err) {
+    const durationMs = Date.now() - start;
+    const msg = err instanceof Error ? err.message : String(err);
+    const isTimeout = err instanceof Error && err.name === "TimeoutError";
+    return {
+      output: "",
+      durationMs,
+      error: isTimeout ? "timeout: Ollama did not respond within 300s" : `network error: ${msg}`,
+    };
+  }
+
+  const durationMs = Date.now() - start;
+
+  if (!response.ok) {
+    return {
+      output: "",
+      durationMs,
+      error: `HTTP ${response.status}: ${response.statusText}`,
+    };
+  }
+
+  let body: { message?: { content?: string } };
+  try {
+    body = await response.json() as typeof body;
+  } catch (err) {
+    return {
+      output: "",
+      durationMs,
+      error: `failed to parse Ollama response JSON: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const content = body?.message?.content ?? "";
+  if (!content) {
+    return { output: "", durationMs, error: "empty response" };
+  }
+
+  return { output: content, durationMs };
+}
+
+// ─── Report Writer ────────────────────────────────────────────────────────────
+
+export type SessionResult = {
+  sessionId: string;
+  title: string;
+  ollamaOutput: string;
+};
+
+export async function writeReport(
+  reportPath: string,
+  runs: SessionResult[]
+): Promise<void> {
+  mkdirSync(dirname(reportPath), { recursive: true });
+
+  const now = new Date();
+  const dateStr = now.toISOString().slice(0, 10); // YYYY-MM-DD
+  const timeStr = now.toTimeString().slice(0, 5);  // HH:MM
+
+  const blocks = runs
+    .map((r) => `### ${r.title} (${r.sessionId})\n\n${r.ollamaOutput}\n\n`)
+    .join("");
+
+  if (existsSync(reportPath)) {
+    const existing = await Bun.file(reportPath).text();
+    const separator = `\n\n---\n\n## Run at ${timeStr}\n\n`;
+    await Bun.write(reportPath, existing + separator + blocks);
+  } else {
+    const header = `# Distillation Report — ${dateStr}\n\n`;
+    await Bun.write(reportPath, header + blocks);
+  }
+}
+
+// ─── JSONL Run Log ────────────────────────────────────────────────────────────
+
+export type RunError = {
+  session_id: string;
+  phase: string;
+  message: string;
+};
+
+export type RunRecord = {
+  ts: string;           // RFC 3339
+  ts_ms: number;        // epoch ms
+  duration_ms: number;
+  mode: "normal" | "session";
+  model: string;
+  sessions_read: number;
+  report_blocks_generated: number;
+  report_path: string;
+  success: boolean;
+  errors: RunError[];
+};
+
+export async function appendRunLog(logPath: string, record: RunRecord): Promise<void> {
+  mkdirSync(dirname(logPath), { recursive: true });
+  const line = JSON.stringify(record) + "\n";
+  appendFileSync(logPath, line, "utf8");
 }

--- a/.config/opencode/scripts/ollama-distill.ts
+++ b/.config/opencode/scripts/ollama-distill.ts
@@ -123,6 +123,14 @@ export function openDatabase(dbPath: string): Database {
 
   // Read-only verification probe: CREATE TEMP TABLE must throw SQLITE_READONLY.
   // If it succeeds, the connection is not truly read-only — abort immediately.
+  //
+  // This probe is bun:sqlite-specific. Standard SQLite routes TEMP tables to a
+  // separate temp file that bypasses the main-db read-only enforcement, but
+  // bun:sqlite with `{ readonly: true }` + `mode=ro` rejects TEMP writes too
+  // (verified empirically). If a future Bun release changes that, the probe
+  // will silently stop rejecting and leave the connection unverified — re-test
+  // this after Bun upgrades and consider switching to a probe that writes to
+  // a main-db table (which always honors read-only).
   try {
     db.exec("CREATE TEMP TABLE _verify(x)");
     db.close();

--- a/.dotfiles/.gitignore
+++ b/.dotfiles/.gitignore
@@ -30,6 +30,8 @@
 !/.dotfiles/docs/plans/*.md
 !/.dotfiles/docs/runbooks/
 !/.dotfiles/docs/runbooks/*.md
+!/.dotfiles/docs/solutions/
+!/.dotfiles/docs/solutions/*.md
 !/.github/
 !/.ssh/
 /.ssh/*
@@ -68,6 +70,7 @@
 **/transcripts/
 **/history.jsonl
 
-# Ollama distillation script
+# Ollama distillation pipeline
 !/.config/opencode/scripts/ollama-distill.ts
 !/.config/opencode/scripts/ollama-distill.test.ts
+!/.config/mise/tasks/distill

--- a/.dotfiles/.gitignore
+++ b/.dotfiles/.gitignore
@@ -67,3 +67,7 @@
 **/sessions/
 **/transcripts/
 **/history.jsonl
+
+# Ollama distillation script
+!/.config/opencode/scripts/ollama-distill.ts
+!/.config/opencode/scripts/ollama-distill.test.ts

--- a/.dotfiles/docs/brainstorms/2026-05-21-local-ollama-distillation-requirements.md
+++ b/.dotfiles/docs/brainstorms/2026-05-21-local-ollama-distillation-requirements.md
@@ -1,0 +1,307 @@
+---
+date: 2026-05-21
+topic: local-ollama-distillation
+---
+
+# Local Ollama Distillation Pipeline
+
+## Summary
+
+Tune the Ollama install to fit a memory-constrained M1 Pro and ship a manual-trigger distillation pipeline (v1) that condenses recent OpenCode session activity into a Markdown report Marcus reads. Local model is `qwen3:8b` (current 7-8B SOTA on Ollama, already installed). Input is OpenCode's live SQLite session store at `~/.local/share/opencode/opencode.db`, opened read-only. Output is a Markdown report. **No promotion mechanism, no `ctx_memory` integration, no Magic Context coupling** — v1 is purely a reader's tool. v1 is gated by a validation pass that confirms output is worth reading before any production pipeline code is written.
+
+---
+
+## Problem Frame
+
+Ollama has been installed on this M1 Pro for 19+ months and produces zero value today. The setup was six models totalling 34GB, with four of them stale (19 months) or oversized (`qwen3:14b` doesn't fit alongside OpenCode + Claude Code + browser on 16GB unified memory). The Electron Ollama.app auto-launched at login and kept `ollama serve` running continuously, consuming resident memory on a machine that's already pressured during normal work (~15GB used, ~175MB unused at investigation time). (Setup tuning per R1-R4 has since reclaimed 29GB of disk and removed all autostart mechanisms.)
+
+Meanwhile, OpenCode's session store at `~/.local/share/opencode/opencode.db` (SQLite, 3.7GB on this machine) holds every session, message, and tool-call part from past work. Sessions capture decisions, mistakes, recurring patterns, and reusable rules. Magic Context's historian compacts them into compartments but does not surface them as readable reports. Cross-session learnings get re-derived rather than recovered. Reusable patterns that would be useful to revisit silently stay locked in old session data.
+
+The hardware constrains the cure: local LLMs cannot become another always-on substrate. The pipeline must run opportunistically, produce reviewable artifacts, and fail without blocking primary work. v1 deliberately picks a single input stream, a single trigger, and a single output: a Markdown report. There is no promotion path back into Magic Context, no `ctx_memory` integration, no candidate-memory framing — those mechanisms require LLM tool invocations that don't fit a non-interactive pipeline and add coupling that v1 doesn't need to prove its value. Marcus reads the report, full stop. If the reports are useful, v2 can add integration. If they're not, v1 fails honestly and the work ends.
+
+---
+
+## Actors
+
+- A1. **Marcus**: Runs `mise run distill` when he wants a fresh distillation. Reads the Markdown report. That's it.
+- A2. **Distillation pipeline**: Manual-trigger process that reads OpenCode session data from SQLite, invokes Ollama, produces one Markdown report. Exits when done.
+- A3. **Ollama daemon (`ollama serve`)**: On-demand only — started by the pipeline if not running, left running for `OLLAMA_KEEP_ALIVE` seconds, then unloads the model.
+
+---
+
+## Key Flows
+
+- F1. **Validation pass (one-time, gates everything else)**
+  - **Trigger:** Marcus or planning agent runs the validation script.
+  - **Actors:** A1, A3.
+  - **Steps:**
+    1. Pick 5-10 OpenCode sessions from the SQLite store spanning short/long, recent/older, distinct projects.
+    2. Run each through `qwen3:8b` with the v1 distillation prompt.
+    3. Marcus reads the generated report blocks by hand.
+    4. Qualitative judgement: "Are these reports worth reading?" Pass = yes for the majority. Fail = no, mostly noise/hallucination.
+  - **Outcome:** Project proceeds to F2 if validation passes. Project ends or pivots (e.g., to the retrieval-first reframe in Deferred) if validation fails. No production pipeline code is written until F1 passes.
+
+- F2. **Manual distillation run**
+  - **Trigger:** Marcus runs `mise run distill` (optionally with `--since=<window>` or `--session=<ses_xxx>` flags).
+  - **Actors:** A1, A2, A3.
+  - **Steps:**
+    1. Resolve input window: sessions modified since last successful run, or per flag. Apply the per-run input cap (R7).
+    2. Skip-and-exit if no new sessions exist.
+    3. Start `ollama serve` if not running.
+    4. Invoke `qwen3:8b` per session chunk with the v1 distillation prompt.
+    5. Apply the report length cap (R12) — keep top-5 report blocks; remainder optionally summarized in an "also-ran" tail.
+    6. Write the Markdown report.
+    7. Log run metadata to `~/.local/state/ollama-distill/runs.jsonl`.
+  - **Outcome:** Marcus has a fresh report he can open and read.
+
+---
+
+## Requirements
+
+**Setup tuning (already executed in-session; documented here for record)**
+
+- R1. The Electron `Ollama.app` is removed and Ollama is installed via Homebrew formula (`brew install ollama`). No autostart at login, no `brew services start ollama`, no resident daemon. Pipeline starts `ollama serve` on-demand only.
+- R2. `OLLAMA_KEEP_ALIVE=30s` is set in `~/.config/bash/exports` so models unload soon after each pipeline run.
+- R3. Installed models pruned. `qwen3:8b` is the only blessed text model for this pipeline.
+- R4. Setup tuning reclaimed ≥ 16GB of disk in `~/.ollama/models` (actual: 29GB reclaimed; from 34GB to 4.9GB).
+
+**Validation gate (must pass before any pipeline code is written)**
+
+- R5. Before any production pipeline code is built, run F1 (the validation pass) against 5-10 representative OpenCode sessions. Marcus qualitatively scores: "Are these reports worth reading?" Pass requires a majority of the sample to be judged useful (subjective; no numeric precision threshold). The sampling rule used in F1 (recency span, project span, length span) is documented in the validation script for repeatability. If validation fails, the project either pivots (different prompt, different stream, retrieval-first reframe — see Deferred) or ends — no production pipeline build-out happens.
+
+  **Status (2026-05-21): PASSED.** Round C run produced 7/8 reports judged worth reading (87.5%). Round A baseline was 5/8; Round C iteration added quality-rule prompt patterns (drop forced 5-block min, require specific values/paths/commands in each insight, ban tautologies and topic-paraphrases). The empirical artifacts (`/tmp/r5-distill-v2.py`, `/tmp/r5-outputs-roundC/*.md`) are throwaway; planning lifts the validated prompt + invocation strategy into proper production code. Validated invocation strategy: Ollama HTTP API `/api/chat` with system + user messages, `think: false`, `temperature: 0.3`, `num_ctx: 32768`, transcript wrapped in `<transcript>...</transcript>` XML tags. Two known caveats: (a) model occasionally invents categories outside the allowed 6-label set (saw "Configuration", "Verification") — minor format violation worth tightening in production; (b) meta-work sessions (about restructuring docs) produce weaker reports because source is recursive.
+
+**Pipeline — input**
+
+- R6. v1 ingests one input stream only: OpenCode's SQLite session store at `~/.local/share/opencode/opencode.db`. Pipeline opens the DB **read-only** (`PRAGMA query_only=ON`) with WAL-aware connection settings, joins `session` + `message` + `part` tables (LEFT JOIN part on `part.message_id = message.id`), filters by `WHERE session.time_updated >= <last_run_timestamp> AND session.parent_id IS NULL`, and orders rows by `message.time_created ASC, part.time_created ASC, part.id ASC` for stable chronological traversal. The text content lives in `part.data` (NOT `message.data` — `message.data` is envelope metadata: `role`, `time`, `agent`, `model`). Per-part-type filter for v1:
+  - **Included** — `text` parts (`data.text` content) and `reasoning` parts (`data.text` content). Each emitted line is prefixed with the message role (USER:/ASSISTANT:) read from `message.data.role`.
+  - **Excluded** — `file`, `source-url`, `snapshot`, `patch` parts (binary or diff-heavy, low signal per byte) and `tool-invocation`, `subtask`, `agent`, `step-start`, `step-finish`, `compaction`, `retry` parts (structured context, deferred to v2).
+  - Subagent transcripts (sessions with `parent_id IS NOT NULL`) are deferred to v2 along with GitHub PR review history, Fro Bot daily report digests, and the excluded part types.
+  - Schema in use (verified against OpenCode v1.15.5 source via `@explorer`):
+    - `session(id, project_id, parent_id, title, agent, model, time_created, time_updated, ...)` — 21 columns total
+    - `message(id, session_id, time_created, time_updated, data TEXT)` — `data` is envelope metadata only (`role`/`time`/`agent`/`model`)
+    - `part(id, message_id, session_id, time_created, time_updated, data TEXT)` — `data.type` discriminator; text content in `data.text` for `text`/`reasoning` types
+    - Indexes used: `session_project_idx`, `session_parent_idx`, `part_session_idx` (and implicit `part.message_id` index via FK)
+- R7. Pipeline enforces a per-run input cap of **N=50 sessions OR cumulative `len(message.data) ≤ 1.5 MB`, whichever is smaller**, regardless of how many sessions match the recency filter. This protects against first-run / long-gap explosions. Excess sessions are deferred to the next run (cursor advances to the oldest unprocessed session, not to `now()`). Caps are configurable but the defaults stand for v1.
+- R8. When no new sessions exist since the last successful run AND any pending-from-overflow cursor is empty, the pipeline exits clean without invoking the model.
+- R9. Pipeline handles known SQLite read failure modes explicitly: `SQLITE_BUSY` and `SQLITE_LOCKED` are retried (3 attempts, 100ms backoff) before being logged as a skipped session; `SQLITE_SCHEMA` is treated as fatal and aborts the run with an actionable error (likely caused by OpenCode upgrade — pin and re-test). JSON decode failures in `message.data` log the offending session ID and continue with the next session.
+
+**Pipeline — model**
+
+- R10. Pipeline uses `qwen3:8b` (Q4_K_M quantization, ~5.2GB) as its sole model in v1. Model identity is the v1 default, not a permanent commitment.
+- R11. Pipeline invokes the model with `num_ctx` sized to the input batch but never exceeding 32K tokens (per `@librarian` recommendation for safe memory pressure on 16GB).
+
+**Pipeline — output**
+
+- R12. Pipeline writes one Markdown report per run to a configurable local path (default: TBD per Outstanding Question OQ2). If the file exists, the new content appends with a timestamped subheading. The report contains at most 5 report blocks (top-5 by length/specificity heuristic). Additional blocks above the cap are either summarized in an "also-ran" tail or omitted (pipeline's choice per planning). This is a readability/scannability constraint, not a safety one — there's no downstream system to protect.
+
+**Pipeline — trigger**
+
+- R13. A `mise run distill` task runs the pipeline on-demand from any shell. Accepts `--since=<window>` and `--session=<ses_xxx>` flags. **v1 has no scheduled trigger.** A launchd job is explicitly deferred to v2 pending validation that the manual-only flow produces enough value.
+
+**Reliability and observability**
+
+- R14. Each run produces a JSONL line at `~/.local/state/ollama-distill/runs.jsonl` recording: timestamp, sessions read, sessions deferred to next run (overflow), report blocks generated, report blocks included after cap, report path, duration, success/failure, error context if failed.
+- R15. Pipeline runs best-effort: failures in input collection, model invocation, or report writing log the failure to the JSONL run record and complete with whatever output was produced; the run never blocks other work on the machine.
+
+**Privacy and DB safety**
+
+- R16. No input collected by the pipeline is sent to any cloud service. All processing happens locally via Ollama.
+- R17. Pipeline never writes to `opencode.db`. SQLite connection is opened with `PRAGMA query_only=ON`; planning verifies the chosen runtime (Bun's `bun:sqlite` or Python `sqlite3`) enforces this at the connection layer and fails closed if the pragma can't be set.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R5.** Given the validation pass (F1) is run against 8 OpenCode sessions, when Marcus reads the report blocks, fewer than 5 are judged "worth reading." Validation fails. No production code is written; project is reopened to brainstorm a different prompt, different stream, or retrieval-first reframe.
+
+- AE2. **Covers R7.** Given the SQLite recency filter matches 120 sessions modified since the last successful run, when the pipeline processes them, it consumes the first 50 (per R7 cap), records the remaining 70 as "deferred to next run" in the JSONL record, and the next-run cursor advances to the timestamp of the 50th session (not to `now()`).
+
+- AE3. **Covers R8.** Given the pipeline ran successfully an hour ago, no new sessions have been modified since, and the deferred-overflow cursor from R7 is empty, when Marcus runs `mise run distill` again, the pipeline exits clean within seconds without starting `ollama serve` or invoking the model, and logs the skip to the JSONL run record.
+
+- AE4. **Covers R9, R15.** Given the model produces 12 report blocks in one run and the pipeline encounters a `SQLITE_BUSY` error on one session that doesn't resolve after 3 retries, when the pipeline completes, the report still gets written with top-5 blocks from the 2 successful sessions, the JSONL run record marks success=false with the busy-error context, and the run does not block any other work.
+
+- AE5. **Covers R12.** Given the pipeline runs against 3 sessions and the model produces 9 report blocks, when the run completes, the Markdown report contains exactly 5 blocks (top-5 per R12), and either an "also-ran" tail with the remaining 4 or no mention of them, per the planning-chosen behavior.
+
+---
+
+## Success Criteria
+
+- **Validation gate (R5) passed on 2026-05-21.** Round C run (qwen3:8b + `think=false` + system-message prompt with quality rules + `<transcript>` XML delimiters + lower temperature + output prefix priming) produced 7/8 reports judged worth reading. 100% format pass-rate. Known weakness: meta-work sessions (e.g., restructuring an AGENTS.md or other documentation) produce weaker reports because the source content itself is recursive — block insights end up paraphrasing the topic. This is acceptable for v1; future-Marcus reading a report on a meta-work session will recognize the limitation by category.
+- **Marcus runs `mise run distill` at least 5 times in the first two weeks after launch** — the manual-trigger version of "is this actually useful?"
+- **After 4 weeks, Marcus's qualitative answer to "would you keep using this?" is yes.** Subjective; no numeric proxy. This replaces the round-1/2 brainstorm's "≥5 manual promotions" success criterion, which depended on a promotion path that's been cut.
+- Total disk usage of `~/.ollama/models/` stays at or below 8GB (current: 4.9GB) after R1-R4 setup tuning.
+- No occurrence of "pipeline broke my OpenCode session" or "pipeline made the machine swap" — the on-demand-only resident-memory posture is preserved.
+- No occurrence of "pipeline wrote to opencode.db" — R17 holds.
+- Planning can proceed without inventing input source paths, output destination, model configuration, scope, or success criteria. All are pinned in this doc.
+
+---
+
+## Scope Boundaries
+
+### Deferred for later
+
+- **Integration with Magic Context (`ctx_memory`, candidate memories, promotion path).** v1 is read-only Markdown reports; no agent-tool invocations, no `ctx_memory` writes, no `CANDIDATE_*` namespace. v2 path is mechanically clean: invoke `opencode -p "<prompt that asks for a ctx_memory(action=\"write\", ...) call for this block>"` per block to promote, since OpenCode supports non-interactive prompt invocation from the CLI. v2 gate: reports prove useful AND Marcus explicitly wants the automation.
+- **Retrieval-first reframe.** The SQLite session store's rich metadata (`project_id`, `agent`, `parent_id`, `model`, `time_*`, token counts) plus FTS over `message.data` enables a different product shape: "find me the session where I solved X" instead of (or alongside) report-style distillation. Natural v2 direction AND the natural pivot if R5 validation fails. The SQLite migration that forced R6's correction makes this materially cheaper to build than the JSON-walk version would have been — worth keeping in scope as a fallback even if v1 distillation succeeds.
+- **Subagent (parent_id) traversal.** v1 reads only top-level sessions. Subagent transcripts via `session.parent_id` join are deferred to v2.
+- **Tool-call and tool-result content** from the `part` table. Excluded from v1 for byte/signal efficiency; reachable in v2 via `part_session_idx` if quality requires it.
+- **OpenCode subagent transcripts as an additional input stream.** v2 if v1 proves out.
+- **GitHub PR review history as an input stream.** v2 if v1 proves out.
+- **Fro Bot daily report digests as an input stream.** v2 if v1 proves out.
+- **Scheduled trigger (launchd nightly).** v2 if v1 manual-trigger usage proves the pattern. Defers all the operational-risk findings (battery, sleep, cold-start budget, CPU pre-conditions) along with it.
+- **Two-stage model pipeline (3-4B filter + 7-8B synthesizer).** v2 if v1 quality is empirically insufficient.
+- **Grammar-constrained decoding (xgrammar/outlines) for structured output reliability.** v2 if v1 structured-output reliability becomes a problem.
+
+### Outside this product's identity
+
+- **No web tasks.** Cloud models win decisively; not in scope.
+- **No screen reading.** Vision-model + agent-runtime + macOS permissions = trap.
+- **No file organization.** Local model tool-calling is too weak; irreversible mistakes too costly.
+- **No PR/commit message drafting.** Existing cloud-agent flow is better; this pipeline is not a writing assistant.
+- **No replacement of AFT's local ONNX embeddings.** AFT works today; switching to Ollama embeddings is a separate decision.
+- **No tool-calling, agentic behavior, or multi-turn reasoning in the model invocation.** Single-prompt, single-response per input chunk.
+- **No local model fallback for cloud-rate-limited tasks.** Two prompt profiles is double burden.
+- **No interactive chat UI on top of local models.** Not building an Ollama-WebUI substitute.
+
+---
+
+## Key Decisions
+
+- **v1 produces a Markdown report; that's all.** No promotion path, no `ctx_memory` integration, no candidate-memory framing, no Magic Context coupling. `ctx_memory` is an MCP tool callable only by an LLM inside an OpenCode/Claude session, so a CLI pipeline reaches it by spawning a one-shot `opencode -p "<prompt>"` invocation per block — mechanically clean but extra scope v1 doesn't need to prove its value. v2 layers that on if reports prove useful AND Marcus wants the automation; the design has a known shape, not a blocker.
+
+- **Pipeline reads `message.data` from OpenCode's SQLite session store, not the legacy JSON tree:** The JSON tree at `~/.local/share/opencode/storage/{session,message,part}/` was migrated to SQLite on 2026-02-18 and is no longer the canonical store. SQLite is materially easier to filter (indexed `time_updated`, single-column subagent linkage via `parent_id`) than walking JSON files would have been.
+
+- **Validation gate as Step 0 (R5):** v1 must prove output quality on 5-10 sample sessions before any production code is written. Qualitative pass/fail (subjective: "worth reading?"), not numeric precision. Earlier rounds tried 50% then 70% precision thresholds; both were arbitrary given how subjective "useful report block" is. Marcus's read of the sample is the signal.
+
+- **Per-run input cap with overflow cursor (R7):** Addresses the round-2 feasibility finding that `WHERE time_updated >= <last_run>` alone can blow up on first run or long-gap backfill. Hard cap at N=50 sessions OR 1.5MB cumulative, whichever hits first; deferred sessions roll into the next run.
+
+- **Explicit SQLite failure-mode handling (R9):** Addresses the round-2 finding that `PRAGMA query_only=ON` alone isn't a complete concurrency spec. `SQLITE_BUSY`/`SQLITE_LOCKED` retry with backoff; `SQLITE_SCHEMA` aborts as fatal (signals OpenCode upgrade); JSON decode failures continue past the affected session.
+
+- **Single input stream for v1 (R6):** OpenCode session transcripts only. Subagent, PR history, Fro Bot reports deferred to v2 to bound complexity and isolate the v1 signal-quality question.
+
+- **Manual trigger only for v1 (R13):** Defers launchd job, battery/CPU pre-conditions, sleep-wake behavior, and cold-start budget concerns to v2. Validates the workflow first; automates only if there's a workflow worth automating.
+
+- **Report length cap of 5 blocks (R12):** Readability/scannability constraint, not a memory-protection constraint (no memory to protect). Earlier rounds framed this as a "safety cap on writes"; with writes removed, it's just "the report should be readable in 2 minutes."
+
+- **Single-stage model invocation for v1, not two-stage:** Oracle proposed 3-4B-filter + 7-8B-synthesizer for best quality-per-resource. Adopting it adds pipeline complexity before the single-stage baseline has been validated. Defer until v1 quality is empirically insufficient.
+
+- **`qwen3:8b` (Q4_K_M) is the v1 default model:** `@librarian` confirmed it is the current 7-8B SOTA on Ollama as of 2026-05-21. Qwen 3.5 and 3.6 exist but skip the 7-8B size class entirely. Validation gate may discover quality requires Modelfile/prompt tuning.
+
+- **`OLLAMA_KEEP_ALIVE=30s` is non-negotiable:** Memory-pressure reality on 16GB. Default 5-minute keep-alive holds 5GB resident long after the pipeline finishes.
+
+- **Architectural posture: Ollama as `ffmpeg`, not as a substrate:** On-demand only, no always-loaded model, no Electron app, no interactive dependency. The pipeline produces a reviewable artifact and fails without blocking primary work.
+
+- **Canonical terminology: "report block".** Earlier rounds drifted between "candidate memory" / "candidate block" / "memory candidate." With the promotion concept cut, the unit is unambiguously a section in the Markdown report — "report block."
+
+---
+
+## Dependencies / Assumptions
+
+- Assumes `qwen3:8b` quality is good enough to produce report blocks worth reading on M1 Pro 16GB. **Risk acknowledged:** `@librarian` notes "moderate hallucination rate in summarization" and "moderate JSON/structured output reliability without grammar-constrained decoding." Mitigation: the validation gate (R5) catches this before any production code is written. Additional mitigation: v1 is read-only Markdown — hallucinations land in a report Marcus reads, not in a memory store, so noise is filtered at read time, not after the fact.
+
+- Assumes OpenCode's `message.data` JSON shape is stable enough across the minor versions Marcus will run during v1's life. **Risk acknowledged (round-2 finding):** the blob is unversioned; OpenCode 1.16 could change `role`, tool-call nesting, etc. Mitigation: planning pins the OpenCode version v1 is validated against (currently 1.15.5); the pipeline records the detected OpenCode version (from the binary or DB metadata) in each run's JSONL log so silent rot is detectable. If the parser hits an unrecognized shape, the affected sessions are logged as skipped (R9 JSON-decode behavior).
+
+- Assumes SQLite concurrency between OpenCode (writer) and the pipeline (reader) is well-behaved under WAL mode + `PRAGMA query_only=ON` + R9's explicit error handling. Planning verifies on real workloads during validation.
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+(None. The premise was nailed down through five review passes plus the manual-step cut.)
+
+### Deferred to Planning
+
+- **OQ1.** [Affects R12][User decision] Where should the Markdown report land? Default to a non-Obsidian markdown path like `~/notes/daily/` or `~/.local/share/ollama-distill/reports/` unless Marcus specifies an existing vault path.
+- **OQ2.** [Affects R10, R11, R5][Needs research] Does `qwen3:8b` need any specific Ollama Modelfile tuning (system prompt, stop sequences, temperature, top_p) for this pipeline's use case? Investigated as part of the validation gate (R5).
+- **OQ3.** *(Resolved during R5 prep via explorer source citation and direct SQLite probe.)* `message.data` is envelope metadata only (`role`/`time`/`agent`/`model`); text content lives in `part.data` as `data.text` for `type=text` and `type=reasoning` parts. Pipeline reads JOIN of message + part with the v1 part-type filter (R6). Planning still resolves per-runtime concerns: (a) JSON path extraction via `bun:sqlite` JSON functions vs runtime parse, and (b) graceful handling of part types not yet seen (treat as skip + log).
+- **OQ4.** [Affects R6, R17][Technical] Bun's `bun:sqlite` vs Python's `sqlite3`: which has cleaner WAL read-only semantics, JSON extraction ergonomics, and error-handling hooks for R9's `SQLITE_BUSY`/`SQLITE_LOCKED`/`SQLITE_SCHEMA` cases? Planning picks based on a small benchmark.
+- **OQ5.** [Affects R12][User decision] "Also-ran" tail in the report (showing the blocks above the top-5 cap) or omit them entirely? Planning's call after seeing example outputs.
+
+---
+
+## Pipeline shape (visual aid)
+
+```
+                          ┌─────────────────────────┐
+                          │   VALIDATION GATE (R5)  │
+                          │                         │
+                          │   Sample 5-10 sessions  │
+                          │   Run qwen3:8b prompt   │
+                          │   Marcus reads output   │
+                          │                         │
+                          │   Worth reading?        │
+                          │     yes → continue      │
+                          │     no  → stop / pivot  │
+                          └────────────┬────────────┘
+                                       │
+                            (gates everything below)
+                                       │
+                                       ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                    INPUT (read-only SQLite)                          │
+│                                                                      │
+│    ~/.local/share/opencode/opencode.db                               │
+│                                                                      │
+│    SELECT m.data, p.data FROM session s                              │
+│    JOIN message m ON m.session_id = s.id                             │
+│    LEFT JOIN part p ON p.message_id = m.id                           │
+│    WHERE s.time_updated >= <last_run_timestamp>                      │
+│      AND s.parent_id IS NULL                                         │
+│    ORDER BY m.time_created, p.time_created, p.id                     │
+│    LIMIT N=50 sessions OR 1.5MB cumulative text (R7)                 │
+│                                                                      │
+│    Filter parts: include type=text/reasoning, skip the rest          │
+│    (text content = p.data.text; m.data.role = USER/ASSISTANT label)  │
+│    PRAGMA query_only=ON; SQLITE_BUSY/LOCKED retried,                 │
+│      SQLITE_SCHEMA fatal — R9                                        │
+└────────────────────────────────┬─────────────────────────────────────┘
+                                 │
+                                 ▼
+              ┌──────────────────────────────────────────┐
+              │   DISTILLATION PIPELINE (manual only)    │
+              │                                          │
+              │   Trigger: `mise run distill`            │
+              │                                          │
+              │   1. Skip if no new input + no overflow  │
+              │   2. Start `ollama serve` (if needed)    │
+              │   3. Invoke qwen3:8b per session chunk   │
+              │   4. Apply top-5 length cap (R12)        │
+              │   5. Write Markdown report               │
+              │   6. Log run metadata to JSONL           │
+              │                                          │
+              │   NO writes to opencode.db (R17)         │
+              │   NO ctx_memory writes (no promotion)    │
+              └────────────────────┬─────────────────────┘
+                                   │
+                                   ▼
+                ┌────────────────────────────────────────┐
+                │   Markdown report                      │
+                │   (path per OQ1)                       │
+                │                                        │
+                │   ## Report (top 5 blocks)             │
+                │     - block 1                          │
+                │     - block 2                          │
+                │     - ...                              │
+                │                                        │
+                │   ## Also-ran (optional — OQ5)         │
+                │     - ...                              │
+                │                                        │
+                │   Marcus reads it. End of v1.          │
+                └────────────────────────────────────────┘
+```
+
+---
+
+## What planning still has to figure out
+
+- Report destination (OQ1).
+- Modelfile/prompt tuning during the validation gate (OQ2).
+- `message.data` JSON parser (OQ3).
+- Implementation language + SQLite runtime choice (OQ4) — `bun:sqlite` and Python `sqlite3` are the natural candidates.
+- "Also-ran" tail inclusion (OQ5).
+- The validation gate's distillation prompt itself — first deliverable.
+- Markdown report formatting: block structure, headings, source-session linkage in each block (e.g., session id + title) so Marcus can dig into the source if a block is intriguing.
+- The "length/specificity heuristic" used to pick top-5 blocks (R12).
+- OpenCode-version detection mechanism for the JSONL run log (round-2 hardening for `message.data` drift).

--- a/.dotfiles/docs/plans/2026-05-22-001-feat-local-ollama-distillation-plan.md
+++ b/.dotfiles/docs/plans/2026-05-22-001-feat-local-ollama-distillation-plan.md
@@ -1,0 +1,425 @@
+---
+title: 'feat: Add local Ollama distillation pipeline (mise run distill)'
+type: feat
+status: active
+date: 2026-05-22
+origin: docs/brainstorms/2026-05-21-local-ollama-distillation-requirements.md
+---
+
+# feat: Add local Ollama distillation pipeline (mise run distill)
+
+## Overview
+
+Implement a Bun/TypeScript CLI that reads OpenCode's SQLite session store, runs the validated `qwen3:8b` distillation prompt against recent sessions, and writes a Markdown report. Exposed as `mise run distill`. No `ctx_memory` writes; no Magic Context coupling; pipeline is strictly a reader. R5 validation gate is already passed (7/8 reports judged worth reading); this plan lifts the validated prompt + invocation strategy from the throwaway R5 script into production code.
+
+## Problem Frame
+
+OpenCode's SQLite session store at `~/.local/share/opencode/opencode.db` (3.7GB on this machine) holds every past session, message, and tool-call. The historian compacts them into compartments but doesn't surface readable reports. Cross-session learnings re-derive instead of recover. Meanwhile Ollama on this M1 Pro 16GB has been installed for 19 months producing zero value; setup tuning (R1-R4) has reclaimed 29GB of disk and removed all autostart, leaving a properly-pinned `qwen3:8b` ready for on-demand work. This pipeline gives Ollama a real job: turn recent OpenCode activity into a Markdown report Marcus reads.
+
+Origin: `docs/brainstorms/2026-05-21-local-ollama-distillation-requirements.md`
+
+## Requirements Trace
+
+- R1-R4 (origin): Setup tuning — done in-session 2026-05-21 (29GB reclaimed, no autostart, only qwen3:8b retained). This plan does not re-implement them.
+- R5 (origin): Validation gate — PASSED on 2026-05-21 (7/8 reports worth reading using qwen3:8b + system message + `think=false` + XML delims + quality rules + lower temperature). This plan lifts the validated strategy.
+- R6 (origin): Read-only SQLite ingest with role-labeled text extraction from `text`/`reasoning` parts, joined with session metadata, filtered by recency + `parent_id IS NULL`.
+- R7 (origin): Per-run input cap (50 sessions OR 1.5MB cumulative text, whichever first).
+- R8 (origin): Skip-and-exit if no new sessions since last successful run.
+- R9 (origin): Explicit SQLite failure-mode handling (`SQLITE_BUSY`/`SQLITE_LOCKED` retry, `SQLITE_SCHEMA` fatal, JSON decode failures skip session).
+- R10 (origin): `qwen3:8b` Q4_K_M is the v1 model.
+- R11 (origin): `num_ctx` ≤ 32K (validated by R5).
+- R12 (origin): Markdown report output with top-5 report-block length cap.
+- R13 (origin): Manual trigger `mise run distill` with `--since` and `--session` flags; no scheduled trigger.
+- R14 (origin): JSONL run log at `~/.local/state/ollama-distill/runs.jsonl`.
+- R15 (origin): Best-effort execution — failures log to JSONL and complete with partial output.
+- R16 (origin): No cloud egress.
+- R17 (origin): Pipeline never writes to `opencode.db`; verify read-only at connection layer.
+
+(R1-R4 already shipped; this plan covers R5-R17.)
+
+## Scope Boundaries
+
+- No `ctx_memory` writes — pipeline is read-only Markdown report output.
+- No subagent transcript ingestion (sessions with `parent_id IS NOT NULL`).
+- No `part` content beyond `type=text` and `type=reasoning`.
+- No scheduled trigger (launchd nightly). Manual only.
+- No GitHub PR / Fro Bot / additional input streams.
+- No interactive UI; CLI only.
+- No write integration with Magic Context or any agent tool.
+- No agent invocation from the pipeline. (Brainstorm's Deferred section notes `opencode -p` as a v2 path; v1 does not use it.)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **CLI utility precedent**: `.config/opencode/scripts/opencode-doctor.ts` is the canonical Bun/TS CLI utility in this repo. Pairs with companion `.config/opencode/scripts/opencode-doctor.test.ts`. Uses `#!/usr/bin/env bun` shebang, executable bit. The distill script lands at `.config/opencode/scripts/ollama-distill.ts` + companion `.test.ts`.
+- **Mise task convention**: `.config/mise/tasks/<name>` files with executable bit + shebang + `#MISE description=...` header. Auto-discovered. Distill task is `tasks/distill` (no sub-namespace).
+- **Example mise task wrapping Bun script**: `.config/mise/tasks/opencode/doctor` invokes `.config/opencode/scripts/opencode-doctor.ts` with `bun run`. Distill mirrors this.
+- **XDG state directory**: `~/.local/state/` is endorsed by AGENTS.md. No existing tool in dotfiles uses it yet but convention is established.
+- **R5 validated script (throwaway, not committed)**: `/tmp/r5-distill-v2.py` contains the validated extraction SQL, prompt, and Ollama HTTP API invocation. This plan ports the logic to Bun/TS — the script itself is not preserved.
+
+### Institutional Learnings
+
+- `docs/solutions/` does not exist in this repo. No prior solutions to inherit.
+
+### External References
+
+- Ollama HTTP API `/api/chat` reference: <https://github.com/ollama/ollama/blob/main/docs/api.md> — validated in R5 with `think: false`, `temperature: 0.3`, `num_ctx: 32768`.
+- Bun SQLite docs: <https://bun.sh/docs/api/sqlite>.
+- Qwen3 thinking-mode control: API `think: false` parameter or `--think=false` CLI flag. (Memory ID 3670.)
+
+## Key Technical Decisions
+
+- **Implementation language: Bun + TypeScript.** Mirrors `.config/opencode/scripts/opencode-doctor.ts` precedent. Bun ships `bun:sqlite` built-in, has native `fetch`, has built-in test runner.
+- **Implementation file: `.config/opencode/scripts/ollama-distill.ts`** + companion `.test.ts`. Both need allowlist entries in `.dotfiles/.gitignore`.
+- **Mise task: `.config/mise/tasks/distill`.** Thin wrapper that invokes `bun run .config/opencode/scripts/ollama-distill.ts "$@"`.
+- **State directory: `~/.local/state/ollama-distill/`** for `runs.jsonl` (run log), `cursor.json` (last-run timestamp), and `reports/YYYY-MM-DD.md` (default report path).
+- **Report destination default: `~/.local/state/ollama-distill/reports/YYYY-MM-DD.md`** (resolves brainstorm OQ1). Override via `--out=<path>` flag.
+- **No Modelfile** (resolves OQ2). Ollama HTTP API options pass `think: false`, `temperature: 0.3`, `num_ctx: 32768`.
+- **No "also-ran" tail** (resolves OQ5). R5 quality-rules prompt eliminates padding.
+- **Simplified cursor (revision-1 finding F1):** `cursor.json` stores only `{ last_run_timestamp: number | null }`. No overflow tracking — the recency filter (`WHERE session.time_updated > <last_run_timestamp>`) naturally re-surfaces any sessions not processed in the previous run. R7's per-run cap (50/1.5MB) selects a subset of matching sessions ordered ASC by `time_updated`; on success, the cursor advances to the `time_updated` of the LAST processed session (NOT to `now()`), so unprocessed sessions remain visible to the next run. No state can be silently skipped.
+- **`--session=<id>` is non-mutating (revision-1 finding F3):** When `--session` is passed, the pipeline processes exactly that session and exits. Does NOT read cursor, does NOT update cursor, does NOT write to the default daily report file. Output goes to stdout by default; pass `--out=<path>` to redirect to a file. JSONL log records the run with a `mode: "session"` field so it's distinguishable from regular runs.
+- **`--since=<value>` is a recency-filter override that does NOT mutate cursor:** Behaves the same as a regular run except `last_run_timestamp` is read from the flag rather than the cursor. Cursor still updates after success per the simplified-cursor rule. This is the correct behavior for one-off catch-ups (you may want to backfill the last 30 days without losing your normal-cadence cursor position). If a user wants to BOTH backfill AND reset the cursor, they delete `cursor.json` first.
+- **Schema-invariant check at startup (revision-1 finding F4):** Replaces the brittle hash check with explicit column-presence assertions. On open, query `PRAGMA table_info('session')`, `('message')`, `('part')` and verify expected columns exist (`session.id, project_id, parent_id, time_updated`; `message.id, session_id, time_created, data`; `part.id, message_id, message_id, time_created, data`). If ANY expected column is missing, **fail closed** with `SchemaError` and exit code 3. This is fail-closed (not warn-only) because the parser produces silent garbage on missing columns.
+- **Skip the `agent` part type** even though it carries text — structured subagent context, not user/assistant conversation text. Per brainstorm R6.
+- **Treat unknown part types as skip + log** (forward-compat). Stats hash in JSONL log reports unknown types.
+- **Read-only enforcement (R17):** open SQLite with URI mode `file:...?mode=ro` + `PRAGMA query_only=ON` + a runtime probe (`CREATE TEMP TABLE _verify(x)` must fail with SQLITE_READONLY). Belt-and-suspenders justified because R17 explicitly says "fails closed at the connection layer."
+- **Explicit `busy_timeout`:** SQLite connection sets `PRAGMA busy_timeout=5000` (5s) in addition to the per-query 3-retry / 100ms backoff. Reduces test brittleness; matches OpenCode's likely write-burst patterns.
+- **No retry on `SQLITE_SCHEMA`** (R9). Fatal because parser may produce garbage. JSONL records the error; next run succeeds after Marcus re-validates against updated OpenCode.
+- **Collapsed exit codes (revision-1 finding F8):** `0` = success (report written, all sessions processed cleanly), `1` = failure or partial failure (some sessions failed, no-ollama, schema error, anything non-success). JSONL log carries detailed cause; exit code is binary signal for "did this work or not."
+- **Compound doc deferred to its own task** (revision-1 finding F7): The brainstorm + plan + session memories already capture the institutional learnings. A compound doc duplicating them adds no signal. If a genuinely-reusable pattern emerges from implementation (e.g., a Bun/TS recipe for reading WAL SQLite from a CLI), THAT becomes the compound entry post-implementation, separate from this PR. Per the stated flow, the compound doc still lands in the same PR but as a thin entry capturing only what's net-new from implementation (likely: Bun's bun:sqlite WAL-mode behavior + read-only enforcement pattern that wasn't pre-validated by R5).
+
+## Open Questions
+
+### Resolved During Planning
+
+- OQ1 (origin: report destination): `~/.local/state/ollama-distill/reports/YYYY-MM-DD.md` default; `--out=<path>` flag for override.
+- OQ2 (origin: Modelfile tuning): No Modelfile needed; HTTP API options sufficient.
+- OQ3 (origin: message.data schema): Resolved during R5 via explorer + direct probe.
+- OQ4 (origin: Bun vs Python): Bun/TS per repo precedent.
+- OQ5 (origin: also-ran tail): Omit; R5 quality-rules prompt eliminates padding.
+
+### Deferred to Implementation
+
+- **Exact `--since` flag parsing format**: accept `7d`, `2026-05-15`, or epoch ms? Implementer picks; documented in `--help`.
+- **Exact JSONL field naming** (snake_case vs camelCase, timestamp format): plan recommends snake_case + RFC 3339 + ms epoch but implementer decides.
+- **Cursor bootstrap default on first run**: plan recommends `now() - 7d`; implementer confirms during execution.
+
+## Output Structure
+
+3 new tracked files + 1 modified file + 1 thin compound doc:
+
+```
+.dotfiles/.gitignore                                            # modified — allowlist entries added
+.config/opencode/scripts/
+  ollama-distill.ts                                             # new — Bun/TS CLI implementation
+  ollama-distill.test.ts                                        # new — Bun test runner companion
+.config/mise/tasks/
+  distill                                                       # new — mise task wrapper (executable)
+docs/solutions/
+  2026-05-22-bun-sqlite-readonly-wal-pattern.md                 # new — compound doc (post-implementation, captures the WAL/read-only pattern only)
+```
+
+State directory created at runtime (untracked):
+
+```
+~/.local/state/ollama-distill/
+  cursor.json
+  runs.jsonl
+  reports/
+    YYYY-MM-DD.md
+```
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                     mise run distill [--since X] [--session ID]     │
+│                                                                     │
+│  ↓ wraps                                                            │
+│                                                                     │
+│  bun run .config/opencode/scripts/ollama-distill.ts "$@"            │
+└────────────────────────────────────┬────────────────────────────────┘
+                                     │
+                                     ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                     ollama-distill.ts (Bun)                         │
+│                                                                     │
+│  Phase A: load cursor + parse args + Ollama health check            │
+│    ~/.local/state/ollama-distill/cursor.json                        │
+│       → { last_run_timestamp }                                      │
+│    --since overrides for the run (cursor still advances)            │
+│    --session bypasses cursor entirely (non-mutating)                │
+│    GET /api/tags → if fails, exit 1 with actionable error           │
+│                                                                     │
+│  Phase B: open SQLite (read-only, verified, schema-checked)         │
+│    file:~/.local/share/opencode/opencode.db?mode=ro                 │
+│       + PRAGMA query_only=ON                                        │
+│       + PRAGMA busy_timeout=5000                                    │
+│       + R17 probe: CREATE TEMP TABLE _verify(x) MUST fail           │
+│       + schema invariant check: expected columns must exist         │
+│         (fail-closed, exit 1, on any missing column)                │
+│                                                                     │
+│  Phase C: select sessions                                           │
+│    SELECT id, time_updated FROM session                             │
+│    WHERE time_updated > <last_run_timestamp>                        │
+│      AND parent_id IS NULL                                          │
+│    ORDER BY time_updated ASC                                        │
+│    LIMIT N=50 OR cumulative extracted text ≤ 1.5MB (R7)             │
+│                                                                     │
+│    (--session mode skips this; processes the one passed ID)         │
+│                                                                     │
+│  Phase D: per session — extract + invoke Ollama                     │
+│    extract_transcript: JOIN message + part, ORDER BY time_created   │
+│      filter parts: type IN (text, reasoning)                        │
+│      label by message.data.role (USER:/ASSISTANT:)                  │
+│      truncate at 60K chars                                          │
+│      retry on SQLITE_BUSY/LOCKED (3x, 100ms backoff)                │
+│      fail-closed on SQLITE_SCHEMA (exit 1)                          │
+│      skip session on JSON decode failure                            │
+│                                                                     │
+│    callOllama: POST /api/chat (system + user, think=false,          │
+│                temperature=0.3, num_ctx=32768)                      │
+│                                                                     │
+│  Phase E: write outputs                                             │
+│    Markdown report: ~/.local/state/ollama-distill/reports/<date>.md │
+│      (or --out path; or stdout in --session mode)                   │
+│    JSONL run log: ~/.local/state/ollama-distill/runs.jsonl          │
+│    Update cursor: last_run_timestamp = max(time_updated of          │
+│      processed sessions); ONLY in normal mode, not --session mode   │
+│                                                                     │
+│  Exit codes: 0=success, 1=any failure (JSONL has detail)            │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: SQLite reader + transcript extraction**
+
+**Goal:** Implement read-only SQLite connection with R17 hardening (URI mode + PRAGMA + temp-table probe), schema-invariant check (fail-closed on missing columns), and the role-labeled transcript-extraction function.
+
+**Requirements:** R6, R9, R17
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `.config/opencode/scripts/ollama-distill.ts` (initial: imports, types, SQLite reader module, extract function)
+- Create: `.config/opencode/scripts/ollama-distill.test.ts` (Unit 1 tests)
+- Modify: `.dotfiles/.gitignore` (allowlist `.config/opencode/scripts/ollama-distill.ts` and `.test.ts`)
+
+**Approach:**
+- Open SQLite via `new Database("file:" + dbPath + "?mode=ro", { readonly: true })` from `bun:sqlite`
+- After open: `PRAGMA query_only=ON; PRAGMA busy_timeout=5000`
+- Read-only verification probe: `CREATE TEMP TABLE _verify(x)` — MUST throw SQLITE_READONLY; if it succeeds, abort with explicit error
+- Schema invariant check: for each of `session`/`message`/`part`, query `PRAGMA table_info(<name>)` and assert expected columns exist. Expected columns (from explorer + 2026-05-21 probe): `session: id, project_id, parent_id, time_created, time_updated`; `message: id, session_id, time_created, data`; `part: id, message_id, session_id, time_created, data`. Throw `SchemaError` on any missing column; CLI catches and exits 1 with the missing-column name in the message.
+- Extract function: `extractTranscript(sessionId): { transcript: string, stats: { messages, text_parts, reasoning_parts, skipped_parts, skipped_types[], transcript_chars, truncated } }`
+- SQL: `SELECT m.id, m.data, p.data FROM message m LEFT JOIN part p ON p.message_id = m.id WHERE m.session_id = ? ORDER BY m.time_created ASC, p.time_created ASC, p.id ASC`
+- Group by message_id; parse `m.data.role` and uppercase it; per part: parse `p.data`; if `type === "text"` emit `${role}: ${data.text}`; if `type === "reasoning"` emit `${role} [reasoning]: ${data.text}`; otherwise increment skipped_parts and add to skipped_types Set
+- Truncate at 60000 chars with marker
+- SQLITE_BUSY/SQLITE_LOCKED retry: 3-attempt loop with 100ms backoff around the SELECT
+- SQLITE_SCHEMA: throw `SchemaError`; caller maps to exit 1
+
+**Patterns to follow:**
+- `.config/opencode/scripts/opencode-doctor.ts` for module/error/exit conventions
+- AGENTS.md gitignore allowlist quirk: new files may need `git add -f`
+
+**Test scenarios:**
+- **Happy path:** session with 3 messages (each with one text part) → 3 role-labeled lines in chronological order, stats correct
+- **Mixed part types:** session with text + reasoning + tool + step-start parts → only text/reasoning emit; others recorded in skipped_types
+- **Truncation:** session with >60K chars text → truncated content + marker + `stats.truncated === true`
+- **Read-only verification:** fresh DB open → `CREATE TEMP TABLE` probe throws SQLITE_READONLY
+- **Schema-missing-column:** mock or fixture DB missing `session.parent_id` → SchemaError thrown with the column name
+- **SQLite busy retry:** mock driver returns SQLITE_BUSY twice then success → returns successfully after 2 retries
+- **JSON decode failure:** part row with malformed JSON → part skipped, extract continues, stats records skipped_parts
+
+**Verification:**
+- `bun test .config/opencode/scripts/ollama-distill.test.ts` passes all Unit 1 scenarios
+- Manual cross-check: extracted transcript for a known session matches what `/tmp/r5-distill-v2.py` produced (compare against Round C R5 output for the same session)
+
+---
+
+- [ ] **Unit 2: Cursor + session selection + Ollama client + report writer**
+
+**Goal:** Implement the simplified cursor (last_run_timestamp only), session selection with R7 cap, Ollama HTTP client with validated R5 strategy, and the Markdown report writer + JSONL run log.
+
+**Requirements:** R7, R8, R10, R11, R12, R14, R15
+
+**Dependencies:** Unit 1 (uses extract function).
+
+**Files:**
+- Modify: `.config/opencode/scripts/ollama-distill.ts` (add cursor, selection, Ollama client, report/log writer modules)
+- Modify: `.config/opencode/scripts/ollama-distill.test.ts` (add Unit 2 tests with mocked fetch)
+
+**Approach:**
+- Cursor at `~/.local/state/ollama-distill/cursor.json` as `{ last_run_timestamp: number | null }` (epoch ms). File-missing bootstrap: `now() - 7d`.
+- Selection (normal mode): `SELECT id, time_updated FROM session WHERE time_updated > ? AND parent_id IS NULL ORDER BY time_updated ASC`. Iterate, call extract for byte count, stop when 50 sessions OR cumulative bytes ≥ 1.5MB. Track `max_processed_time_updated`.
+- Cursor advances on success to `max_processed_time_updated` (NOT to `now()` — unprocessed sessions remain visible next run by natural recency filter).
+- Cursor atomic-write: write to `cursor.json.tmp` + rename. Skip cursor update entirely in --session mode.
+- Ollama client: `callOllama(transcript): Promise<{ output, durationMs, error? }>`. Lifts SYSTEM_PROMPT + USER_TEMPLATE verbatim from `/tmp/r5-distill-v2.py` Round C version. POST to `http://127.0.0.1:11434/api/chat` with payload `{ model: "qwen3:8b", messages: [system, user], stream: false, think: false, options: { temperature: 0.3, num_ctx: 32768 } }`. 300s timeout via `AbortSignal.timeout(300_000)`. No retry on HTTP failure.
+- Report writer: path = `--out` flag OR `~/.local/state/ollama-distill/reports/YYYY-MM-DD.md`. Append if same-day file exists with `\n\n---\n\n## Run at HH:MM\n\n` separator. Per-session content: `### <session-title> (<session-id>)\n\n<ollama-output>\n\n`. `mkdir -p` parent dir before write.
+- JSONL log writer: append to `~/.local/state/ollama-distill/runs.jsonl`. Record per run: `{ ts, ts_ms, duration_ms, mode: "normal" | "session", model, sessions_read, report_blocks_generated, report_path, success, errors[] }`. On per-session error: append to `errors` as `{ session_id, phase, message }`. `success` mirrors process exit code (true = exit 0).
+
+**Patterns to follow:**
+- `.config/opencode/scripts/opencode-doctor.ts` module organization
+- Bun: `bun:sqlite`, `Bun.file().json()`, `Bun.write()`, `node:fs` `renameSync` for atomic write
+- AbortController/AbortSignal for fetch timeout
+
+**Test scenarios:**
+- **Cursor bootstrap:** missing file → bootstraps to `now() - 7d`
+- **Cap reached at 50 sessions:** 75 small candidates → first 50 selected, cursor advances to time_updated of 50th
+- **Cap reached at 1.5MB:** cumulative extracted text just over 1.5MB after the 7th of 10 sessions → first 7 selected
+- **Unprocessed sessions re-surface naturally:** after a capped run, the same recency-filter query at next run includes the not-yet-processed sessions (because cursor advanced only to last-processed, not to now)
+- **Atomic cursor write:** simulate kill mid-write → old cursor still valid on next read
+- **Ollama happy path:** mocked fetch returns `{ message: { content: "## Block\n..." } }` → callOllama returns correct output + duration
+- **Ollama network error:** mocked fetch throws → returns `{ output: "", error: "..." }` with non-zero duration
+- **Ollama timeout:** mocked fetch never resolves (small AbortSignal in test) → returns error "timeout"
+- **Report append behavior:** existing same-day file → new content appended with separator
+- **Partial failure:** 3 sessions, 1 Ollama call fails → report has 2 session blocks + JSONL `errors` has one entry + JSONL `success: false`
+
+**Verification:**
+- `bun test` passes all Unit 2 scenarios
+- Manual: run pipeline twice quickly → second run reports zero new sessions and exits clean
+- Manual: smoke test against 1-2 real sessions → output matches Round C R5 output within model temperature variation
+
+---
+
+- [ ] **Unit 3: CLI entry + flag parsing + Ollama health check**
+
+**Goal:** Wire all modules into a CLI with `--since`, `--session`, `--out`, `--extract-only`, `--help`. Implement Ollama health check + non-mutating `--session` semantics + fail-closed exit codes.
+
+**Requirements:** R13, R15
+
+**Dependencies:** Units 1, 2.
+
+**Files:**
+- Modify: `.config/opencode/scripts/ollama-distill.ts` (main entry + flag parser)
+- Modify: `.config/opencode/scripts/ollama-distill.test.ts` (Unit 3 tests for flag parsing + dispatch)
+
+**Approach:**
+- Simple positional + `--flag=value` parsing via `Bun.argv` (no full arg-parsing lib)
+- Flags:
+  - `--since=<value>` — recency filter override; accepts ISO date, `Nd` relative, or epoch ms. Cursor still updates after success.
+  - `--session=<id>` — non-mutating: process exactly one session; does NOT read or write cursor; output to stdout unless `--out` provided; JSONL logged with `mode: "session"`.
+  - `--out=<path>` — override report destination (or output target in --session mode).
+  - `--extract-only` — debug: print extracted transcript, skip Ollama. Does NOT update cursor.
+  - `--help` — usage.
+- Ollama health check at startup: `GET http://127.0.0.1:11434/api/tags` with 2s `AbortSignal.timeout`. On failure: stderr `"ollama serve not reachable at 127.0.0.1:11434. Start it with: ollama serve &"` + exit 1.
+- Best-effort completion (R15): main wrapped in try/catch; uncaught exceptions write a failure JSONL record and stderr message, exit 1.
+- Exit codes (collapsed per F8): `0` = clean success (report written, every session processed without error), `1` = any failure (no-ollama, schema error, partial-success with errors, fatal SQLite error). JSONL carries cause detail.
+
+**Patterns to follow:**
+- `.config/opencode/scripts/opencode-doctor.ts` for exit code + stderr conventions
+- Don't spawn `ollama serve` — user-managed lifecycle (brainstorm's "Ollama as ffmpeg")
+
+**Test scenarios:**
+- **Flag parsing happy path:** `--since=2026-05-15 --out=/tmp/r.md` → `{ since: <ms>, out: "/tmp/r.md" }`
+- **`--since` formats accepted:** `7d`, `2026-05-15`, `1747267200000` all parse correctly
+- **`--session` non-mutating:** passing `--session=ses_xxx` runs against that one session, does NOT touch cursor.json, output goes to stdout when no --out
+- **`--session` + `--out`:** output redirected to specified file, JSONL records `mode: "session"`
+- **No ollama:** mock fetch on `/api/tags` returns ECONNREFUSED → exit 1 with actionable stderr message
+- **Schema error in extract:** mock extract throws SchemaError → exit 1 + JSONL records the error
+- **Partial success:** 3 sessions, 1 fails → exit 1 (binary: any failure → non-zero) + report still written + JSONL records details
+- **Unknown flag:** `--foo=bar` → exit 1 + usage to stderr
+
+**Verification:**
+- `bun test` passes all Unit 3 scenarios
+- Manual: `bun run .config/opencode/scripts/ollama-distill.ts --help` shows usage
+- Manual: smoke test producing same outputs as `/tmp/r5-distill-v2.py` Round C against the same samples
+
+---
+
+- [ ] **Unit 4: Mise task wrapper + allowlist + compound doc**
+
+**Goal:** Expose pipeline as `mise run distill`; ensure all new files tracked; add the thin post-implementation compound doc capturing only what's net-new from implementation (the Bun/TS WAL-mode SQLite pattern).
+
+**Requirements:** R13 (mise trigger); process step (compound doc per stated flow)
+
+**Dependencies:** Unit 3 (CLI must work first); implementation must be complete to write the compound entry.
+
+**Files:**
+- Create: `.config/mise/tasks/distill` (executable Bun-wrapper task)
+- Modify: `.dotfiles/.gitignore` (add `.config/mise/tasks/distill` allowlist; verify the plan doc + ts files are also allowlisted; verify `docs/solutions/*.md`)
+- Create: `docs/solutions/2026-05-22-bun-sqlite-readonly-wal-pattern.md` (thin compound doc — only captures the Bun-specific WAL/read-only enforcement pattern that wasn't pre-validated by R5 or the brainstorm)
+
+**Approach:**
+
+Task file:
+```
+#!/usr/bin/env bash
+#MISE description="Run local Ollama distillation against recent OpenCode sessions; writes Markdown report to ~/.local/state/ollama-distill/reports/"
+#MISE dir="{{cwd}}"
+set -euo pipefail
+exec bun run "$HOME/.config/opencode/scripts/ollama-distill.ts" "$@"
+```
+
+Allowlist entries appended to `.dotfiles/.gitignore`:
+```
+!/.config/opencode/scripts/ollama-distill.ts
+!/.config/opencode/scripts/ollama-distill.test.ts
+!/.config/mise/tasks/distill
+```
+
+Verify (don't duplicate) entries for `!/.dotfiles/docs/plans/*.md` and `!/.dotfiles/docs/solutions/*.md`.
+
+Make `tasks/distill` executable: `chmod +x .config/mise/tasks/distill`.
+
+Compound doc scope (per F7): NOT a retelling of the brainstorm/plan/memories. Captures only the implementation-discovered pattern: how Bun's `bun:sqlite` honors URI mode + PRAGMA query_only against a live OpenCode WAL database, what the runtime probe pattern looks like, what `busy_timeout` value worked in practice. Approximate length: 1-2 screens. References the plan + memories rather than duplicating them.
+
+**Patterns to follow:**
+- `.config/mise/tasks/opencode/doctor` for exact wrapper-script style + header conventions
+- AGENTS.md gitignore quirk: even with allowlist entries, may need `git add -f` first commit
+- Per the `ce:compound` skill template if invoked: YAML frontmatter + Problem/Solution/Learnings sections
+
+**Test scenarios:**
+- Test expectation: none — Unit 4 is config + docs. Verification is structural.
+
+**Verification:**
+- `mise tasks ls | grep distill` shows task discovered
+- `mise tasks info distill` shows description from `#MISE` header
+- `mise run distill --help` runs wrapper successfully and prints CLI usage
+- `git --git-dir=$HOME/.dotfiles ls-files | grep -E 'ollama-distill|distill$|bun-sqlite'` shows all 4 new files tracked
+- `gitleaks protect --staged` passes on all new/modified files
+- Compound doc opens cleanly in `bat`, has YAML frontmatter, references the plan + brainstorm + relevant memory IDs
+
+## System-Wide Impact
+
+- **Interaction graph:** Pipeline is a leaf process. Reads opencode.db (one of multiple concurrent readers). Writes to a dedicated state directory it owns exclusively. No interaction with Magic Context, AFT, or any other plugin.
+- **Error propagation:** All errors land in JSONL run log + non-zero exit code. No errors propagate elsewhere.
+- **State lifecycle risks:** Cursor.json atomic-write protects against kill-mid-write corruption. Reports/JSONL are append-only.
+- **API surface parity:** N/A — no API consumers; CLI flags are the only surface, `--help` is the doc.
+- **Integration coverage:** No cross-layer integrations; unit tests + Unit 3 smoke-test verification suffice.
+- **Unchanged invariants:**
+  - OpenCode session store schema (R17 + Unit 1 read-only verification + schema-invariant check ensures detect + fail-closed)
+  - Shell environment (adds one mise task, doesn't modify existing)
+  - Magic Context, AFT, OpenCode plugins (no shared state; SQLite WAL coexists with OpenCode's writer by design)
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| OpenCode upgrades `message.data` / `part.data` JSON shape; parser silently produces garbage | Schema-invariant check fails closed on missing columns (Unit 1). Per-session JSON decode failures skip the affected session (R9). If new part types appear, they're logged in stats as unknown skipped_types — visible in JSONL. |
+| SQLite WAL checkpoint or busy-write during pipeline run | `PRAGMA busy_timeout=5000` at connection + per-query SQLITE_BUSY/LOCKED retry (3x, 100ms backoff). Transcript SELECT is one quick query per session; not a long transaction. |
+| `qwen3:8b` quality regresses on real-world sessions vs R5 sample | Re-validation pattern from R5 is preserved. Marcus can re-run `/tmp/r5-distill-v2.py` (throwaway, recoverable from git history if archived) against fresh samples. Brainstorm's Deferred section names retrieval-first as the persistent-failure pivot. |
+| Bun version drift breaks `bun:sqlite` or `Bun.write` API surface (revision-1 F11 partial) | Pipeline is small enough to repair; Bun API stability across minor versions is generally good. If breakage happens, it surfaces immediately (test suite). No production deploy → no urgency. |
+| Append-only daily reports + JSONL grow unbounded (revision-1 F10) | Acceptable for v1. Daily report ~5-50KB even with 5 runs/day; 1 year of daily runs <50MB total state. If becomes a problem in v2: add `--rollover` flag or `--max-runs-per-day` cap. |
+| Concurrent OpenCode writer + pipeline reader produces inconsistent state across queries (revision-1 F11 partial) | Each query is its own statement; no multi-query transactions in v1 pipeline. WAL mode (which Bun's bun:sqlite supports) means readers see a snapshot at statement boundary. Different sessions' data may be from slightly different OpenCode write states but each session's own messages+parts are atomic. Acceptable for "distill the last few sessions" use case. |
+| State directory missing on first run | `mkdir -p` before write. |
+
+## Documentation / Operational Notes
+
+- **README**: None planned for v1. Mise task description + `--help` output are the doc surface.
+- **Compound doc** (Unit 4) captures the WAL/read-only pattern only.
+- **No rollout, no monitoring, no migration** — local-only tool, single user.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-21-local-ollama-distillation-requirements.md](../brainstorms/2026-05-21-local-ollama-distillation-requirements.md)
+- **R5 validated script (throwaway):** `/tmp/r5-distill-v2.py`
+- **R5 outputs (throwaway):** `/tmp/r5-outputs-roundC/*.md`
+- **Existing CLI utility precedent:** `.config/opencode/scripts/opencode-doctor.ts` + `.test.ts`
+- **Existing mise task wrapper precedent:** `.config/mise/tasks/opencode/doctor`
+- **Bun SQLite API:** <https://bun.sh/docs/api/sqlite>
+- **Ollama HTTP API:** <https://github.com/ollama/ollama/blob/main/docs/api.md>
+- **Memory IDs from this session:** 3666 (orchestrator discipline), 3667-3668 (OpenCode SQLite schema + part types), 3670 (qwen3 think=false), 3671 (8B attention degradation + mitigations), 3673 (Ollama install posture), 3675 (read truncation artifacts before claiming about content), 3682 (dotfiles bare-repo docs/ path convention)

--- a/.dotfiles/docs/solutions/2026-05-22-bun-sqlite-readonly-wal-pattern.md
+++ b/.dotfiles/docs/solutions/2026-05-22-bun-sqlite-readonly-wal-pattern.md
@@ -1,0 +1,121 @@
+---
+date: 2026-05-22
+category: pattern
+tags: [bun, sqlite, wal, read-only, opencode]
+problem-area: reading a live WAL SQLite database from a Bun CLI without disturbing the writer
+---
+
+# Bun bun:sqlite read-only pattern for live WAL databases
+
+## Problem
+
+A Bun/TypeScript CLI needs to read OpenCode's live SQLite session store (`~/.local/share/opencode/opencode.db`, ~3.7GB, actively written by the OpenCode process via WAL mode). The CLI must:
+
+1. Never write to the database (zero risk of corrupting OpenCode's state)
+2. Not block OpenCode's writer with long-held locks
+3. Handle the case where OpenCode commits a schema migration while the CLI holds a connection
+4. Survive transient SQLITE_BUSY / SQLITE_LOCKED returns during WAL checkpoints or short writer transactions
+
+Standard SQLite "open read-only" guidance is the URI mode (`file:path?mode=ro`) OR `PRAGMA query_only=ON`. Neither alone is sufficient for a connection that lives across multiple queries against a heavily-active writer.
+
+## Solution
+
+Defense-in-depth read-only enforcement, verified empirically at startup:
+
+```ts
+import { Database } from "bun:sqlite"
+
+function openReadOnly(dbPath: string): Database {
+  // 1. URI mode + readonly option (the real guard — bun:sqlite honors both)
+  const db = new Database(`file:${dbPath}?mode=ro`, { readonly: true })
+
+  // 2. PRAGMA query_only as belt-and-suspenders (per-connection;
+  //    enforced by the SQLite library, not the OS file mode)
+  db.exec("PRAGMA query_only=ON")
+
+  // 3. Tunable busy_timeout (5s) so transient WAL checkpoints
+  //    don't surface as immediate SQLITE_BUSY errors
+  db.exec("PRAGMA busy_timeout=5000")
+
+  // 4. Runtime probe — verify read-only is *actually* active.
+  //    Without this, a misconfigured connection silently allows writes.
+  try {
+    db.exec("CREATE TEMP TABLE _verify_readonly (x INTEGER)")
+    db.exec("DROP TABLE _verify_readonly")
+    db.close()
+    throw new Error("Read-only enforcement failed: connection accepts writes.")
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("Read-only enforcement failed")) {
+      throw err
+    }
+    // Expected: CREATE TEMP TABLE rejected because the connection is read-only.
+  }
+
+  return db
+}
+```
+
+Pair the read-only enforcement with a schema-invariant check for fail-closed behavior when OpenCode upgrades:
+
+```ts
+function assertSchemaInvariants(db: Database): void {
+  const expected = {
+    session: ["id", "project_id", "parent_id", "time_created", "time_updated"],
+    message: ["id", "session_id", "time_created", "data"],
+    part:    ["id", "message_id", "session_id", "time_created", "data"],
+  }
+  for (const [table, columns] of Object.entries(expected)) {
+    const cols = db.query(`PRAGMA table_info(${table})`).all() as { name: string }[]
+    const names = new Set(cols.map((c) => c.name))
+    const missing = columns.filter((c) => !names.has(c))
+    if (missing.length > 0) {
+      throw new SchemaError(
+        `${table} missing columns: ${missing.join(", ")}. ` +
+        `OpenCode may have upgraded; re-validate the schema.`,
+      )
+    }
+  }
+}
+```
+
+Per-query retry on SQLITE_BUSY / SQLITE_LOCKED:
+
+```ts
+function withBusyRetry<T>(fn: () => T, attempts = 3, backoffMs = 100): T {
+  let lastErr: unknown
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return fn()
+    } catch (err) {
+      lastErr = err
+      const msg = err instanceof Error ? err.message : String(err)
+      if (!msg.includes("SQLITE_BUSY") && !msg.includes("SQLITE_LOCKED")) {
+        throw err
+      }
+      if (i < attempts - 1) Bun.sleepSync(backoffMs)
+    }
+  }
+  throw lastErr
+}
+```
+
+## What this does not protect against
+
+- **SQLITE_SCHEMA mid-run.** If OpenCode commits a schema migration between two queries, you'll see SQLITE_SCHEMA on the next prepare. Treat as fatal: a parser tuned for the old schema may produce garbage from new-shape rows. Exit and require re-validation. Do not retry.
+- **Schema additions** (new tables, new columns). The invariant check above asserts *minimum* columns. New optional columns won't break the check or the parser. This is the desired posture — forward-compat for additions.
+- **Whole-DB corruption.** Out of scope.
+
+## Why this matters
+
+OpenCode is a long-running process that holds the SQLite handle and writes continuously. A naive reader CLI that opens writable and runs a query is technically safe (writes nothing) but doesn't *prove* it. The runtime probe converts a per-connection invariant into a per-startup assertion, so we fail closed on the day someone copies this pattern and forgets `{ readonly: true }`.
+
+The `busy_timeout` + per-query retry combination handles the realistic failure mode where OpenCode is mid-transaction or the WAL is being checkpointed.
+
+## References
+
+- Origin plan: `docs/plans/2026-05-22-001-feat-local-ollama-distillation-plan.md`
+- Brainstorm: `docs/brainstorms/2026-05-21-local-ollama-distillation-requirements.md`
+- Implementation: `.config/opencode/scripts/ollama-distill.ts`
+- Tests: `.config/opencode/scripts/ollama-distill.test.ts` (read-only verification, schema-missing-column, SQLITE_BUSY retry scenarios)
+- Bun SQLite docs: <https://bun.sh/docs/api/sqlite>
+- Magic Context memories: 3667 (OpenCode SQLite schema), 3668 (part types + canonical SQL)


### PR DESCRIPTION
## Why

OpenCode keeps every session I've ever had in a local SQLite store (3.7GB and growing). Some of it is durable knowledge — decisions, constraints, hard-won workflow rules. Most of it is filler. Reading old sessions to extract the durable bits doesn't scale, and saving to memory only happens when I notice in-the-moment that something's worth keeping.

This PR adds `mise run distill`: a manual-trigger CLI that reads sessions from the live SQLite store (read-only, no risk to OpenCode's state) and runs them through local `qwen3:8b` via Ollama to produce Markdown report blocks I can read at my own pace. Single human gate on the output. Zero cloud. No automatic memory writes.

## What

A new Bun/TypeScript CLI at `.config/opencode/scripts/ollama-distill.ts`, wrapped by `.config/mise/tasks/distill`. The pipeline:

1. Opens `~/.local/share/opencode/opencode.db` read-only (URI mode + `PRAGMA query_only=ON` + a runtime TEMP TABLE write probe + `busy_timeout=5000`).
2. Asserts schema invariants on `session`, `message`, `part` tables. Fails closed if OpenCode ever changes shape underneath.
3. Selects sessions updated since the last cursor timestamp; extracts role-labeled text from `text` and `reasoning` part rows; caps input at 60K chars per session.
4. Sends each transcript to `qwen3:8b` via Ollama `/api/chat` with `think: false`, `temperature: 0.3`, `num_ctx: 32768`.
5. Writes a Markdown report under `~/.local/state/ollama-distill/reports/YYYY-MM-DD.md`, appends a JSONL run record under `runs.jsonl`, and advances the cursor only through the longest contiguous run of successful sessions.

## How it survives OpenCode upgrades

OpenCode migrated its session store from JSON to SQLite in February 2026. The implementation treats `opencode.db`'s schema as a versioned external contract:

- Defense-in-depth read-only enforcement (four layers, documented in [`docs/solutions/2026-05-22-bun-sqlite-readonly-wal-pattern.md`](docs/solutions/2026-05-22-bun-sqlite-readonly-wal-pattern.md))
- Schema-invariant check on table+column presence at startup; fails closed on missing columns
- `SQLITE_BUSY` / `SQLITE_LOCKED` retry with 3 attempts + 100ms backoff, applied to both transcript extraction and the upstream session-list query
- `SQLITE_SCHEMA` mid-run treated as fatal — a parser tuned for the old shape may produce garbage from the new shape
- Malformed JSON in `message.data` / `part.data` rows skipped with a stderr warning, not crashed

## How it survives partial failures

If session 1 succeeds and session 2 fails Ollama (network blip, model hung, malformed response), the cursor stops at session 1's `time_updated` and session 2 stays in scope for the next run. A file-based lock at `~/.local/state/ollama-distill/.lock` prevents concurrent normal-mode runs from clobbering each other. Daily reports are written atomically (temp + rename). Every failure path — DB-not-found, schema-invariant-violation, session-select-error, Ollama-unreachable — writes a JSONL record with `success: false` and a phase-typed error entry.

## Demo

```
$ mise run distill -- --session=ses_xxxxx --out=/tmp/smoke.md
[distill] $ ~/.config/mise/tasks/distill --session=ses_xxxxx --out=/tmp/smoke.md

$ cat /tmp/smoke.md
### Session ses_xxxxx

## Review Agent Configuration Handling

**Category:** Decision
**Insight:** The `ce:review` tool automatically handles agent selection without needing project-specific configuration.
**Why it matters:** This reduces the need for manual configuration and streamlines the setup process.
**Source context:** The `setup` skill's instructions for handling review agent configuration.

## Project-Specific Context Placement

**Category:** Constraint
**Insight:** Project-specific review context, such as performance metrics or code quality rules, should be placed in the project's AGENTS.md file.
**Why it matters:** It ensures that all agents have access to the necessary context for effective review.
**Source context:** The `setup` skill's instructions for handling review agent configuration.

$ tail -1 ~/.local/state/ollama-distill/runs.jsonl | jq .
{
  "ts": "2026-05-22T18:27:27.408Z",
  "duration_ms": 22405,
  "mode": "session",
  "model": "qwen3:8b",
  "sessions_read": 1,
  "report_blocks_generated": 1,
  "report_path": "/tmp/smoke.md",
  "success": true,
  "errors": []
}
```

## Tests

65 tests in `.config/opencode/scripts/ollama-distill.test.ts` covering: SQLite read-only enforcement (TEMP TABLE probe, schema invariants, busy retry, malformed-row skip), cursor partial-failure semantics, concurrency lock acquisition, truncation prefix-preservation, atomic report writes, flag parser hardening (positional / empty / duplicate rejection, unparseable `--since`), Ollama response narrowing, and the JSONL log contract across all failure modes. End-to-end smoke against real Ollama confirms the production path including lock cleanup.

## Setup tuning

Bundled because it's part of getting Ollama into a posture this pipeline can rely on:

- Removed `/Library/LaunchDaemons/ollama.plist` (was binding `0.0.0.0:11434` system-wide).
- Replaced the Electron `ollama-app` cask with the formula-only `ollama` (CLI-only, no menu bar, no autostart). On-demand `ollama serve` only.
- `OLLAMA_KEEP_ALIVE=30s` added to `.config/bash/exports` so the model unloads from memory shortly after a batch.
- Pruned 5 unused models (`qwen3:14b`, `llama3.1:latest`, `llama3.2:latest`, two vision variants). Only `qwen3:8b` (5.2GB) remains. Disk reclaimed 34GB → 4.9GB.

## Scope boundaries

Out of scope here, deferred until observed utility justifies the complexity:

- Automated promotion of report blocks to durable memory.
- Subagent transcript traversal (`parent_id` walking).
- Multi-day rollup reports.
- Full-text search over `message.data` for "find me the session where I solved X".

Permanently out of scope:

- Writing to `opencode.db` under any circumstance.
- Cloud LLM calls.
- Cross-machine sync.
- Scheduled runs (cron, launchd, GitHub Actions).

## Manual setup after merge

None. Mise auto-discovers the task. `ollama` is already installed via the formula. `qwen3:8b` is already pulled. `OLLAMA_KEEP_ALIVE` takes effect on next shell.

Usage:
- `mise run distill -- --session=<id> --out=/tmp/x.md` for a one-off debug run.
- `mise run distill` for a normal run (reads the cursor, writes to today's report).