### PR TITLE
fix(ollama-distill): filter ephemeral sessions, bootstrap cursor

### DIFF
--- a/.config/opencode/scripts/ollama-distill.test.ts
+++ b/.config/opencode/scripts/ollama-distill.test.ts
@@ -159,12 +159,12 @@ describe("extractTranscript", () => {
 
   // ─── Test 3: Truncation ─────────────────────────────────────────────────────
 
-  test("truncation: content exceeding 60K chars is truncated with marker", async () => {
+  test("truncation: content exceeding 120K chars is truncated with marker", async () => {
     const db = createFixtureDb();
     const sid = "sess-3";
 
-    // Create a message with text that exceeds 60K chars
-    const bigText = "x".repeat(61_000);
+    // Create a message with text that exceeds 120K chars
+    const bigText = "x".repeat(121_000);
     const m1 = insertMessage(db, sid, "user", 1000, "msg-1");
     insertPart(db, m1, sid, "text", bigText, 1001, "p-1");
 
@@ -180,11 +180,11 @@ describe("extractTranscript", () => {
 
   // ─── Test 3b: Fix #3 — Truncation keeps prefix ─────────────────────────────
 
-  test("Fix #3: single 100K-char part yields prefix + marker (not just marker)", async () => {
+  test("Fix #3: single 200K-char part yields prefix + marker (not just marker)", async () => {
     const db = createFixtureDb();
     const sid = "sess-3b";
 
-    const bigText = "A".repeat(100_000);
+    const bigText = "A".repeat(200_000);
     const m1 = insertMessage(db, sid, "user", 1000, "msg-1");
     insertPart(db, m1, sid, "text", bigText, 1001, "p-1");
 
@@ -195,8 +195,8 @@ describe("extractTranscript", () => {
     // Should have substantial prefix content (not just the marker)
     const markerIdx = transcript.indexOf("[... transcript truncated for context limit]");
     expect(markerIdx).toBeGreaterThan(1000); // at least 1000 chars of original content
-    // Total length should be close to 60K (not 100K)
-    expect(transcript.length).toBeLessThanOrEqual(60_100); // 60K + marker length
+    // Total length should be close to 120K (not 200K)
+    expect(transcript.length).toBeLessThanOrEqual(120_100); // 120K + marker length
 
     db.close();
   });
@@ -585,6 +585,48 @@ describe("selectSessions", () => {
     const result = await selectSessions(db, 5000, 50);
     expect(result.sessions.length).toBe(0);
     expect(result.max_processed_time_updated).toBe(5000);
+    db.close();
+  });
+
+  test("project_id filter: sessions with project_id='global' are excluded", async () => {
+    const db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE session (
+        id TEXT PRIMARY KEY,
+        project_id TEXT,
+        parent_id TEXT,
+        time_created INTEGER,
+        time_updated INTEGER
+      );
+      CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+      CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+    `);
+
+    // Insert 3 sessions: one global (should be excluded), two real project sessions
+    for (const [id, projectId, timeUpdated] of [
+      ["sess-global", "global", 1001],
+      ["sess-abc123", "abc123", 1002],
+      ["sess-def456", "def456", 1003],
+    ] as [string, string, number][]) {
+      db.run(
+        "INSERT INTO session (id, project_id, parent_id, time_created, time_updated) VALUES (?, ?, NULL, ?, ?)",
+        [id, projectId, timeUpdated, timeUpdated]
+      );
+      const msgId = id + "-msg";
+      db.run("INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)", [
+        msgId, id, timeUpdated, JSON.stringify({ role: "user" }),
+      ]);
+      db.run("INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?, ?, ?, ?, ?)", [
+        id + "-part", msgId, id, timeUpdated, JSON.stringify({ type: "text", text: "hello" }),
+      ]);
+    }
+
+    const result = await selectSessions(db, 0, 50);
+    expect(result.sessions.length).toBe(2);
+    const ids = result.sessions.map((s) => s.id);
+    expect(ids).toContain("sess-abc123");
+    expect(ids).toContain("sess-def456");
+    expect(ids).not.toContain("sess-global");
     db.close();
   });
 });
@@ -1153,6 +1195,61 @@ describe("main", () => {
     }
   });
 
+  test("Fix #2 cursor floor: no cursor + all sessions fail → cursor.json written at bootstrap floor", async () => {
+    const stateDir = join(tmpdir(), "distill-test-floor-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-test-floor-" + Math.random().toString(36).slice(2) + ".db");
+    const runStart = Date.now();
+    const now = runStart;
+    createFileDb(dbPath, [
+      { id: "ses_fl1", timeUpdated: now - 5 * 24 * 3600 * 1000, text: "session one" },
+      { id: "ses_fl2", timeUpdated: now - 4 * 24 * 3600 * 1000, text: "session two" },
+    ]);
+
+    // No cursor file exists — bootstrap default is 7 days ago
+    globalThis.fetch = async (url: string | URL | Request, _init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : (url as Request).url;
+      if (urlStr.includes("/api/tags")) {
+        return new Response(JSON.stringify({ models: [] }), { status: 200 });
+      }
+      if (urlStr.includes("/api/chat")) {
+        return new Response("Internal Server Error", { status: 500, statusText: "Internal Server Error" });
+      }
+      throw new Error(`Unexpected URL: ${urlStr}`);
+    };
+
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(["bun", "script.ts"], () => {}, () => {});
+      expect(code).toBe(1); // all failed → non-zero exit
+
+      // (a) cursor.json must be written even though zero sessions succeeded
+      const cursorPath = join(stateDir, "cursor.json");
+      expect(existsSync(cursorPath)).toBe(true);
+
+      // (b) its last_run_timestamp equals the bootstrap floor (7 days ago ± 5s tolerance)
+      const cursor = JSON.parse(readFileSync(cursorPath, "utf8"));
+      const sevenDaysMs = 7 * 24 * 3600 * 1000;
+      const expectedFloor = runStart - sevenDaysMs;
+      expect(cursor.last_run_timestamp).toBeGreaterThanOrEqual(expectedFloor - 5000);
+      expect(cursor.last_run_timestamp).toBeLessThanOrEqual(expectedFloor + 5000);
+
+      // (c) a second run reads that cursor and uses it as the recency window start
+      //     (i.e., sessions from before the floor are not re-selected)
+      //     We verify by checking the cursor value is used: insert a session older than
+      //     the floor and confirm it would not be selected on next run.
+      //     Simplest proxy: the cursor timestamp is close to 7d ago, not 0 or "now".
+      expect(cursor.last_run_timestamp).toBeGreaterThan(runStart - sevenDaysMs - 10_000);
+      expect(cursor.last_run_timestamp).toBeLessThan(runStart - sevenDaysMs + 10_000);
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+
   test("partial success: 2nd Ollama call fails → returns 1, JSONL errors has 1 entry", async () => {
     const stateDir = join(tmpdir(), "distill-test-partial-" + Math.random().toString(36).slice(2));
     const dbPath = join(tmpdir(), "distill-test-partial-" + Math.random().toString(36).slice(2) + ".db");
@@ -1285,7 +1382,7 @@ describe("main", () => {
     }
   });
 
-  test("Fix #1: first session fails → cursor does not advance at all", async () => {
+  test("Fix #1: first session fails → cursor written at window floor (not advanced)", async () => {
     const stateDir = join(tmpdir(), "distill-test-cursor-fix1b-" + Math.random().toString(36).slice(2));
     const dbPath = join(tmpdir(), "distill-test-cursor-fix1b-" + Math.random().toString(36).slice(2) + ".db");
     const now = Date.now();
@@ -1297,7 +1394,7 @@ describe("main", () => {
       { id: "ses_f2", timeUpdated: s2Time, text: "session two" },
     ]);
 
-    // Pre-write a cursor so we can verify it doesn't change
+    // Pre-write a cursor so we can verify it stays at the floor
     mkdirSync(stateDir, { recursive: true });
     const initialCursorTs = s1Time - 1000;
     writeFileSync(join(stateDir, "cursor.json"), JSON.stringify({ last_run_timestamp: initialCursorTs }));
@@ -1323,7 +1420,8 @@ describe("main", () => {
       const code = await main(["bun", "script.ts"], () => {}, () => {});
       expect(code).toBe(1);
 
-      // Cursor should NOT have advanced
+      // Cursor must be written (Fix #2: always write cursor), but at the window floor
+      // (initialCursorTs), not advanced to any session's time_updated
       const cursor = JSON.parse(readFileSync(join(stateDir, "cursor.json"), "utf8"));
       expect(cursor.last_run_timestamp).toBe(initialCursorTs);
     } finally {

--- a/.config/opencode/scripts/ollama-distill.ts
+++ b/.config/opencode/scripts/ollama-distill.ts
@@ -59,7 +59,7 @@ export class ReadOnlyVerificationError extends Error {
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const TRUNCATION_LIMIT = 60_000;
+const TRUNCATION_LIMIT = 120_000;
 const TRUNCATION_MARKER = "\n\n[... transcript truncated for context limit]";
 const BUSY_RETRY_ATTEMPTS = 3;
 const BUSY_RETRY_DELAY_MS = 100;
@@ -411,7 +411,7 @@ export async function selectSessions(
     db
       .query<SessionRow, [number, number]>(
         `SELECT id, time_updated FROM session
-         WHERE time_updated > ? AND parent_id IS NULL
+         WHERE time_updated > ? AND parent_id IS NULL AND (project_id IS NULL OR project_id <> 'global')
          ORDER BY time_updated ASC
          LIMIT ?`
       )
@@ -1210,10 +1210,13 @@ export async function main(
 
       await appendRunLog(logPath, record);
 
-      // Fix #1: Advance cursor only to the end of the contiguous successful prefix
-      if (cursorAdvanceTo > (cursor.last_run_timestamp ?? 0)) {
-        await saveCursor(stateDir, { last_run_timestamp: cursorAdvanceTo });
-      }
+      // Always write a cursor at the end of a normal-mode run to prevent bootstrap deadlock.
+      // If ≥1 session succeeded contiguously from the start, advance to the last success.
+      // If zero sessions succeeded, write the window floor so the next run retries the same
+      // window rather than re-bootstrapping from scratch.
+      const windowFloor = cursor.last_run_timestamp ?? (Date.now() - SEVEN_DAYS_MS);
+      const nextCursor = cursorAdvanceTo > windowFloor ? cursorAdvanceTo : windowFloor;
+      await saveCursor(stateDir, { last_run_timestamp: nextCursor });
 
       return success ? 0 : 1;
     } finally {


### PR DESCRIPTION
## Why

First real-world `mise run distill` after the pipeline landed surfaced three issues that the small validation samples missed.

In a 7-day window on this machine: 42 root sessions matched the recency filter; 34 were ephemeral test-harness sessions OpenCode leaves behind in `/private/tmp` and `/private/var/folders/.../T/...` (subagent-stop-probe runs, sse-tests, oc-version-tests). Only 8 were actual work sessions. The resulting report was 34 blocks of zero-value meta-noise about test scaffolding. Of the 8 real sessions, all 8 hit the 60K-char truncation cap, none advanced the cursor, no cursor file was written, and the next run would have processed the same window from scratch.

## What

Three focused fixes.

**1. Exclude ephemeral sessions from selection.** OpenCode buckets sessions in non-project directories as `project_id = 'global'` (a stable hardcoded fallback for sessions whose directory has no enclosing project entry). The session-list query now adds `AND (project_id IS NULL OR project_id <> 'global')`. The `IS NULL` guard is for test fixtures — production OpenCode always sets `project_id`, so behavior on real data is identical to a bare `<> 'global'`.

This filter has one known false negative: a single legitimate `.dotfiles` session that OpenCode bucketed as `global` because dotfiles is a bare repo without `.git` in the worktree. Accepted as ~0.2% cost in exchange for using OpenCode's own bucket instead of macOS tmp-path folklore that would break the next time Apple or OpenCode changes ephemeral path patterns.

**2. Bootstrap the cursor on no-success runs.** Previously the cursor was only written when at least one session succeeded contiguously from the start. A first run with zero successes (e.g., all truncated or all Ollama failures) left no cursor file at all, and every subsequent run re-scanned the same window from the bootstrap default. The pipeline was structurally stuck.

Normal-mode runs now always write a cursor at the end. When no sessions succeed, the cursor is written at the window floor — the previous cursor's `last_run_timestamp` if one existed at run start, or the 7-day bootstrap default if not. Failed sessions remain in scope on the next run (cursor doesn't skip past them), but the pipeline can no longer get permanently stuck.

**3. Raise the per-session transcript char cap from 60K to 120K.** Real work sessions on this machine routinely exceed 60K chars; the earlier test sample was smaller. 120K still fits within `qwen3:8b`'s 128K input context window. Truncation logic itself unchanged — prefix + marker, still treated as a failure for cursor advance.

## Empirical delta

Same 7-day window, before and after this PR:

|                          | Before        | After             |
|--------------------------|---------------|-------------------|
| Sessions scanned          | 42            | 8                 |
| Sessions producing output | 8 (all noise) | 1 (under 120K cap)|
| Total report blocks       | 34            | 5                 |
| Durable content blocks    | 0             | 4                 |
| Cursor file written       | No            | Yes (at floor)    |

## Tests

65 → 67. Two new regression tests: `project_id = 'global'` sessions are excluded from selection, and a first run where all sessions fail still writes a cursor file at the bootstrap floor.

End-to-end verified against real Ollama: same 7-day window now yields a 5-block report with specific memory IDs, smart-note references, PR/issue numbers, and investigation breadcrumbs.

## What's still imperfect

Even with the 120K cap, 7 of 8 real sessions on this machine still truncate. Truncation correctly marks those sessions as failed for cursor advance, so they stay in scope for retry, but if they keep truncating they'll never produce signal. Two reasonable follow-ups when this gets in the way:

- Switch the truncation strategy from "head + marker" to "tail" or "first-and-last K chars" so the most recent context survives.
- Per-session chunked summarization with a final consolidation pass.

Both are additive on top of this PR.