### PR TITLE
feat(ollama-distill): chunked summarization at message boundaries

### DIFF
--- a/.config/opencode/scripts/ollama-distill.test.ts
+++ b/.config/opencode/scripts/ollama-distill.test.ts
@@ -20,8 +20,11 @@ import {
   withSqliteBusyRetry,
   acquireLock,
   releaseLock,
+  chunkSegments,
+  renderChunkTranscript,
   type ExtractStats,
   type RunRecord,
+  type MessageSegment,
 } from "./ollama-distill.ts";
 
 // Save original fetch so we can restore it after each Ollama test
@@ -543,18 +546,14 @@ describe("selectSessions", () => {
     db.close();
   });
 
-  test("byte cap: stops before accumulating byte cap of transcript chars", async () => {
+  test("maxSessions cap: 5 sessions in DB + maxSessions=3 returns exactly 3", async () => {
     const db = createSelectionDb();
-    // Each session ~40KB of text (under 60K truncation limit)
-    // With a 100KB cap, should stop after ~2-3 sessions
-    const chunkText = "x".repeat(40_000);
-    for (let i = 0; i < 10; i++) {
+    const chunkText = "x".repeat(200_000); // 200K chars each — would have blown old 1.5MB cap
+    for (let i = 0; i < 5; i++) {
       insertSessionWithText(db, `sess-${i}`, 1000 + i, chunkText);
     }
-    const result = await selectSessions(db, 0, 50, 100_000);
-    // Should stop well before 10 sessions (40K chars each, cap 100K → stops at 2-3)
-    expect(result.sessions.length).toBeLessThan(10);
-    expect(result.sessions.length).toBeGreaterThan(0);
+    const result = await selectSessions(db, 0, 3);
+    expect(result.sessions.length).toBe(3);
     db.close();
   });
 
@@ -695,7 +694,7 @@ describe("callOllama", () => {
   });
 
   test("timeout: AbortSignal.timeout fires → returns timeout error", async () => {
-    // We can't easily test the 300s timeout, but we can verify the error path
+    // We can't easily test the 600s timeout, but we can verify the error path
     // by mocking fetch to throw a TimeoutError
     globalThis.fetch = async () => {
       const err = new Error("The operation was aborted due to timeout");
@@ -707,6 +706,7 @@ describe("callOllama", () => {
       const result = await callOllama("test transcript");
       expect(result.output).toBe("");
       expect(result.error).toContain("timeout");
+      expect(result.error).toContain("600s");
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -1538,6 +1538,585 @@ describe("acquireLock / releaseLock", () => {
       expect(() => acquireLock(stateDir)).toThrow("another distill run");
     } finally {
       releaseLock(lockPath);
+    }
+  });
+});
+
+// ─── v1.2: chunkSegments tests ────────────────────────────────────────────────
+
+describe("chunkSegments", () => {
+  function seg(role: "USER" | "ASSISTANT", chars: number): MessageSegment {
+    return { role, text: "x".repeat(chars), char_count: chars };
+  }
+
+  test("empty input returns empty array", () => {
+    expect(chunkSegments([])).toEqual([]);
+  });
+
+  test("single small segment returns one chunk", () => {
+    const segments = [seg("USER", 100)];
+    const chunks = chunkSegments(segments);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toHaveLength(1);
+  });
+
+  test("exactly-target-sized segment returns one chunk", () => {
+    // 55000 chars + 12 overhead = 55012, which is > target (55000), but since
+    // current is empty we always push the first segment regardless
+    const segments = [seg("USER", 55_000)];
+    const chunks = chunkSegments(segments);
+    expect(chunks).toHaveLength(1);
+  });
+
+  test("multiple small segments that fit in one chunk", () => {
+    // 3 segments of 10K each = 30K + overhead, well under 55K target
+    const segments = [seg("USER", 10_000), seg("ASSISTANT", 10_000), seg("USER", 10_000)];
+    const chunks = chunkSegments(segments);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toHaveLength(3);
+  });
+
+  test("segments spanning two chunks when target exceeded", () => {
+    // 3 segments of 30K each: first two would be 60K+overhead > 55K target
+    // so: chunk1=[seg0, seg1 won't fit at target], chunk2=[seg1, seg2 won't fit], chunk3=[seg2]
+    // Actually: seg0 (30K+12=30012) fits in chunk1. seg1 (30012) would make 60024 > 55000 target
+    // → finalize chunk1=[seg0], start chunk2 with seg1. seg2 (30012) would make 60024 > 55000
+    // → finalize chunk2=[seg1], start chunk3 with seg2.
+    const segments = [seg("USER", 30_000), seg("ASSISTANT", 30_000), seg("USER", 30_000)];
+    const chunks = chunkSegments(segments);
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0]).toHaveLength(1);
+    expect(chunks[1]).toHaveLength(1);
+    expect(chunks[2]).toHaveLength(1);
+  });
+
+  test("segments that pack perfectly under target stay in one chunk", () => {
+    // Two segments of 20K each: 20012 + 20012 = 40024 < 55000 target → one chunk
+    const segments = [seg("USER", 20_000), seg("ASSISTANT", 20_000)];
+    const chunks = chunkSegments(segments);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toHaveLength(2);
+  });
+
+  test("segment exceeding hard cap forces its own chunk", () => {
+    // A pre-truncated segment at exactly SEGMENT_HARD_CAP (70K) chars
+    // It's the first segment so it always goes into its own chunk
+    const bigSeg = seg("USER", 70_000);
+    const smallSeg = seg("ASSISTANT", 100);
+    const chunks = chunkSegments([bigSeg, smallSeg]);
+    // bigSeg alone: 70000+12=70012 > hardCap(70000) but it's first so it goes in chunk1
+    // smallSeg: currentChars=70012, adding 112 > hardCap → finalize chunk1, start chunk2
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0][0]).toBe(bigSeg);
+    expect(chunks[1][0]).toBe(smallSeg);
+  });
+
+  test("exceeds hard cap forces split mid-sequence", () => {
+    // seg0=40K, seg1=35K: 40012+35012=75024 > hardCap(70000) → split
+    const s0 = seg("USER", 40_000);
+    const s1 = seg("ASSISTANT", 35_000);
+    const chunks = chunkSegments([s0, s1]);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toContain(s0);
+    expect(chunks[1]).toContain(s1);
+  });
+});
+
+// ─── v1.2: renderChunkTranscript tests ───────────────────────────────────────
+
+describe("renderChunkTranscript", () => {
+  test("single USER segment renders correctly", () => {
+    const segments: MessageSegment[] = [{ role: "USER", text: "hello world", char_count: 11 }];
+    expect(renderChunkTranscript(segments)).toBe("USER: hello world");
+  });
+
+  test("single ASSISTANT segment renders correctly", () => {
+    const segments: MessageSegment[] = [{ role: "ASSISTANT", text: "hi there", char_count: 8 }];
+    expect(renderChunkTranscript(segments)).toBe("ASSISTANT: hi there");
+  });
+
+  test("multi-segment renders with role prefixes and newlines", () => {
+    const segments: MessageSegment[] = [
+      { role: "USER", text: "question", char_count: 8 },
+      { role: "ASSISTANT", text: "answer", char_count: 6 },
+    ];
+    expect(renderChunkTranscript(segments)).toBe("USER: question\nASSISTANT: answer");
+  });
+
+  test("USER+ASSISTANT alternation renders in order", () => {
+    const segments: MessageSegment[] = [
+      { role: "USER", text: "a", char_count: 1 },
+      { role: "ASSISTANT", text: "b", char_count: 1 },
+      { role: "USER", text: "c", char_count: 1 },
+    ];
+    expect(renderChunkTranscript(segments)).toBe("USER: a\nASSISTANT: b\nUSER: c");
+  });
+
+  test("ASSISTANT-only segment renders correctly", () => {
+    const segments: MessageSegment[] = [
+      { role: "ASSISTANT", text: "standalone", char_count: 10 },
+    ];
+    expect(renderChunkTranscript(segments)).toBe("ASSISTANT: standalone");
+  });
+
+  test("empty segments returns empty string", () => {
+    expect(renderChunkTranscript([])).toBe("");
+  });
+});
+
+// ─── v1.2: end-to-end chunked inference tests ────────────────────────────────
+
+// Helper: create a DB with sessions where each session has a long transcript
+function createChunkedDb(
+  dbPath: string,
+  sessions: Array<{ id: string; timeUpdated: number; messages: Array<{ role: string; text: string }> }>
+) {
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE session (
+      id TEXT PRIMARY KEY,
+      project_id TEXT,
+      parent_id TEXT,
+      time_created INTEGER,
+      time_updated INTEGER
+    );
+    CREATE TABLE message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT,
+      time_created INTEGER,
+      data TEXT
+    );
+    CREATE TABLE part (
+      id TEXT PRIMARY KEY,
+      message_id TEXT,
+      session_id TEXT,
+      time_created INTEGER,
+      data TEXT
+    );
+  `);
+
+  for (const session of sessions) {
+    db.run(
+      "INSERT INTO session (id, project_id, parent_id, time_created, time_updated) VALUES (?, NULL, NULL, ?, ?)",
+      [session.id, session.timeUpdated - 1000, session.timeUpdated]
+    );
+
+    for (let i = 0; i < session.messages.length; i++) {
+      const msg = session.messages[i];
+      const msgId = `${session.id}-msg-${i}`;
+      db.run(
+        "INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)",
+        [msgId, session.id, session.timeUpdated - 1000 + i, JSON.stringify({ role: msg.role })]
+      );
+      const partId = `${session.id}-part-${i}`;
+      db.run(
+        "INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?, ?, ?, ?, ?)",
+        [partId, msgId, session.id, session.timeUpdated - 1000 + i, JSON.stringify({ type: "text", text: msg.text })]
+      );
+    }
+  }
+
+  db.close();
+}
+
+describe("v1.2 end-to-end chunked inference", () => {
+  test("session with 3 segments totaling ~100K chars produces 2 chunks, both succeed, report has (2 chunks) suffix", async () => {
+    const stateDir = join(tmpdir(), "distill-e2e-chunked-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-e2e-chunked-" + Math.random().toString(36).slice(2) + ".db");
+    const now = Date.now();
+
+    // 3 messages of ~20K chars each = ~60K total → should produce 2 chunks
+    // chunk1: msg0+msg1 = 40K+overhead < 55K target; msg2 would push to 60K > 55K → split
+    // chunk2: msg2 alone
+    const text20K = "A".repeat(20_000);
+    createChunkedDb(dbPath, [
+      {
+        id: "ses_chunked1",
+        timeUpdated: now - 1000,
+        messages: [
+          { role: "user", text: text20K },
+          { role: "assistant", text: text20K },
+          { role: "user", text: text20K },
+        ],
+      },
+    ]);
+
+    let ollamaCallCount = 0;
+    globalThis.fetch = async (url: string | URL | Request, _init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : (url as Request).url;
+      if (urlStr.includes("/api/tags")) {
+        return new Response(JSON.stringify({ models: [] }), { status: 200 });
+      }
+      if (urlStr.includes("/api/chat")) {
+        ollamaCallCount++;
+        return new Response(
+          JSON.stringify({ message: { content: `## Chunk ${ollamaCallCount} Summary\n\nContent here.` } }),
+          { status: 200 }
+        );
+      }
+      throw new Error(`Unexpected URL: ${urlStr}`);
+    };
+
+    const reportPath = join(stateDir, "test-report.md");
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(["bun", "script.ts", `--out=${reportPath}`], () => {}, () => {});
+      expect(code).toBe(0);
+
+      // Should have called Ollama twice (2 chunks)
+      expect(ollamaCallCount).toBe(2);
+
+      // Report should exist and contain "(2 chunks)" in the session header
+      expect(existsSync(reportPath)).toBe(true);
+      const reportContent = readFileSync(reportPath, "utf8");
+      expect(reportContent).toContain("(2 chunks)");
+      expect(reportContent).toContain("Chunk 1 Summary");
+      expect(reportContent).toContain("Chunk 2 Summary");
+
+      // Cursor should be advanced (session succeeded)
+      const cursor = JSON.parse(readFileSync(join(stateDir, "cursor.json"), "utf8"));
+      expect(cursor.last_run_timestamp).toBe(now - 1000);
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+
+  test("2 chunks, second chunk fails Ollama → session marked FAILED, error has chunk index", async () => {
+    const stateDir = join(tmpdir(), "distill-e2e-chunk-fail-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-e2e-chunk-fail-" + Math.random().toString(36).slice(2) + ".db");
+    const now = Date.now();
+
+    const text34K = "B".repeat(34_000);
+    createChunkedDb(dbPath, [
+      {
+        id: "ses_failchunk",
+        timeUpdated: now - 1000,
+        messages: [
+          { role: "user", text: text34K },
+          { role: "assistant", text: text34K },
+          { role: "user", text: text34K },
+        ],
+      },
+    ]);
+
+    let ollamaCallCount = 0;
+    globalThis.fetch = async (url: string | URL | Request, _init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : (url as Request).url;
+      if (urlStr.includes("/api/tags")) {
+        return new Response(JSON.stringify({ models: [] }), { status: 200 });
+      }
+      if (urlStr.includes("/api/chat")) {
+        ollamaCallCount++;
+        if (ollamaCallCount === 2) {
+          // Second chunk fails
+          return new Response("Internal Server Error", { status: 500, statusText: "Internal Server Error" });
+        }
+        return new Response(
+          JSON.stringify({ message: { content: "## Summary\n\nContent." } }),
+          { status: 200 }
+        );
+      }
+      throw new Error(`Unexpected URL: ${urlStr}`);
+    };
+
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(["bun", "script.ts"], () => {}, () => {});
+      expect(code).toBe(1); // failure
+
+      // Cursor should NOT be advanced (session failed)
+      const cursorPath = join(stateDir, "cursor.json");
+      expect(existsSync(cursorPath)).toBe(true);
+      const cursor = JSON.parse(readFileSync(cursorPath, "utf8"));
+      // Cursor stays at window floor, not at session's time_updated
+      expect(cursor.last_run_timestamp).not.toBe(now - 1000);
+
+      // JSONL log should have error with chunk index in message
+      const logPath = join(stateDir, "runs.jsonl");
+      expect(existsSync(logPath)).toBe(true);
+      const record = JSON.parse(readFileSync(logPath, "utf8").trim());
+      expect(record.success).toBe(false);
+      expect(record.errors.length).toBeGreaterThan(0);
+      expect(record.errors[0].phase).toBe("ollama");
+      expect(record.errors[0].message).toContain("chunk 2/");
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+
+  test("regression: small single-chunk session produces header WITHOUT (N chunks) suffix", async () => {
+    const stateDir = join(tmpdir(), "distill-e2e-single-chunk-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-e2e-single-chunk-" + Math.random().toString(36).slice(2) + ".db");
+    const now = Date.now();
+
+    // Small transcript — fits in one chunk
+    createChunkedDb(dbPath, [
+      {
+        id: "ses_small",
+        timeUpdated: now - 1000,
+        messages: [
+          { role: "user", text: "Hello, what is 2+2?" },
+          { role: "assistant", text: "It is 4." },
+        ],
+      },
+    ]);
+
+    globalThis.fetch = async (url: string | URL | Request, _init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : (url as Request).url;
+      if (urlStr.includes("/api/tags")) {
+        return new Response(JSON.stringify({ models: [] }), { status: 200 });
+      }
+      if (urlStr.includes("/api/chat")) {
+        return new Response(
+          JSON.stringify({ message: { content: "## Summary\n\nSimple session." } }),
+          { status: 200 }
+        );
+      }
+      throw new Error(`Unexpected URL: ${urlStr}`);
+    };
+
+    const reportPath = join(stateDir, "test-report.md");
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(["bun", "script.ts", `--out=${reportPath}`], () => {}, () => {});
+      expect(code).toBe(0);
+
+      const reportContent = readFileSync(reportPath, "utf8");
+      // Should NOT contain "(N chunks)" suffix for single-chunk sessions
+      expect(reportContent).not.toContain("chunks)");
+      // Should contain the session header without chunk count
+      expect(reportContent).toContain("ses_small");
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+});
+
+// ─── v1.2 smoke-fix tests (Fix A/B/C/D) ──────────────────────────────────────
+
+describe("v1.2 smoke fixes", () => {
+  // Fix A: timeout string uses 600s
+  test("Fix A: timeout error string contains '600s'", async () => {
+    globalThis.fetch = async () => {
+      const err = new Error("The operation was aborted due to timeout");
+      err.name = "TimeoutError";
+      throw err;
+    };
+    try {
+      const result = await callOllama("test");
+      expect(result.error).toContain("600s");
+      expect(result.error).not.toContain("300s");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  // Fix B: selectSessions no longer caps by bytes — large sessions all selected
+  test("Fix B: 10 sessions × 200K chars each all selected when maxSessions=10", async () => {
+    const db = createSelectionDb();
+    const bigText = "x".repeat(200_000);
+    for (let i = 0; i < 10; i++) {
+      insertSessionWithText(db, `big-sess-${i}`, 2000 + i, bigText);
+    }
+    const result = await selectSessions(db, 0, 10);
+    expect(result.sessions.length).toBe(10);
+    db.close();
+  });
+
+  // Fix C: partial-success session writes blocks to report
+  test("Fix C: partial-success (3/5 chunks) writes 3 blocks, title contains '3/5 chunks succeeded', sessionSucceeded=false", async () => {
+    const stateDir = join(tmpdir(), "distill-partial-c-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-partial-c-" + Math.random().toString(36).slice(2) + ".db");
+    const now = Date.now();
+
+    // Create a session with a large transcript that will produce 5+ chunks
+    // Each segment ~35K chars → 3 segments per chunk at 55K target → need ~15 segments for 5 chunks
+    // Simpler: mock callOllama at the fetch level — succeed on calls 1-3, fail on call 4
+    const text35K = "C".repeat(35_000);
+    const messages: Array<{ role: string; text: string }> = [];
+    for (let i = 0; i < 15; i++) {
+      messages.push({ role: i % 2 === 0 ? "user" : "assistant", text: text35K });
+    }
+
+    createChunkedDb(dbPath, [
+      { id: "ses_partial_c", timeUpdated: now - 1000, messages },
+    ]);
+
+    let ollamaCallCount = 0;
+    globalThis.fetch = async (url: string | URL | Request, _init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : (url as Request).url;
+      if (urlStr.includes("/api/tags")) {
+        return new Response(JSON.stringify({ models: [] }), { status: 200 });
+      }
+      if (urlStr.includes("/api/chat")) {
+        ollamaCallCount++;
+        if (ollamaCallCount >= 4) {
+          return new Response("Internal Server Error", { status: 500 });
+        }
+        return new Response(
+          JSON.stringify({ message: { content: `## Block ${ollamaCallCount}\n\nContent.` } }),
+          { status: 200 }
+        );
+      }
+      throw new Error(`Unexpected URL: ${urlStr}`);
+    };
+
+    const reportPath = join(stateDir, "partial-report.md");
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(["bun", "script.ts", `--out=${reportPath}`], () => {}, () => {});
+      expect(code).toBe(1); // partial failure → non-zero
+
+      // Report should exist and contain the partial blocks
+      expect(existsSync(reportPath)).toBe(true);
+      const reportContent = readFileSync(reportPath, "utf8");
+      expect(reportContent).toContain("Block 1");
+      expect(reportContent).toContain("Block 2");
+      expect(reportContent).toContain("Block 3");
+      // Title should indicate partial success
+      expect(reportContent).toContain("chunks succeeded");
+
+      // JSONL: success=false, errors has chunk failure, report_path is resolved
+      const logPath = join(stateDir, "runs.jsonl");
+      const record = JSON.parse(readFileSync(logPath, "utf8").trim());
+      expect(record.success).toBe(false);
+      expect(record.errors.length).toBeGreaterThan(0);
+      expect(record.errors[0].message).toContain("chunk 4/");
+      expect(record.report_path).toBe(reportPath);
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+
+  // Fix D: total-failure session — report_path is still resolved in JSONL
+  test("Fix D: total-failure (chunk 1 fails) → sessionResults empty, report_path still resolved in JSONL", async () => {
+    const stateDir = join(tmpdir(), "distill-total-fail-d-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-total-fail-d-" + Math.random().toString(36).slice(2) + ".db");
+    const now = Date.now();
+
+    createFileDb(dbPath, [
+      { id: "ses_total_fail", timeUpdated: now - 1000, text: "some content" },
+    ]);
+
+    globalThis.fetch = async (url: string | URL | Request, _init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : (url as Request).url;
+      if (urlStr.includes("/api/tags")) {
+        return new Response(JSON.stringify({ models: [] }), { status: 200 });
+      }
+      if (urlStr.includes("/api/chat")) {
+        return new Response("Internal Server Error", { status: 500 });
+      }
+      throw new Error(`Unexpected URL: ${urlStr}`);
+    };
+
+    const reportPath = join(stateDir, "fail-report.md");
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(["bun", "script.ts", `--out=${reportPath}`], () => {}, () => {});
+      expect(code).toBe(1);
+
+      // JSONL: report_path must be the resolved path, not ""
+      const logPath = join(stateDir, "runs.jsonl");
+      const record = JSON.parse(readFileSync(logPath, "utf8").trim());
+      expect(record.success).toBe(false);
+      expect(record.report_path).toBe(reportPath);
+      expect(record.report_path).not.toBe("");
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+
+  // Fix C+D: multi-session with partial failure — report contains both sessions' content
+  test("Fix C+D: session1 partial (3 chunks succeed) + session2 full success (1 chunk) → report has both, report_blocks_generated=4", async () => {
+    const stateDir = join(tmpdir(), "distill-multi-partial-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-multi-partial-" + Math.random().toString(36).slice(2) + ".db");
+    const now = Date.now();
+
+    // Session 1: large enough to produce 4+ chunks; fail on chunk 4
+    const text35K = "D".repeat(35_000);
+    const messages1: Array<{ role: string; text: string }> = [];
+    for (let i = 0; i < 15; i++) {
+      messages1.push({ role: i % 2 === 0 ? "user" : "assistant", text: text35K });
+    }
+
+    // Session 2: small, 1 chunk
+    createChunkedDb(dbPath, [
+      { id: "ses_mp1", timeUpdated: now - 2000, messages: messages1 },
+      { id: "ses_mp2", timeUpdated: now - 1000, messages: [{ role: "user", text: "short" }] },
+    ]);
+
+    let ollamaCallCount = 0;
+    globalThis.fetch = async (url: string | URL | Request, _init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : (url as Request).url;
+      if (urlStr.includes("/api/tags")) {
+        return new Response(JSON.stringify({ models: [] }), { status: 200 });
+      }
+      if (urlStr.includes("/api/chat")) {
+        ollamaCallCount++;
+        // Calls 1-3: session 1 chunks 1-3 succeed; call 4: session 1 chunk 4 fails
+        // Call 5: session 2 chunk 1 succeeds
+        if (ollamaCallCount === 4) {
+          return new Response("Internal Server Error", { status: 500 });
+        }
+        return new Response(
+          JSON.stringify({ message: { content: `## Block ${ollamaCallCount}\n\nContent.` } }),
+          { status: 200 }
+        );
+      }
+      throw new Error(`Unexpected URL: ${urlStr}`);
+    };
+
+    const reportPath = join(stateDir, "multi-report.md");
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(["bun", "script.ts", `--out=${reportPath}`], () => {}, () => {});
+      expect(code).toBe(1); // partial failure
+
+      // Report should contain both sessions' content
+      expect(existsSync(reportPath)).toBe(true);
+      const reportContent = readFileSync(reportPath, "utf8");
+      expect(reportContent).toContain("ses_mp1");
+      expect(reportContent).toContain("ses_mp2");
+      expect(reportContent).toContain("Block 1");
+      expect(reportContent).toContain("Block 5"); // session 2's block
+
+      // JSONL: report_blocks_generated = 3 (partial) + 1 (full) = 4
+      const logPath = join(stateDir, "runs.jsonl");
+      const record = JSON.parse(readFileSync(logPath, "utf8").trim());
+      expect(record.report_blocks_generated).toBe(4);
+      expect(record.report_path).toBe(reportPath);
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
     }
   });
 });

--- a/.config/opencode/scripts/ollama-distill.test.ts
+++ b/.config/opencode/scripts/ollama-distill.test.ts
@@ -162,11 +162,11 @@ describe("extractTranscript", () => {
 
   // ─── Test 3: Truncation ─────────────────────────────────────────────────────
 
-  test("truncation: content exceeding 120K chars is truncated with marker", async () => {
+  test("truncation: content exceeding SEGMENT_HARD_CAP (70K) is truncated with marker", async () => {
     const db = createFixtureDb();
     const sid = "sess-3";
 
-    // Create a message with text that exceeds 120K chars
+    // Create a message with text that exceeds SEGMENT_HARD_CAP (70K chars)
     const bigText = "x".repeat(121_000);
     const m1 = insertMessage(db, sid, "user", 1000, "msg-1");
     insertPart(db, m1, sid, "text", bigText, 1001, "p-1");
@@ -198,8 +198,8 @@ describe("extractTranscript", () => {
     // Should have substantial prefix content (not just the marker)
     const markerIdx = transcript.indexOf("[... transcript truncated for context limit]");
     expect(markerIdx).toBeGreaterThan(1000); // at least 1000 chars of original content
-    // Total length should be close to 120K (not 200K)
-    expect(transcript.length).toBeLessThanOrEqual(120_100); // 120K + marker length
+    // Total length should be close to SEGMENT_HARD_CAP (70K), not 200K
+    expect(transcript.length).toBeLessThanOrEqual(70_100); // SEGMENT_HARD_CAP + marker length
 
     db.close();
   });

--- a/.config/opencode/scripts/ollama-distill.ts
+++ b/.config/opencode/scripts/ollama-distill.ts
@@ -6,6 +6,12 @@ import { homedir } from "node:os";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
+export type MessageSegment = {
+  role: "USER" | "ASSISTANT";  // matches the existing prefix format
+  text: string;                 // the body of this segment (no leading "USER:" line)
+  char_count: number;
+};
+
 export type ExtractStats = {
   messages: number;
   text_parts: number;
@@ -13,11 +19,14 @@ export type ExtractStats = {
   skipped_parts: number;
   skipped_types: string[];
   transcript_chars: number;
-  truncated: boolean;
+  truncated: boolean;           // now means "a single message exceeded the hard cap and got truncated mid-message"
+  segments_total: number;       // NEW
+  segments_truncated: number;   // NEW — usually 0
 };
 
 export type ExtractResult = {
-  transcript: string;
+  transcript: string;           // existing — concatenated USER:/ASSISTANT: lines, unchanged shape
+  segments: MessageSegment[];   // NEW — for the chunker
   stats: ExtractStats;
 };
 
@@ -61,6 +70,11 @@ export class ReadOnlyVerificationError extends Error {
 
 const TRUNCATION_LIMIT = 120_000;
 const TRUNCATION_MARKER = "\n\n[... transcript truncated for context limit]";
+// Per-segment hard cap: if a single message body exceeds this, it gets prefix-truncated.
+// The chunker enforces 70K per CHUNK; segments are smaller than chunks.
+const SEGMENT_HARD_CAP = 70_000;
+// Overhead per segment when reconstructing transcript (role prefix + newline)
+const ROLE_PREFIX_OVERHEAD = 12; // "ASSISTANT: \n" is 12 chars; "USER: \n" is 7; use 12 as safe upper bound
 const BUSY_RETRY_ATTEMPTS = 3;
 const BUSY_RETRY_DELAY_MS = 100;
 
@@ -252,6 +266,8 @@ function buildTranscript(rows: TranscriptRow[]): ExtractResult {
     skipped_types: [],
     transcript_chars: 0,
     truncated: false,
+    segments_total: 0,
+    segments_truncated: 0,
   };
 
   // Group rows by message_id preserving insertion order
@@ -280,13 +296,14 @@ function buildTranscript(rows: TranscriptRow[]): ExtractResult {
   }
 
   const skippedTypesSet = new Set<string>();
+  const segments: MessageSegment[] = [];
   const lines: string[] = [];
-  let totalChars = 0;
-  let truncated = false;
 
   for (const msgId of messageOrder) {
     const { envelope, partRows } = messageMap.get(msgId)!;
-    const role = String(envelope.role ?? "unknown").toUpperCase();
+    const rawRole = String(envelope.role ?? "unknown").toUpperCase();
+    // Normalize role to USER or ASSISTANT for segments; fall back to USER for unknown
+    const segRole: "USER" | "ASSISTANT" = rawRole === "ASSISTANT" ? "ASSISTANT" : "USER";
     stats.messages++;
 
     for (const row of partRows) {
@@ -301,12 +318,15 @@ function buildTranscript(rows: TranscriptRow[]): ExtractResult {
         continue;
       }
 
-      let line: string;
+      let segText: string;
+      let linePrefix: string;
       if (partData.type === "text") {
-        line = `${role}: ${(partData as { type: "text"; text: string }).text}`;
+        segText = (partData as { type: "text"; text: string }).text;
+        linePrefix = `${rawRole}: `;
         stats.text_parts++;
       } else if (partData.type === "reasoning") {
-        line = `${role} [reasoning]: ${(partData as { type: "reasoning"; text: string }).text}`;
+        segText = (partData as { type: "reasoning"; text: string }).text;
+        linePrefix = `${rawRole} [reasoning]: `;
         stats.reasoning_parts++;
       } else {
         stats.skipped_parts++;
@@ -314,38 +334,116 @@ function buildTranscript(rows: TranscriptRow[]): ExtractResult {
         continue;
       }
 
-      // Fix #3: Keep prefix up to (CAP - markerLength) chars, then append marker
-      const lineWithNewline = lines.length === 0 ? line : "\n" + line;
-      const newTotal = totalChars + lineWithNewline.length;
-
-      if (newTotal > TRUNCATION_LIMIT) {
-        truncated = true;
-        // Keep as much of the current line as fits before the marker
-        const available = TRUNCATION_LIMIT - totalChars - (lines.length === 0 ? 0 : 1); // account for "\n"
-        if (available > 0) {
-          const prefix = lines.length === 0 ? line.slice(0, available) : line.slice(0, available);
-          lines.push(prefix);
-        }
-        break;
+      // Fix #1: Per-segment hard cap — if a single message body exceeds SEGMENT_HARD_CAP,
+      // prefix-truncate that ONE segment and flag it. Other segments stay intact.
+      let finalSegText = segText;
+      let segTruncated = false;
+      if (segText.length > SEGMENT_HARD_CAP) {
+        const available = SEGMENT_HARD_CAP - TRUNCATION_MARKER.length;
+        finalSegText = segText.slice(0, available) + TRUNCATION_MARKER;
+        segTruncated = true;
+        stats.segments_truncated++;
+        stats.truncated = true;
       }
 
+      segments.push({
+        role: segRole,
+        text: finalSegText,
+        char_count: finalSegText.length,
+      });
+
+      // Build the concatenated transcript line (backward-compat)
+      const line = linePrefix + finalSegText;
       lines.push(line);
-      totalChars = newTotal;
+
+      if (segTruncated) {
+        // Don't break — other messages still get processed into segments
+      }
     }
-
-    if (truncated) break;
   }
 
-  let transcript = lines.join("\n");
-  if (truncated) {
-    transcript += TRUNCATION_MARKER;
-  }
+  const transcript = lines.join("\n");
 
   stats.skipped_types = Array.from(skippedTypesSet);
+  stats.segments_total = segments.length;
   stats.transcript_chars = transcript.length;
-  stats.truncated = truncated;
 
-  return { transcript, stats };
+  return { transcript, segments, stats };
+}
+
+// ─── Chunker ──────────────────────────────────────────────────────────────────
+
+// Per-chunk independence is intentional. Sessions where context built up in
+// chunk N only pays off in chunk N+1 will produce a thinner second block.
+// 8B models hallucinate or lose coherence when given a "consolidate previous
+// summaries" pass, so this pipeline accepts the lossy boundary as a tradeoff
+// for predictable per-chunk quality. See PR #<TBD> for rationale.
+
+/**
+ * Split an ordered list of MessageSegments into chunks for independent
+ * Ollama inference. Each chunk targets ~55K chars; hard cap is 70K.
+ *
+ * Algorithm:
+ * 1. Start a new chunk: current = [], currentChars = 0.
+ * 2. For each segment:
+ *    a. Compute segment size: seg.char_count + ROLE_PREFIX_OVERHEAD.
+ *    b. If current is empty: push segment, add size, continue.
+ *    c. If currentChars + segSize > hardCapChars: finalize current, start new chunk with this segment.
+ *    d. Else if currentChars + segSize > targetChars: finalize current WITHOUT this segment, push to new chunk.
+ *    e. Else: append to current.
+ * 3. Finalize last chunk if non-empty.
+ */
+export function chunkSegments(
+  segments: MessageSegment[],
+  targetChars = 55_000,
+  hardCapChars = 70_000
+): MessageSegment[][] {
+  const chunks: MessageSegment[][] = [];
+  let current: MessageSegment[] = [];
+  let currentChars = 0;
+
+  for (const seg of segments) {
+    const segSize = seg.char_count + ROLE_PREFIX_OVERHEAD;
+
+    if (current.length === 0) {
+      // Always push at least one segment per chunk (even if it exceeds hardCap —
+      // extractTranscript already truncated it to SEGMENT_HARD_CAP)
+      current.push(seg);
+      currentChars += segSize;
+      continue;
+    }
+
+    if (currentChars + segSize > hardCapChars) {
+      // Would overflow hard cap: finalize current chunk, start new one
+      chunks.push(current);
+      current = [seg];
+      currentChars = segSize;
+    } else if (currentChars + segSize > targetChars) {
+      // Would exceed target but fits under hard cap: finalize current WITHOUT this segment
+      chunks.push(current);
+      current = [seg];
+      currentChars = segSize;
+    } else {
+      current.push(seg);
+      currentChars += segSize;
+    }
+  }
+
+  if (current.length > 0) {
+    chunks.push(current);
+  }
+
+  return chunks;
+}
+
+/**
+ * Reconstruct the USER: .../ASSISTANT: ... transcript string from a chunk's
+ * segments. Matches the exact format extractTranscript produces.
+ */
+export function renderChunkTranscript(segments: MessageSegment[]): string {
+  return segments
+    .map((seg) => `${seg.role}: ${seg.text}`)
+    .join("\n");
 }
 
 // ─── Cursor ───────────────────────────────────────────────────────────────────
@@ -389,6 +487,7 @@ export type SelectedSession = {
   id: string;
   time_updated: number;
   transcript: string;
+  segments: MessageSegment[];
   stats: ExtractStats;
 };
 
@@ -401,7 +500,7 @@ export async function selectSessions(
   db: Database,
   lastRunTimestamp: number | null,
   maxSessions = 50,
-  maxBytes = 1.5 * 1024 * 1024
+  maxBytes = Infinity  // deprecated: chunked inference makes per-session byte caps unnecessary; kept for API compat
 ): Promise<SelectionResult> {
   const since = lastRunTimestamp ?? 0;
   const fetchCap = Math.ceil(maxSessions * 1.5);
@@ -419,20 +518,13 @@ export async function selectSessions(
   );
 
   const sessions: SelectedSession[] = [];
-  let cumulativeBytes = 0;
 
   for (const row of rows) {
     if (sessions.length >= maxSessions) break;
 
-    const { transcript, stats } = await extractTranscript(db, row.id);
-    const byteCount = stats.transcript_chars;
+    const { transcript, segments, stats } = await extractTranscript(db, row.id);
 
-    if (cumulativeBytes + byteCount > maxBytes && sessions.length > 0) break;
-
-    sessions.push({ id: row.id, time_updated: row.time_updated, transcript, stats });
-    cumulativeBytes += byteCount;
-
-    if (cumulativeBytes >= maxBytes) break;
+    sessions.push({ id: row.id, time_updated: row.time_updated, transcript, segments, stats });
   }
 
   const max_processed_time_updated =
@@ -483,7 +575,7 @@ export const USER_TEMPLATE = `<transcript>
 Extract up to 5 report blocks from the transcript above. Start your response with "## ".`;
 
 const OLLAMA_URL = "http://127.0.0.1:11434/api/chat";
-const OLLAMA_TIMEOUT_MS = 300_000;
+const OLLAMA_TIMEOUT_MS = 600_000;  // 10 min — empirically chunks take ~1m50s; 10x cap covers slow chunks without unbounded hang
 
 export type OllamaResult = {
   output: string;
@@ -523,7 +615,7 @@ export async function callOllama(
     return {
       output: "",
       durationMs,
-      error: isTimeout ? "timeout: Ollama did not respond within 300s" : `network error: ${msg}`,
+      error: isTimeout ? "timeout: Ollama did not respond within 600s" : `network error: ${msg}`,
     };
   }
 
@@ -941,7 +1033,7 @@ export async function main(
         return 1;
       }
 
-      let extractResult: { transcript: string; stats: ExtractStats };
+      let extractResult: { transcript: string; segments: MessageSegment[]; stats: ExtractStats };
       try {
         extractResult = await extractTranscript(db, sessionId);
       } catch (err) {
@@ -952,7 +1044,7 @@ export async function main(
       }
       db.close();
 
-      const { transcript } = extractResult;
+      const { transcript, segments: sessionSegments } = extractResult;
 
       // --extract-only: skip Ollama
       if (args.extractOnly) {
@@ -973,7 +1065,25 @@ export async function main(
         return 1;
       }
 
-      const ollamaResult = await callOllama(transcript, MODEL);
+      const sessionChunks = chunkSegments(sessionSegments);
+      const sessionChunkBlocks: string[] = [];
+      let sessionChunkError: string | undefined;
+
+      for (let c = 0; c < sessionChunks.length; c++) {
+        const chunkTranscript = renderChunkTranscript(sessionChunks[c]);
+        const ollamaResult = await callOllama(chunkTranscript, MODEL);
+        if (ollamaResult.error) {
+          sessionChunkError = `chunk ${c + 1}/${sessionChunks.length}: ${ollamaResult.error}`;
+          break;
+        }
+        sessionChunkBlocks.push(ollamaResult.output);
+      }
+
+      // If no chunks (empty transcript), treat as success with empty output
+      if (sessionChunks.length === 0) {
+        sessionChunkBlocks.push("");
+      }
+
       const durationMs = Date.now() - startMs;
 
       const record: RunRecord = {
@@ -983,22 +1093,25 @@ export async function main(
         mode: "session",
         model: MODEL,
         sessions_read: 1,
-        report_blocks_generated: ollamaResult.error ? 0 : 1,
+        report_blocks_generated: sessionChunkError ? 0 : sessionChunkBlocks.length,
         report_path: args.out ?? "stdout",
-        success: !ollamaResult.error,
-        errors: ollamaResult.error
-          ? [{ session_id: sessionId, phase: "ollama", message: ollamaResult.error }]
+        success: !sessionChunkError,
+        errors: sessionChunkError
+          ? [{ session_id: sessionId, phase: "ollama", message: sessionChunkError }]
           : [],
       };
 
       await appendRunLog(logPath, record);
 
-      if (ollamaResult.error) {
-        stderr(`Ollama error for ${sessionId}: ${ollamaResult.error}\n`);
+      if (sessionChunkError) {
+        stderr(`Ollama error for ${sessionId}: ${sessionChunkError}\n`);
         return 1;
       }
 
-      const output = `### Session ${sessionId}\n\n${ollamaResult.output}\n`;
+      const sessionHeader = sessionChunks.length > 1
+        ? `### Session ${sessionId} (${sessionChunks.length} chunks)\n\n`
+        : `### Session ${sessionId}\n\n`;
+      const output = sessionHeader + sessionChunkBlocks.join("\n\n") + "\n";
       if (args.out) {
         await Bun.write(args.out, output);
       } else {
@@ -1137,39 +1250,87 @@ export async function main(
         return 0;
       }
 
-      // Fix #1: Process sessions through Ollama, tracking per-session success
-      // for cursor advancement (only advance through contiguous successful prefix)
+      // Fix #4: Process sessions through Ollama with chunked inference.
+      // Per-chunk independence is intentional — see chunkSegments() comment block.
       const sessionResults: SessionResult[] = [];
       const errors: RunError[] = [];
       // Track which sessions succeeded (by index, in time order)
       const sessionSucceeded: boolean[] = [];
+      let reportBlocksGenerated = 0;
 
       for (const s of sessions) {
-        // Fix #3: Truncated sessions are treated as failures for cursor purposes
-        if (s.stats.truncated) {
+        // Fix #3: Sessions with per-segment truncation are treated as failures for cursor purposes
+        if (s.stats.segments_truncated > 0) {
           errors.push({
             session_id: s.id,
             phase: "truncation",
-            message: `Transcript truncated at ${TRUNCATION_LIMIT} chars; session excluded from cursor advance`,
+            message: `${s.stats.segments_truncated} segment(s) truncated at ${SEGMENT_HARD_CAP} chars; session excluded from cursor advance`,
           });
-          stderr(`Warning: transcript truncated for ${s.id}; treating as failure for cursor\n`);
+          stderr(`Warning: segment(s) truncated for ${s.id}; treating as failure for cursor\n`);
           sessionSucceeded.push(false);
           continue;
         }
 
-        const ollamaResult = await callOllama(s.transcript, MODEL);
-        if (ollamaResult.error) {
-          errors.push({ session_id: s.id, phase: "ollama", message: ollamaResult.error });
-          stderr(`Warning: Ollama error for ${s.id}: ${ollamaResult.error}\n`);
-          sessionSucceeded.push(false);
+        const chunks = chunkSegments(s.segments);
+
+        if (chunks.length === 0) {
+          // No content — mark succeeded trivially (consistent with empty-transcript handling)
+          sessionSucceeded.push(true);
           continue;
         }
-        sessionResults.push({
-          sessionId: s.id,
-          title: `Session ${s.id.slice(0, 20)}`,
-          ollamaOutput: ollamaResult.output,
-        });
-        sessionSucceeded.push(true);
+
+        let allChunksSucceeded = true;
+        const chunkBlocks: string[] = [];
+        const chunkErrors: RunError[] = [];
+
+        for (let c = 0; c < chunks.length; c++) {
+          const chunkTranscript = renderChunkTranscript(chunks[c]);
+          const ollamaResult = await callOllama(chunkTranscript, MODEL);
+          if (ollamaResult.error) {
+            chunkErrors.push({
+              session_id: s.id,
+              phase: "ollama",
+              message: `chunk ${c + 1}/${chunks.length}: ${ollamaResult.error}`,
+            });
+            allChunksSucceeded = false;
+            break;  // stop processing remaining chunks on first failure
+          }
+          chunkBlocks.push(ollamaResult.output);
+        }
+
+        // Header convention:
+        // - 1 chunk total, success: title = "Session <id>"
+        // - N chunks, all succeeded: title = "Session <id> (N chunks)"
+        // - M of N chunks succeeded (partial): title = "Session <id> (M/N chunks succeeded)"
+        // writeReport wraps title as: ### <title> (<sessionId>)
+        let title: string;
+        if (chunks.length === 1 && allChunksSucceeded) {
+          title = `Session ${s.id}`;
+        } else if (allChunksSucceeded) {
+          title = `Session ${s.id} (${chunks.length} chunks)`;
+        } else if (chunkBlocks.length > 0) {
+          title = `Session ${s.id} (${chunkBlocks.length}/${chunks.length} chunks succeeded)`;
+        } else {
+          title = `Session ${s.id} (failed)`;
+        }
+
+        if (chunkBlocks.length > 0) {
+          // Write whatever we got, even on partial failure
+          sessionResults.push({
+            sessionId: s.id,
+            title,
+            ollamaOutput: chunkBlocks.join("\n\n"),
+          });
+          reportBlocksGenerated += chunkBlocks.length;
+        }
+
+        if (allChunksSucceeded) {
+          sessionSucceeded.push(true);
+        } else {
+          errors.push(...chunkErrors);
+          stderr(`Warning: Ollama error for ${s.id}: ${chunkErrors[0]?.message}\n`);
+          sessionSucceeded.push(false);
+        }
       }
 
       // Fix #1: Advance cursor only through the longest contiguous successful prefix
@@ -1184,13 +1345,11 @@ export async function main(
         }
       }
 
-      // Write report
+      // Write report — always call when there's a resolved path; empty sessionResults = header-only file
       const dateStr = new Date().toISOString().slice(0, 10);
       const reportPath = args.out ?? join(stateDir, "reports", `${dateStr}.md`);
 
-      if (sessionResults.length > 0) {
-        await writeReport(reportPath, sessionResults);
-      }
+      await writeReport(reportPath, sessionResults);
 
       const durationMs = Date.now() - startMs;
       const success = errors.length === 0;
@@ -1202,8 +1361,8 @@ export async function main(
         mode: "normal",
         model: MODEL,
         sessions_read: sessions.length,
-        report_blocks_generated: sessionResults.length,
-        report_path: sessionResults.length > 0 ? reportPath : "",
+        report_blocks_generated: reportBlocksGenerated,
+        report_path: reportPath,
         success,
         errors,
       };

--- a/.config/opencode/scripts/ollama-distill.ts
+++ b/.config/opencode/scripts/ollama-distill.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { Database } from "bun:sqlite";
-import { mkdirSync, renameSync, existsSync, appendFileSync, openSync, closeSync, unlinkSync } from "node:fs";
+import { mkdirSync, renameSync, existsSync, appendFileSync, openSync, closeSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 
@@ -68,7 +68,6 @@ export class ReadOnlyVerificationError extends Error {
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const TRUNCATION_LIMIT = 120_000;
 const TRUNCATION_MARKER = "\n\n[... transcript truncated for context limit]";
 // Per-segment hard cap: if a single message body exceeds this, it gets prefix-truncated.
 // The chunker enforces 70K per CHUNK; segments are smaller than chunks.
@@ -377,26 +376,30 @@ function buildTranscript(rows: TranscriptRow[]): ExtractResult {
 // chunk N only pays off in chunk N+1 will produce a thinner second block.
 // 8B models hallucinate or lose coherence when given a "consolidate previous
 // summaries" pass, so this pipeline accepts the lossy boundary as a tradeoff
-// for predictable per-chunk quality. See PR #<TBD> for rationale.
+// for predictable per-chunk quality. See PR #1707 for rationale.
 
 /**
  * Split an ordered list of MessageSegments into chunks for independent
- * Ollama inference. Each chunk targets ~55K chars; hard cap is 70K.
+ * Ollama inference.
  *
- * Algorithm:
+ * Algorithm: greedy packing with a single size threshold.
  * 1. Start a new chunk: current = [], currentChars = 0.
  * 2. For each segment:
  *    a. Compute segment size: seg.char_count + ROLE_PREFIX_OVERHEAD.
- *    b. If current is empty: push segment, add size, continue.
- *    c. If currentChars + segSize > hardCapChars: finalize current, start new chunk with this segment.
- *    d. Else if currentChars + segSize > targetChars: finalize current WITHOUT this segment, push to new chunk.
- *    e. Else: append to current.
+ *    b. If current is empty: always push the segment (even if it alone exceeds
+ *       targetChars — extractTranscript already truncated it to SEGMENT_HARD_CAP).
+ *    c. If currentChars + segSize > targetChars: finalize current chunk, start
+ *       a new chunk with this segment.
+ *    d. Else: append to current.
  * 3. Finalize last chunk if non-empty.
+ *
+ * Default targetChars is 55K. Single segments larger than that go into their
+ * own chunk; extractTranscript pre-truncates each segment to SEGMENT_HARD_CAP
+ * (70K) so oversized lone segments are still bounded.
  */
 export function chunkSegments(
   segments: MessageSegment[],
-  targetChars = 55_000,
-  hardCapChars = 70_000
+  targetChars = 55_000
 ): MessageSegment[][] {
   const chunks: MessageSegment[][] = [];
   let current: MessageSegment[] = [];
@@ -406,20 +409,17 @@ export function chunkSegments(
     const segSize = seg.char_count + ROLE_PREFIX_OVERHEAD;
 
     if (current.length === 0) {
-      // Always push at least one segment per chunk (even if it exceeds hardCap —
-      // extractTranscript already truncated it to SEGMENT_HARD_CAP)
+      // Always push at least one segment per chunk — even if it alone exceeds
+      // targetChars. extractTranscript already truncated it to SEGMENT_HARD_CAP.
       current.push(seg);
       currentChars += segSize;
       continue;
     }
 
-    if (currentChars + segSize > hardCapChars) {
-      // Would overflow hard cap: finalize current chunk, start new one
-      chunks.push(current);
-      current = [seg];
-      currentChars = segSize;
-    } else if (currentChars + segSize > targetChars) {
-      // Would exceed target but fits under hard cap: finalize current WITHOUT this segment
+    if (currentChars + segSize > targetChars) {
+      // Would exceed target: finalize current chunk, start new one with this segment.
+      // Single segments larger than targetChars are already truncated by
+      // extractTranscript to SEGMENT_HARD_CAP, so they fit when alone in a fresh chunk.
       chunks.push(current);
       current = [seg];
       currentChars = segSize;
@@ -940,7 +940,7 @@ export function acquireLock(stateDir: string): string {
     const fd = openSync(lockPath, "wx");
     closeSync(fd);
     // Write PID + timestamp as lock content
-    Bun.write(lockPath, `${process.pid}\n${new Date().toISOString()}\n`);
+    writeFileSync(lockPath, `${process.pid}\n${new Date().toISOString()}\n`);
     return lockPath;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Why

After v1.0 (initial pipeline) and v1.1 (filter ephemeral sessions, raise truncation cap to 120K), the first real-world `mise run distill` runs revealed that 7 of 8 real work sessions still exceeded the 120K-char cap. Truncation correctly marked those sessions as failed for cursor (so they stayed in scope for retry), but with every retry still truncating, the pipeline produced one usable session report per run while losing most of its input.

The right fix isn't a larger cap — qwen3:8b's 128K input context window is the hard ceiling, and pushing chunks toward that ceiling degrades attention quality on 8B-class models ("lost in the middle"). The right fix is **chunked summarization at message boundaries**, with each chunk processed independently.

This pattern is borrowed from [`cortexkit/magic-context`](https://github.com/cortexkit/magic-context), which solves the same problem for the live OpenCode session compartmentalization layer. Magic Context uses token-based message-boundary chunking with completely independent per-chunk summarization (no rolled-forward context, no second-pass consolidator). The simpler shape generalizes well to this batch-processing pipeline.

## What

The pipeline now splits long transcripts into chunks of ~55K chars (hard cap 70K) at `USER:` / `ASSISTANT:` message boundaries, runs each chunk through `qwen3:8b` independently with the existing report-block prompt, and concatenates the resulting blocks under a single session header that names the chunk count when >1.

### Core chunking changes

- **`extractTranscript` no longer truncates the overall transcript.** Returns a new `segments: MessageSegment[]` field alongside the existing concatenated `transcript` string. Per-segment truncation only fires when a single message body exceeds the 70K-char segment cap (rare; typical messages are 1-5K). Stats now include `segments_total` and `segments_truncated`.
- **New `chunkSegments(segments, targetChars = 55_000, hardCapChars = 70_000): MessageSegment[][]`.** Pure function. Packs segments into chunks greedily, never cuts mid-segment, finalizes the current chunk when adding the next segment would exceed the target (preferred) or hard cap (forced).
- **New `renderChunkTranscript(segments): string`.** Reconstructs the `USER: ...\nASSISTANT: ...` format that `callOllama()` expects from a chunk's segments.
- **Normal-mode main loop and `--session` mode both rewired.** Per-session: extract → chunk → for each chunk run `callOllama` → concat outputs under one session header.
- **Session header convention.** Multi-chunk sessions show `### Session <id> (<N> chunks)` when all succeed, or `### Session <id> (<M>/<N> chunks succeeded)` on partial failure. Single-chunk sessions keep the existing `### Session <id>` shape.
- **`num_ctx` stays at 32768.** Chunks ≤60K chars fit comfortably within the existing validated operating point. No Ollama config change.

### First-real-world-run adjustments

The first end-to-end smoke against the live SQLite store surfaced four issues that the unit-test sample didn't catch. All four are addressed here:

- **Per-call Ollama timeout raised from 300s to 600s.** Real chunks take ~1m50s on M1 Pro 16GB with `qwen3:8b`. Occasional content-dependent slow chunks needed more headroom than the original timeout allowed.
- **`selectSessions` byte cap removed.** The 1.5MB cumulative cap predated chunked inference and was a context-window guard. With chunking, each session is independently chunked, so a per-session byte budget is no longer meaningful. The `maxSessions` count cap is retained as the sole selection limit. The `maxBytes` parameter is kept in the function signature for API compatibility with a `deprecated` comment and an `Infinity` default.
- **Partial-success content preserved.** When a session's first N chunks succeed and chunk N+1 fails, the N successful chunks are now written to the report under a `(N/M chunks succeeded)` header. Cursor advance still requires all chunks to succeed — failed-but-partial sessions stay in scope for retry, but their partial content isn't discarded.
- **`report_path` always resolved in JSONL.** Previously the JSONL `report_path` field was empty when zero sessions succeeded, hiding the fact that `--out` was honored. Now it always reports the destination path (`--out` value or `<state-dir>/reports/<date>.md`).

### Per-chunk independence is intentional

Each chunk is summarized in isolation. Sessions where context built up in chunk N only pays off in chunk N+1 will produce a thinner second block. This is documented in a code comment block above the chunker. Two reasons to accept the tradeoff rather than add a consolidation pass:

1. 8B-class models hallucinate or lose coherence on "consolidate previous summaries" tasks.
2. A second LLM pass doubles inference cost. The empirical signal from earlier runs is "more chunks, more raw signal, fewer hallucinations" — the right direction is more first-pass output, not more refinement.

The deferred follow-up is cross-chunk title-fuzzy-match dedup if duplication becomes annoying in practice. Cheap, deterministic, no extra LLM calls.

## Tests

89 tests (was 67 baseline before chunking, 84 after the first chunking pass, 89 after the fix pack). 22 new tests covering:

- `chunkSegments`: empty input, single small segment, segments that pack exactly under target, segments that overflow into a new chunk at the target boundary, segments that force a hard-cap split, a single oversized segment forming its own chunk.
- `renderChunkTranscript`: single segment, multi-segment alternation, ASSISTANT-only.
- End-to-end success: a multi-segment session produces multiple chunks, all successful, header shows `(N chunks)`, total block count is the sum across chunks.
- End-to-end failure: chunk 2 fails Ollama; session marked failed for cursor; JSONL `errors[]` records the failing chunk index in the message.
- End-to-end partial: chunks 1-3 succeed, chunk 4 fails; report contains 3 blocks under `(3/5 chunks succeeded)` title; cursor doesn't advance.
- Multi-session combinations: partial-success session + full-success session in one run; report contains both, `report_blocks_generated` is the sum.
- Timeout error string uses "600s" (regression on the raised constant).
- `selectSessions` no longer caps by bytes: 10 sessions × 200K chars each all selected when `maxSessions ≥ 10`.
- Regression: single-chunk sessions keep the original header shape (no `(N chunks)` suffix).

## What's still imperfect

- **Per-chunk inference is slow on M1 Pro 16GB.** ~2m20s per 55K-char chunk with `num_ctx: 32768`. Real sessions are 1700-4700 messages → 14-40 chunks → 30-90 minutes per session. A full 7-day-window batch (8 sessions) takes 6-8 hours. The pipeline accepts this as a known constraint for now; a future revision will add a `--max-sessions=<N>` cap (current default is 50) so the user can run smaller batches that catch up incrementally via the cursor.
- The cap at 70K chars means a single message exceeding 70K still truncates mid-message. Rare for real OpenCode sessions but possible (e.g., a giant pasted log). The truncation marker remains; affected segments mark the session as failed for cursor.
- No cross-chunk dedup. If two chunks of the same session both produce a block on "Decision: use X", both appear in the report. Deferred until empirically annoying.