### PR TITLE
chore(ollama-distill): v1.3 cleanup pass

### DIFF
--- a/.config/opencode/scripts/ollama-distill.test.ts
+++ b/.config/opencode/scripts/ollama-distill.test.ts
@@ -1602,7 +1602,7 @@ describe("acquireLock / releaseLock", () => {
 
 describe("chunkSegments", () => {
   function seg(role: "USER" | "ASSISTANT", chars: number): MessageSegment {
-    return { role, text: "x".repeat(chars), char_count: chars };
+    return { kind: "text", role, text: "x".repeat(chars), char_count: chars, time_created: 0, message_id: "msg_test" };
   }
 
   test("empty input returns empty array", () => {
@@ -1682,35 +1682,35 @@ describe("chunkSegments", () => {
 
 describe("renderChunkTranscript", () => {
   test("single USER segment renders correctly", () => {
-    const segments: MessageSegment[] = [{ role: "USER", text: "hello world", char_count: 11 }];
+    const segments: MessageSegment[] = [{ kind: "text", role: "USER", text: "hello world", char_count: 11, time_created: 0, message_id: "m1" }];
     expect(renderChunkTranscript(segments)).toBe("USER: hello world");
   });
 
   test("single ASSISTANT segment renders correctly", () => {
-    const segments: MessageSegment[] = [{ role: "ASSISTANT", text: "hi there", char_count: 8 }];
+    const segments: MessageSegment[] = [{ kind: "text", role: "ASSISTANT", text: "hi there", char_count: 8, time_created: 0, message_id: "m2" }];
     expect(renderChunkTranscript(segments)).toBe("ASSISTANT: hi there");
   });
 
   test("multi-segment renders with role prefixes and newlines", () => {
     const segments: MessageSegment[] = [
-      { role: "USER", text: "question", char_count: 8 },
-      { role: "ASSISTANT", text: "answer", char_count: 6 },
+      { kind: "text", role: "USER", text: "question", char_count: 8, time_created: 0, message_id: "m3" },
+      { kind: "text", role: "ASSISTANT", text: "answer", char_count: 6, time_created: 0, message_id: "m4" },
     ];
     expect(renderChunkTranscript(segments)).toBe("USER: question\nASSISTANT: answer");
   });
 
   test("USER+ASSISTANT alternation renders in order", () => {
     const segments: MessageSegment[] = [
-      { role: "USER", text: "a", char_count: 1 },
-      { role: "ASSISTANT", text: "b", char_count: 1 },
-      { role: "USER", text: "c", char_count: 1 },
+      { kind: "text", role: "USER", text: "a", char_count: 1, time_created: 0, message_id: "m5" },
+      { kind: "text", role: "ASSISTANT", text: "b", char_count: 1, time_created: 0, message_id: "m6" },
+      { kind: "text", role: "USER", text: "c", char_count: 1, time_created: 0, message_id: "m7" },
     ];
     expect(renderChunkTranscript(segments)).toBe("USER: a\nASSISTANT: b\nUSER: c");
   });
 
   test("ASSISTANT-only segment renders correctly", () => {
     const segments: MessageSegment[] = [
-      { role: "ASSISTANT", text: "standalone", char_count: 10 },
+      { kind: "text", role: "ASSISTANT", text: "standalone", char_count: 10, time_created: 0, message_id: "m8" },
     ];
     expect(renderChunkTranscript(segments)).toBe("ASSISTANT: standalone");
   });
@@ -2281,7 +2281,7 @@ describe("callOllama malformed response handling", () => {
       new Response("<html>Bad Gateway</html>", { status: 200 });
 
     try {
-      const result = await callOllama("http://127.0.0.1:11434", "sys", "transcript", "ses_x");
+      const result = await callOllama("test transcript");
       expect(result.output).toBe("");
       expect(result.error).toBeDefined();
       const errMsg = result.error!.toLowerCase();
@@ -2296,7 +2296,7 @@ describe("callOllama malformed response handling", () => {
       new Response(JSON.stringify({ response: "wrong shape" }), { status: 200 });
 
     try {
-      const result = await callOllama("http://127.0.0.1:11434", "sys", "transcript", "ses_x");
+      const result = await callOllama("test transcript");
       expect(result.output).toBe("");
       expect(result.error).toBeDefined();
     } finally {
@@ -2354,7 +2354,7 @@ describe("chunkSegments exact-boundary edge cases", () => {
   // ROLE_PREFIX_OVERHEAD = 12 (see ollama-distill.ts)
   const ROLE_PREFIX_OVERHEAD = 12;
 
-  function makeSegment(chars: number, role: "user" | "assistant" = "user"): MessageSegment {
+  function makeSegment(chars: number, role: "USER" | "ASSISTANT" = "USER"): MessageSegment {
     return {
       kind: "text",
       role,

--- a/.config/opencode/scripts/ollama-distill.test.ts
+++ b/.config/opencode/scripts/ollama-distill.test.ts
@@ -1098,7 +1098,7 @@ describe("main", () => {
     }
   });
 
-  test("--session non-mutating: cursor file not created, output to stdout", async () => {
+  test("--session does not advance cursor: cursor file not created, JSONL written, output to stdout", async () => {
     const stateDir = join(tmpdir(), "distill-test-session-" + Math.random().toString(36).slice(2));
     const dbPath = join(tmpdir(), "distill-test-session-" + Math.random().toString(36).slice(2) + ".db");
     createFileDb(dbPath, [{ id: "ses_test123", timeUpdated: 2000, text: "session content here" }]);
@@ -1112,12 +1112,23 @@ describe("main", () => {
       const code = await main(["bun", "script.ts", "--session=ses_test123"], (s) => stdoutLines.push(s), () => {});
       expect(code).toBe(0);
 
-      // Cursor must NOT be created (non-mutating)
+      // Cursor must NOT be created (does not advance cursor)
       expect(existsSync(join(stateDir, "cursor.json"))).toBe(false);
+
+      // JSONL IS written (all distillation activity is auditable)
+      const logPath = join(stateDir, "runs.jsonl");
+      expect(existsSync(logPath)).toBe(true);
+      const record = JSON.parse(readFileSync(logPath, "utf8").trim());
+      expect(record.mode).toBe("session");
 
       // Output should contain the session block
       const stdout = stdoutLines.join("");
       expect(stdout).toContain("ses_test123");
+
+      // Default report path (YYYY-MM-DD.md) must NOT be touched
+      const dateStr = new Date().toISOString().slice(0, 10);
+      const defaultReport = join(stateDir, "reports", `${dateStr}.md`);
+      expect(existsSync(defaultReport)).toBe(false);
     } finally {
       globalThis.fetch = originalFetch;
       delete process.env.OLLAMA_DISTILL_STATE_DIR;
@@ -1433,13 +1444,13 @@ describe("main", () => {
   });
 
   // Fix #2: File lock prevents concurrent runs
-  test("Fix #2: lock file present → main exits 1 with 'another distill run' message", async () => {
+  test("Fix #2: lock file present with live PID → main exits 1 with 'another distill run' message", async () => {
     const stateDir = join(tmpdir(), "distill-test-lock-" + Math.random().toString(36).slice(2));
     mkdirSync(stateDir, { recursive: true });
 
-    // Write a sentinel lock file
+    // Write a lock file with the CURRENT process PID (live process — not stale)
     const lockPath = join(stateDir, ".lock");
-    writeFileSync(lockPath, "99999\n2026-01-01T00:00:00.000Z\n");
+    writeFileSync(lockPath, `${process.pid}\n2026-01-01T00:00:00.000Z\n`);
 
     const stderrLines: string[] = [];
     process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
@@ -1511,6 +1522,51 @@ describe("main", () => {
       expect(record.success).toBe(false);
       // Schema error is caught during openDatabase (db-open-failure) or selectSessions
       expect(["db-open-failure", "schema-invariant-violation"]).toContain(record.errors[0].phase);
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+
+  // FIX-T1: truncated segment → exit 1, phase:"truncation" in JSONL, cursor not advanced
+  test("truncated segment: exit 1, JSONL has phase:truncation, cursor not advanced past session", async () => {
+    const stateDir = join(tmpdir(), "distill-test-trunc-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-test-trunc-" + Math.random().toString(36).slice(2) + ".db");
+    const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+    const now = Date.now();
+
+    // One root session with a part whose text exceeds SEGMENT_HARD_CAP (70K)
+    createFileDb(dbPath, [{
+      id: "ses_trunc1",
+      timeUpdated: now - 1000,
+      text: "x".repeat(80_000),
+    }]);
+
+    globalThis.fetch = mockOllamaOk("## Test Block\n\n**Category:** Test\n**Insight:** mocked\n");
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(["bun", "script.ts"], () => {}, () => {});
+      expect(code).toBe(1);
+
+      // JSONL: errors array must contain a truncation entry for this session
+      const logPath = join(stateDir, "runs.jsonl");
+      expect(existsSync(logPath)).toBe(true);
+      const record = JSON.parse(readFileSync(logPath, "utf8").trim());
+      const truncErr = record.errors?.find(
+        (e: { phase: string; session_id: string }) => e.phase === "truncation" && e.session_id === "ses_trunc1"
+      );
+      expect(truncErr).toBeDefined();
+
+      // Cursor must NOT have advanced past the truncated session — stays at bootstrap floor
+      const cursorPath = join(stateDir, "cursor.json");
+      expect(existsSync(cursorPath)).toBe(true);
+      const cursor = JSON.parse(readFileSync(cursorPath, "utf8"));
+      expect(cursor.last_run_timestamp).toBeGreaterThan(now - SEVEN_DAYS_MS - 5000);
+      expect(cursor.last_run_timestamp).toBeLessThan(now - SEVEN_DAYS_MS + 5000);
     } finally {
       globalThis.fetch = originalFetch;
       delete process.env.OLLAMA_DISTILL_STATE_DIR;
@@ -2118,5 +2174,234 @@ describe("v1.2 smoke fixes", () => {
       delete process.env.OPENCODE_DB_PATH;
       if (existsSync(dbPath)) unlinkSync(dbPath);
     }
+  });
+});
+
+// ─── FIX-T2: Stale-lock recovery tests ────────────────────────────────────────
+
+describe("acquireLock stale-lock recovery", () => {
+  test("empty lockfile → treated as stale, lock acquired", () => {
+    const stateDir = join(tmpdir(), "distill-lock-empty-" + Math.random().toString(36).slice(2));
+    mkdirSync(stateDir, { recursive: true });
+    const lockPath = join(stateDir, ".lock");
+    writeFileSync(lockPath, ""); // empty — malformed
+
+    // Should not throw; stale lock is cleaned up and re-acquired
+    let acquiredPath: string | undefined;
+    expect(() => { acquiredPath = acquireLock(stateDir); }).not.toThrow();
+    expect(existsSync(lockPath)).toBe(true);
+    if (acquiredPath) releaseLock(acquiredPath);
+  });
+
+  test("lockfile with dead PID → treated as stale, lock acquired", () => {
+    const stateDir = join(tmpdir(), "distill-lock-dead-" + Math.random().toString(36).slice(2));
+    mkdirSync(stateDir, { recursive: true });
+    const lockPath = join(stateDir, ".lock");
+    // Use a very high PID that almost certainly doesn't exist
+    writeFileSync(lockPath, "9999999\n2026-01-01T00:00:00.000Z\n");
+
+    let acquiredPath: string | undefined;
+    expect(() => { acquiredPath = acquireLock(stateDir); }).not.toThrow();
+    expect(existsSync(lockPath)).toBe(true);
+    if (acquiredPath) releaseLock(acquiredPath);
+  });
+
+  test("lockfile with malformed content (non-numeric PID) → treated as stale, lock acquired", () => {
+    const stateDir = join(tmpdir(), "distill-lock-malformed-" + Math.random().toString(36).slice(2));
+    mkdirSync(stateDir, { recursive: true });
+    const lockPath = join(stateDir, ".lock");
+    writeFileSync(lockPath, "not-a-pid\n2026-01-01T00:00:00.000Z\n");
+
+    let acquiredPath: string | undefined;
+    expect(() => { acquiredPath = acquireLock(stateDir); }).not.toThrow();
+    expect(existsSync(lockPath)).toBe(true);
+    if (acquiredPath) releaseLock(acquiredPath);
+  });
+
+  test("lockfile with live PID → throws 'another distill run' error", () => {
+    const stateDir = join(tmpdir(), "distill-lock-live-" + Math.random().toString(36).slice(2));
+    mkdirSync(stateDir, { recursive: true });
+    const lockPath = join(stateDir, ".lock");
+    // Use current process PID — definitely alive
+    writeFileSync(lockPath, `${process.pid}\n2026-01-01T00:00:00.000Z\n`);
+
+    expect(() => acquireLock(stateDir)).toThrow(/another distill run/);
+    // Clean up manually since we didn't acquire
+    unlinkSync(lockPath);
+  });
+});
+
+// ─── FIX-T3: Process-listener stability ───────────────────────────────────────
+
+describe("main() process listener stability", () => {
+  test("calling main() 5 times does not accumulate SIGINT/SIGTERM/exit listeners", async () => {
+    const stateDir = join(tmpdir(), "distill-listener-" + Math.random().toString(36).slice(2));
+    mkdirSync(stateDir, { recursive: true });
+    const dbPath = join(tmpdir(), "distill-listener-" + Math.random().toString(36).slice(2) + ".db");
+
+    // Create a minimal DB so main() gets past DB open
+    const db = new Database(dbPath);
+    db.run(`CREATE TABLE IF NOT EXISTS session (id TEXT, "time_updated" INTEGER)`);
+    db.run(`CREATE TABLE IF NOT EXISTS message (id TEXT, session_id TEXT, data TEXT)`);
+    db.run(`CREATE TABLE IF NOT EXISTS message_part (id TEXT, message_id TEXT, data TEXT)`);
+    db.close();
+
+    globalThis.fetch = mockOllamaOk();
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    const before = {
+      sigint: process.listenerCount("SIGINT"),
+      sigterm: process.listenerCount("SIGTERM"),
+      exit: process.listenerCount("exit"),
+    };
+
+    try {
+      for (let i = 0; i < 5; i++) {
+        await main(["bun", "script.ts"], () => {}, () => {});
+      }
+
+      expect(process.listenerCount("SIGINT")).toBeLessThanOrEqual(before.sigint + 1);
+      expect(process.listenerCount("SIGTERM")).toBeLessThanOrEqual(before.sigterm + 1);
+      expect(process.listenerCount("exit")).toBeLessThanOrEqual(before.exit + 1);
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+});
+
+// ─── FIX-T5: Malformed-200 Ollama response ────────────────────────────────────
+
+describe("callOllama malformed response handling", () => {
+  test("HTML 200 response → error contains 'malformed' or 'parse'", async () => {
+    globalThis.fetch = async () =>
+      new Response("<html>Bad Gateway</html>", { status: 200 });
+
+    try {
+      const result = await callOllama("http://127.0.0.1:11434", "sys", "transcript", "ses_x");
+      expect(result.output).toBe("");
+      expect(result.error).toBeDefined();
+      const errMsg = result.error!.toLowerCase();
+      expect(errMsg.match(/malformed|parse|json/)).toBeTruthy();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("valid JSON but wrong shape (missing message.content) → error", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ response: "wrong shape" }), { status: 200 });
+
+    try {
+      const result = await callOllama("http://127.0.0.1:11434", "sys", "transcript", "ses_x");
+      expect(result.output).toBe("");
+      expect(result.error).toBeDefined();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+// ─── FIX-T6: Cursor non-advancement assertion (strengthen) ────────────────────
+
+describe("cursor non-advancement on error", () => {
+  test("cursor stays near bootstrap value when all sessions fail", async () => {
+    const stateDir = join(tmpdir(), "distill-cursor-noadvance-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-cursor-noadvance-" + Math.random().toString(36).slice(2) + ".db");
+
+    const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+    const now = Date.now();
+
+    // Session with timeUpdated in the last 7 days so it's in window
+    const db = new Database(dbPath);
+    db.run(`CREATE TABLE IF NOT EXISTS session (id TEXT, "time_updated" INTEGER)`);
+    db.run(`CREATE TABLE IF NOT EXISTS message (id TEXT, session_id TEXT, data TEXT)`);
+    db.run(`CREATE TABLE IF NOT EXISTS message_part (id TEXT, message_id TEXT, data TEXT)`);
+    db.run(`INSERT INTO session VALUES ('ses_fail1', ${now - 1000})`);
+    db.close();
+
+    globalThis.fetch = async () => new Response("Internal Server Error", { status: 500 });
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(["bun", "script.ts"], () => {}, () => {});
+      expect(code).toBe(1);
+
+      // Cursor should NOT have been advanced — it stays at bootstrap
+      const cursorPath = join(stateDir, "cursor.json");
+      if (existsSync(cursorPath)) {
+        const cursor = JSON.parse(readFileSync(cursorPath, "utf8"));
+        // Bootstrap value is Date.now() - SEVEN_DAYS_MS at time of run
+        expect(cursor.last_run_timestamp).toBeGreaterThan(now - SEVEN_DAYS_MS - 5000);
+        expect(cursor.last_run_timestamp).toBeLessThan(now - SEVEN_DAYS_MS + 5000);
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+});
+
+// ─── FIX-T7: chunkSegments exact-boundary cases ───────────────────────────────
+
+describe("chunkSegments exact-boundary edge cases", () => {
+  // ROLE_PREFIX_OVERHEAD = 12 (see ollama-distill.ts)
+  const ROLE_PREFIX_OVERHEAD = 12;
+
+  function makeSegment(chars: number, role: "user" | "assistant" = "user"): MessageSegment {
+    return {
+      kind: "text",
+      role,
+      text: "x".repeat(chars),
+      char_count: chars,
+      time_created: Date.now(),
+      message_id: "msg_" + Math.random().toString(36).slice(2),
+    };
+  }
+
+  test("single segment whose size exactly equals targetChars fits in one chunk", () => {
+    const targetChars = 1000;
+    // segSize = char_count + ROLE_PREFIX_OVERHEAD; to get segSize === targetChars:
+    const charCount = targetChars - ROLE_PREFIX_OVERHEAD;
+    const seg = makeSegment(charCount);
+    const chunks = chunkSegments([seg], targetChars);
+    expect(chunks.length).toBe(1);
+    expect(chunks[0].length).toBe(1);
+  });
+
+  test("single segment one byte over targetChars still fits alone (oversized goes in own chunk)", () => {
+    const targetChars = 1000;
+    const charCount = targetChars - ROLE_PREFIX_OVERHEAD + 1; // segSize = targetChars + 1
+    const seg = makeSegment(charCount);
+    const chunks = chunkSegments([seg], targetChars);
+    // Single oversized segment always goes in its own chunk (extractTranscript already capped it)
+    expect(chunks.length).toBe(1);
+  });
+
+  test("two segments whose combined size exactly equals targetChars fit in one chunk", () => {
+    const targetChars = 1000;
+    // Each segment: charCount such that 2 * (charCount + ROLE_PREFIX_OVERHEAD) === targetChars
+    const charCount = Math.floor((targetChars - 2 * ROLE_PREFIX_OVERHEAD) / 2);
+    const segs = [makeSegment(charCount), makeSegment(charCount)];
+    // Combined segSize = 2 * (charCount + ROLE_PREFIX_OVERHEAD) <= targetChars
+    const chunks = chunkSegments(segs, targetChars);
+    expect(chunks.length).toBe(1);
+  });
+
+  test("second segment pushes combined size one byte over targetChars → splits into two chunks", () => {
+    const targetChars = 1000;
+    // First segment fills exactly half
+    const charCount = Math.floor((targetChars - 2 * ROLE_PREFIX_OVERHEAD) / 2);
+    const seg1 = makeSegment(charCount);
+    // Second segment is one byte larger, pushing total over targetChars
+    const seg2 = makeSegment(charCount + 1);
+    const chunks = chunkSegments([seg1, seg2], targetChars);
+    expect(chunks.length).toBe(2);
   });
 });

--- a/.config/opencode/scripts/ollama-distill.ts
+++ b/.config/opencode/scripts/ollama-distill.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { Database } from "bun:sqlite";
-import { mkdirSync, renameSync, existsSync, appendFileSync, openSync, closeSync, unlinkSync, writeFileSync, lstatSync } from "node:fs";
+import { mkdirSync, renameSync, existsSync, appendFileSync, openSync, closeSync, unlinkSync, writeFileSync, lstatSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 
@@ -1083,7 +1083,7 @@ export function acquireLock(stateDir: string): string {
     // EEXIST: check if the lock is stale (dead PID or malformed content)
     let isStale = false;
     try {
-      const content = require("node:fs").readFileSync(lockPath, "utf8") as string;
+      const content = readFileSync(lockPath, "utf8") as string;
       const firstLine = content.split("\n")[0]?.trim() ?? "";
       const pid = parseInt(firstLine, 10);
       if (!firstLine || isNaN(pid) || pid <= 0) {

--- a/.config/opencode/scripts/ollama-distill.ts
+++ b/.config/opencode/scripts/ollama-distill.ts
@@ -1,16 +1,21 @@
 #!/usr/bin/env bun
 import { Database } from "bun:sqlite";
-import { mkdirSync, renameSync, existsSync, appendFileSync, openSync, closeSync, unlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, renameSync, existsSync, appendFileSync, openSync, closeSync, unlinkSync, writeFileSync, lstatSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type MessageSegment = {
-  role: "USER" | "ASSISTANT";  // matches the existing prefix format
-  text: string;                 // the body of this segment (no leading "USER:" line)
-  char_count: number;
-};
+/**
+ * A single message segment extracted from a session transcript.
+ *
+ * Discriminated on `kind`: "text" for normal message bodies, "reasoning" for
+ * model chain-of-thought blocks. The `kind` field drives the `[reasoning]`
+ * label in renderChunkTranscript — omitting it loses that signal.
+ */
+export type MessageSegment =
+  | { kind: "text"; role: "USER" | "ASSISTANT"; text: string; char_count: number; time_created: number; message_id: string }
+  | { kind: "reasoning"; role: "USER" | "ASSISTANT"; text: string; char_count: number; time_created: number; message_id: string };
 
 export type ExtractStats = {
   messages: number;
@@ -19,14 +24,14 @@ export type ExtractStats = {
   skipped_parts: number;
   skipped_types: string[];
   transcript_chars: number;
-  truncated: boolean;           // now means "a single message exceeded the hard cap and got truncated mid-message"
-  segments_total: number;       // NEW
-  segments_truncated: number;   // NEW — usually 0
+  truncated: boolean;           // true when a single message body exceeded the hard cap and got truncated mid-message
+  segments_total: number;
+  segments_truncated: number;   // usually 0; >0 means cursor will not advance past this session
 };
 
 export type ExtractResult = {
-  transcript: string;           // existing — concatenated USER:/ASSISTANT: lines, unchanged shape
-  segments: MessageSegment[];   // NEW — for the chunker
+  transcript: string;           // concatenated USER:/ASSISTANT: lines, unchanged shape
+  segments: MessageSegment[];   // for the chunker
   stats: ExtractStats;
 };
 
@@ -126,6 +131,9 @@ export async function withSqliteBusyRetry<T>(
  * - PRAGMA busy_timeout=5000
  * - Read-only verification probe (CREATE TEMP TABLE must throw)
  * - Schema invariant check (fail-closed on missing columns)
+ *
+ * Gotcha: the read-only probe is bun:sqlite-specific — see inline comment.
+ * // See: docs/solutions/2026-05-22-bun-sqlite-readonly-wal-pattern.md
  */
 export function openDatabase(dbPath: string): Database {
   const uri = "file:" + dbPath + "?mode=ro";
@@ -189,11 +197,10 @@ function checkSchema(db: Database): void {
  *
  * SQL groups message rows with their parts via LEFT JOIN. Parts are ordered
  * chronologically. Each text/reasoning part emits a labeled line; other types
- * are counted as skipped. Truncates at 60K chars (keeping prefix + marker).
- *
- * Retries on SQLITE_BUSY/SQLITE_LOCKED up to 3 times with 100ms backoff.
- */
-export async function extractTranscript(
+ * are counted as skipped. Truncates individual segments at SEGMENT_HARD_CAP
+ * (70K chars) — segments_truncated > 0 in stats means cursor will not advance
+ * past this session.
+ */export async function extractTranscript(
   db: Database,
   sessionId: string
 ): Promise<ExtractResult> {
@@ -217,7 +224,7 @@ export async function extractTranscript(
   return buildTranscript(rows);
 }
 
-// Fix #10: Type-narrowing parse helpers for stored JSON rows
+// Type-narrowing parse helpers for stored JSON rows
 
 /**
  * Parse a part.data JSON string with type narrowing.
@@ -277,7 +284,7 @@ function buildTranscript(rows: TranscriptRow[]): ExtractResult {
     if (!messageMap.has(row.message_id)) {
       messageOrder.push(row.message_id);
 
-      // Fix #10: Use type-narrowing parse helper; skip malformed rows with warning
+      // Use type-narrowing parse helper; skip malformed rows with warning
       const envelope = parseMessageEnvelope(row.message_data);
       if (envelope === null) {
         process.stderr.write(
@@ -306,7 +313,7 @@ function buildTranscript(rows: TranscriptRow[]): ExtractResult {
     stats.messages++;
 
     for (const row of partRows) {
-      // Fix #10: Use type-narrowing parse helper; skip malformed parts with warning
+      // Use type-narrowing parse helper; skip malformed parts with warning
       const partData = parsePartData(row.part_data!);
       if (partData === null) {
         process.stderr.write(
@@ -333,7 +340,7 @@ function buildTranscript(rows: TranscriptRow[]): ExtractResult {
         continue;
       }
 
-      // Fix #1: Per-segment hard cap — if a single message body exceeds SEGMENT_HARD_CAP,
+      // Per-segment hard cap — if a single message body exceeds SEGMENT_HARD_CAP,
       // prefix-truncate that ONE segment and flag it. Other segments stay intact.
       let finalSegText = segText;
       let segTruncated = false;
@@ -346,18 +353,17 @@ function buildTranscript(rows: TranscriptRow[]): ExtractResult {
       }
 
       segments.push({
+        kind: partData.type === "reasoning" ? "reasoning" : "text",
         role: segRole,
         text: finalSegText,
         char_count: finalSegText.length,
+        time_created: 0,  // not available from this query; set to 0
+        message_id: row.message_id,
       });
 
       // Build the concatenated transcript line (backward-compat)
       const line = linePrefix + finalSegText;
       lines.push(line);
-
-      if (segTruncated) {
-        // Don't break — other messages still get processed into segments
-      }
     }
   }
 
@@ -438,11 +444,14 @@ export function chunkSegments(
 
 /**
  * Reconstruct the USER: .../ASSISTANT: ... transcript string from a chunk's
- * segments. Matches the exact format extractTranscript produces.
+ * segments. Emits `[reasoning]` label for reasoning segments to preserve
+ * that signal for the model.
  */
 export function renderChunkTranscript(segments: MessageSegment[]): string {
   return segments
-    .map((seg) => `${seg.role}: ${seg.text}`)
+    .map((seg) => seg.kind === "reasoning"
+      ? `${seg.role} [reasoning]: ${seg.text}`
+      : `${seg.role}: ${seg.text}`)
     .join("\n");
 }
 
@@ -456,11 +465,31 @@ const CURSOR_FILENAME = "cursor.json";
 const CURSOR_TMP_FILENAME = "cursor.json.tmp";
 const SEVEN_DAYS_MS = 7 * 24 * 3600 * 1000;
 
+/**
+ * Type guard for Cursor. Validates shape and timestamp plausibility.
+ * Allows up to one day in the future to tolerate clock drift.
+ */
+function isCursor(x: unknown): x is Cursor {
+  if (typeof x !== "object" || x === null) return false;
+  if (!("last_run_timestamp" in x)) return false;
+  const ts = (x as { last_run_timestamp: unknown }).last_run_timestamp;
+  if (typeof ts !== "number") return false;
+  if (ts < 0) return false;
+  if (ts > Date.now() + 86_400_000) return false; // one day future tolerance
+  return true;
+}
+
+/**
+ * Load the cursor from disk. Falls back to a 7-day bootstrap window on
+ * missing file, JSON parse error, or shape mismatch.
+ */
 export async function loadCursor(stateDir: string): Promise<Cursor> {
   const cursorPath = stateDir + "/" + CURSOR_FILENAME;
   if (existsSync(cursorPath)) {
     try {
-      return await Bun.file(cursorPath).json() as Cursor;
+      const parsed: unknown = await Bun.file(cursorPath).json();
+      if (isCursor(parsed)) return parsed;
+      // Shape mismatch — fall through to bootstrap
     } catch {
       // Corrupted file — bootstrap
     }
@@ -468,6 +497,10 @@ export async function loadCursor(stateDir: string): Promise<Cursor> {
   return { last_run_timestamp: Date.now() - SEVEN_DAYS_MS };
 }
 
+/**
+ * Persist the cursor to disk using an atomic tmp-rename write.
+ * Creates the state directory if it doesn't exist.
+ */
 export async function saveCursor(stateDir: string, cursor: Cursor): Promise<void> {
   mkdirSync(stateDir, { recursive: true });
   const tmpPath = stateDir + "/" + CURSOR_TMP_FILENAME;
@@ -496,16 +529,23 @@ export type SelectionResult = {
   max_processed_time_updated: number;
 };
 
+/**
+ * Select sessions updated since `lastRunTimestamp`, extract their transcripts,
+ * and return them ordered by `time_updated` ASC.
+ *
+ * Caps at `maxSessions` (default 50). Fetches 1.5× that to allow for sessions
+ * that produce empty transcripts. Returns the `max_processed_time_updated` for
+ * cursor advancement.
+ */
 export async function selectSessions(
   db: Database,
   lastRunTimestamp: number | null,
-  maxSessions = 50,
-  maxBytes = Infinity  // deprecated: chunked inference makes per-session byte caps unnecessary; kept for API compat
+  maxSessions = 50
 ): Promise<SelectionResult> {
   const since = lastRunTimestamp ?? 0;
   const fetchCap = Math.ceil(maxSessions * 1.5);
 
-  // Fix #4: Wrap session-list SELECT with SQLITE_BUSY retry helper
+  // Wrap session-list SELECT with SQLITE_BUSY retry helper
   const rows = await withSqliteBusyRetry(() =>
     db
       .query<SessionRow, [number, number]>(
@@ -533,6 +573,20 @@ export async function selectSessions(
       : (lastRunTimestamp ?? 0);
 
   return { sessions, max_processed_time_updated };
+}
+
+/**
+ * Type guard for the Ollama /api/chat response shape.
+ * Expects { message: { content: string } }.
+ */
+function isOllamaChatResponse(x: unknown): x is { message: { content: string } } {
+  return (
+    typeof x === "object" && x !== null && "message" in x &&
+    typeof (x as { message: unknown }).message === "object" &&
+    (x as { message: unknown }).message !== null &&
+    "content" in (x as { message: object }).message &&
+    typeof (x as { message: { content: unknown } }).message.content === "string"
+  );
 }
 
 // ─── Ollama Client ────────────────────────────────────────────────────────────
@@ -583,6 +637,14 @@ export type OllamaResult = {
   error?: string;
 };
 
+/**
+ * Call the Ollama /api/chat endpoint with the system prompt + transcript.
+ * Returns { output, durationMs } on success, or { output: "", error } on failure.
+ *
+ * Gotcha: times out after 10 minutes (OLLAMA_TIMEOUT_MS). Chunks typically
+ * take ~1m50s; the 10x cap covers slow chunks without unbounded hang.
+ * No retry on HTTP errors — that's deferred to v1.4.
+ */
 export async function callOllama(
   transcript: string,
   model = "qwen3:8b"
@@ -629,7 +691,7 @@ export async function callOllama(
     };
   }
 
-  // Fix #9: Parse and narrow the Ollama response shape instead of asserting
+  // Parse and narrow the Ollama response shape
   let rawBody: unknown;
   try {
     rawBody = await response.json();
@@ -642,15 +704,7 @@ export async function callOllama(
   }
 
   // Narrow: expect { message: { content: string } }
-  if (
-    typeof rawBody !== "object" ||
-    rawBody === null ||
-    !("message" in rawBody) ||
-    typeof (rawBody as { message: unknown }).message !== "object" ||
-    (rawBody as { message: unknown }).message === null ||
-    !("content" in (rawBody as { message: object }).message) ||
-    typeof ((rawBody as { message: { content: unknown } }).message.content) !== "string"
-  ) {
+  if (!isOllamaChatResponse(rawBody)) {
     return {
       output: "",
       durationMs,
@@ -658,7 +712,7 @@ export async function callOllama(
     };
   }
 
-  const content = (rawBody as { message: { content: string } }).message.content;
+  const content = rawBody.message.content;
   if (!content) {
     return { output: "", durationMs, error: "empty response" };
   }
@@ -674,18 +728,37 @@ export type SessionResult = {
   ollamaOutput: string;
 };
 
-// Fix #8: Atomic write helper
-async function atomicWrite(path: string, content: string): Promise<void> {
-  const tmpPath = path + ".tmp";
-  await Bun.write(tmpPath, content);
-  renameSync(tmpPath, path);
-}
-
+/**
+ * Write session results to a Markdown report file.
+ *
+ * Appends to an existing file (with a timestamped separator) or creates a new
+ * one. Refuses to write if the target path is a symbolic link to prevent
+ * symlink-based path traversal attacks.
+ *
+ * Gotcha: only called in normal mode (the file lock serializes concurrent
+ * runs), so the append is safe without additional locking.
+ */
 export async function writeReport(
   reportPath: string,
   runs: SessionResult[]
 ): Promise<void> {
   mkdirSync(dirname(reportPath), { recursive: true });
+
+  // Symlink defense: refuse to write if the path is a symlink
+  try {
+    const stat = lstatSync(reportPath);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`refusing to write report: ${reportPath} is a symbolic link`);
+    }
+  } catch (err) {
+    // lstatSync throws ENOENT if the file doesn't exist — that's fine, continue
+    if (err instanceof Error && !err.message.startsWith("refusing to write")) {
+      const isEnoent = (err as NodeJS.ErrnoException).code === "ENOENT";
+      if (!isEnoent) throw err;
+    } else if (err instanceof Error && err.message.startsWith("refusing to write")) {
+      throw err;
+    }
+  }
 
   const now = new Date();
   const dateStr = now.toISOString().slice(0, 10); // YYYY-MM-DD
@@ -695,14 +768,12 @@ export async function writeReport(
     .map((r) => `### ${r.title} (${r.sessionId})\n\n${r.ollamaOutput}\n\n`)
     .join("");
 
-  // Fix #8: Use atomic write for report (read + concat + atomic write)
   if (existsSync(reportPath)) {
-    const existing = await Bun.file(reportPath).text();
     const separator = `\n\n---\n\n## Run at ${timeStr}\n\n`;
-    await atomicWrite(reportPath, existing + separator + blocks);
+    appendFileSync(reportPath, separator + blocks, "utf8");
   } else {
     const header = `# Distillation Report — ${dateStr}\n\n`;
-    await atomicWrite(reportPath, header + blocks);
+    appendFileSync(reportPath, header + blocks, "utf8");
   }
 }
 
@@ -727,6 +798,12 @@ export type RunRecord = {
   errors: RunError[];
 };
 
+/**
+ * Append a RunRecord as a JSONL line to the audit log.
+ * Creates the log directory if it doesn't exist.
+ * Gotcha: uses synchronous appendFileSync — safe because the file lock
+ * serializes normal-mode runs; session mode writes are inherently single-threaded.
+ */
 export async function appendRunLog(logPath: string, record: RunRecord): Promise<void> {
   mkdirSync(dirname(logPath), { recursive: true });
   const line = JSON.stringify(record) + "\n";
@@ -742,12 +819,16 @@ export type ParsedArgs = {
   extractOnly: boolean;
   help: boolean;
   unknownFlag?: string;
-  flagError?: string;   // Fix #6: validation error for invalid flag values
+  flagError?: string;   // validation error for invalid flag values
 };
 
 /**
  * Parse CLI argv (pass Bun.argv.slice(2) or the raw Bun.argv — we skip the
  * first two elements internally).
+ *
+ * Supports both `--flag=value` and `--flag value` (space-separated) forms for
+ * --session, --since, and --out. Errors clearly if the next arg is missing or
+ * starts with `--`.
  */
 export function parseArgs(argv: string[]): ParsedArgs {
   // Skip interpreter + script path if argv looks like Bun.argv (starts with bun path)
@@ -757,11 +838,13 @@ export function parseArgs(argv: string[]): ParsedArgs {
 
   const result: ParsedArgs = { extractOnly: false, help: false };
 
-  // Fix #7: Track seen flags to detect duplicates
+  // Track seen flags to detect duplicates
   const seenFlags = new Set<string>();
 
-  for (const arg of args) {
-    // Fix #7: Reject positional arguments (anything not starting with --)
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    // Reject positional arguments (anything not starting with --)
     if (!arg.startsWith("--") && arg !== "-h") {
       result.flagError = `Unexpected positional argument: '${arg}'. Use --flag=value syntax.`;
       return result;
@@ -780,19 +863,31 @@ export function parseArgs(argv: string[]): ParsedArgs {
       result.extractOnly = true;
       continue;
     }
-    if (arg.startsWith("--since=")) {
+
+    // Helper: consume next arg as value for space-separated form
+    function consumeNext(flagName: string): string | null {
+      const next = args[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        result.flagError = `Missing value for ${flagName}. Use ${flagName}=<value> or ${flagName} <value>.`;
+        return null;
+      }
+      i++;
+      return next;
+    }
+
+    if (arg.startsWith("--since=") || arg === "--since") {
       if (seenFlags.has("--since")) {
         result.flagError = `Duplicate flag: --since`;
         return result;
       }
       seenFlags.add("--since");
-      const value = arg.slice("--since=".length);
-      // Fix #7: Reject empty values
+      const value = arg === "--since" ? consumeNext("--since") : arg.slice("--since=".length);
+      if (value === null) return result;
       if (value === "") {
         result.flagError = `Empty value for --since. Use --since=<value>.`;
         return result;
       }
-      // Fix #6: parseSince returns null on unparseable input
+      // parseSince returns null on unparseable input
       const parsed = parseSince(value);
       if (parsed === null) {
         result.flagError = `Invalid --since value: '${value}'. Accepted formats: epoch ms (e.g. 1779438773648), ISO date (e.g. 2026-05-21), relative days (e.g. 7d).`;
@@ -801,14 +896,15 @@ export function parseArgs(argv: string[]): ParsedArgs {
       result.since = parsed;
       continue;
     }
-    if (arg.startsWith("--session=")) {
+    if (arg.startsWith("--session=") || arg === "--session") {
       if (seenFlags.has("--session")) {
         result.flagError = `Duplicate flag: --session`;
         return result;
       }
       seenFlags.add("--session");
-      const value = arg.slice("--session=".length);
-      // Fix #7: Reject empty values
+      const value = arg === "--session" ? consumeNext("--session") : arg.slice("--session=".length);
+      if (value === null) return result;
+      // Reject empty values
       if (value === "") {
         result.flagError = `Empty value for --session. Use --session=<id>.`;
         return result;
@@ -816,14 +912,15 @@ export function parseArgs(argv: string[]): ParsedArgs {
       result.session = value;
       continue;
     }
-    if (arg.startsWith("--out=")) {
+    if (arg.startsWith("--out=") || arg === "--out") {
       if (seenFlags.has("--out")) {
         result.flagError = `Duplicate flag: --out`;
         return result;
       }
       seenFlags.add("--out");
-      const value = arg.slice("--out=".length);
-      // Fix #7: Reject empty values
+      const value = arg === "--out" ? consumeNext("--out") : arg.slice("--out=".length);
+      if (value === null) return result;
+      // Reject empty values
       if (value === "") {
         result.flagError = `Empty value for --out. Use --out=<path>.`;
         return result;
@@ -846,7 +943,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
  * - "2026-05-15" → ISO date (start of day UTC)
  * - "1747267200000" → epoch ms (>1_000_000_000_000)
  *
- * Fix #6: Returns null on unparseable input (instead of 0).
+ * Returns null on unparseable input (caller emits error).
  */
 function parseSince(value: string): number | null {
   // Relative: Nd
@@ -872,7 +969,7 @@ function parseSince(value: string): number | null {
   const parsed = Date.parse(value);
   if (!isNaN(parsed) && value.includes("T")) return parsed;
 
-  // Fix #6: Can't parse — return null (caller will emit error)
+  // Can't parse — return null (caller will emit error)
   return null;
 }
 
@@ -885,14 +982,38 @@ USAGE:
   mise run distill -- [OPTIONS]                # note: -- separator forwards flags through mise
 
 OPTIONS:
+  -h, --help          Show this message.
   --since=<value>     Recency filter override. Accepts: '7d', '2026-05-15', or epoch ms.
                       Cursor still advances after success.
-  --session=<id>      Process exactly one session (non-mutating: skips cursor read/write,
-                      writes to stdout unless --out provided).
-  --out=<path>        Override report destination (or stdout target in --session mode).
+                      Example: --since=7d  (backfill last 7 days)
+                      Example: --since=2026-05-01  (from May 1st)
+  --session=<id>      Process exactly one session. Does not advance the cursor and does
+                      not acquire the run lock — safe to run alongside a normal batch.
+                      Writes to stdout unless --out is provided. JSONL is still written.
+                      Example: --session=ses_01jxyz...
+  --out=<path>        Override report destination (or output target in --session mode).
+                      Example: --out=/tmp/review.md
   --extract-only      Print extracted transcript(s) to stdout; skip Ollama call.
                       Useful for debugging the extractor.
-  --help              Show this message.
+                      Example: --extract-only --session=ses_01jxyz...
+
+ENVIRONMENT VARIABLES:
+  OLLAMA_DISTILL_STATE_DIR   Override state directory (default: ~/.local/state/ollama-distill)
+  OPENCODE_DB_PATH           Override OpenCode SQLite path (default: XDG_DATA_HOME/opencode/opencode.db)
+  OLLAMA_KEEP_ALIVE          Consumed by the Ollama server itself (not this script) to control
+                             model keep-alive duration. Set to "0" to unload after each call.
+
+OUTPUT FILES:
+  Report:  \$OLLAMA_DISTILL_STATE_DIR/reports/YYYY-MM-DD.md  (default; overridable with --out)
+  JSONL:   \$OLLAMA_DISTILL_STATE_DIR/runs.jsonl
+  Cursor:  \$OLLAMA_DISTILL_STATE_DIR/cursor.json
+
+EXIT CODES:
+  0   Success — report written, all sessions processed cleanly.
+  1   Failure or partial failure — some sessions failed, Ollama unreachable, schema error, etc.
+      JSONL log carries detailed cause.
+  130 Interrupted (SIGINT / Ctrl-C)
+  143 Terminated (SIGTERM)
 
 EXAMPLES:
   mise run distill                                          # normal run; reads cursor, writes today's report
@@ -910,6 +1031,11 @@ OLLAMA REQUIREMENTS:
 
 const OLLAMA_TAGS_URL = "http://127.0.0.1:11434/api/tags";
 
+/**
+ * Probe Ollama's /api/tags endpoint to verify it's reachable.
+ * Returns { ok: true } on success, { ok: false, error } on failure.
+ * Times out after 2 seconds.
+ */
 export async function checkOllamaReachable(): Promise<{ ok: boolean; error?: string }> {
   try {
     const response = await fetch(OLLAMA_TAGS_URL, {
@@ -931,28 +1057,86 @@ export async function checkOllamaReachable(): Promise<{ ok: boolean; error?: str
  * Acquire a file-based lock using O_EXCL semantics.
  * Returns the lock path on success, throws if already held.
  *
- * Fix #2: Prevents concurrent normal-mode runs.
+ * Stale-lock recovery: on EEXIST, reads the lockfile and probes the PID with
+ * kill(pid, 0). If the process is gone (ESRCH), unlinks the stale lock and
+ * retries once. Malformed lockfiles (empty, non-numeric PID) are treated as
+ * stale. If the retry also fails with EEXIST, the original "another distill
+ * run is in progress" error is thrown.
  */
 export function acquireLock(stateDir: string): string {
   const lockPath = join(stateDir, ".lock");
   mkdirSync(stateDir, { recursive: true });
-  try {
+
+  function tryAcquire(): string {
     const fd = openSync(lockPath, "wx");
     closeSync(fd);
-    // Write PID + timestamp as lock content
     writeFileSync(lockPath, `${process.pid}\n${new Date().toISOString()}\n`);
     return lockPath;
+  }
+
+  try {
+    return tryAcquire();
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes("EEXIST")) {
-      throw new Error(
-        `another distill run is in progress (lock at ${lockPath}); remove it manually if stale`
-      );
+    if (!msg.includes("EEXIST")) throw err;
+
+    // EEXIST: check if the lock is stale (dead PID or malformed content)
+    let isStale = false;
+    try {
+      const content = require("node:fs").readFileSync(lockPath, "utf8") as string;
+      const firstLine = content.split("\n")[0]?.trim() ?? "";
+      const pid = parseInt(firstLine, 10);
+      if (!firstLine || isNaN(pid) || pid <= 0) {
+        // Malformed lockfile — treat as stale
+        isStale = true;
+      } else {
+        try {
+          process.kill(pid, 0);
+          // Process is alive — not stale
+        } catch (killErr) {
+          const killMsg = killErr instanceof Error ? killErr.message : String(killErr);
+          if (killMsg.includes("ESRCH")) {
+            // No such process — stale lock
+            isStale = true;
+          }
+          // EPERM means process exists but we can't signal it — not stale
+        }
+      }
+    } catch {
+      // Can't read lockfile — treat as stale
+      isStale = true;
     }
-    throw err;
+
+    if (isStale) {
+      try {
+        unlinkSync(lockPath);
+      } catch {
+        // Best-effort unlink
+      }
+      // Retry once after removing stale lock
+      try {
+        return tryAcquire();
+      } catch (retryErr) {
+        const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
+        if (retryMsg.includes("EEXIST")) {
+          throw new Error(
+            `another distill run is in progress (lock at ${lockPath}); remove it manually if stale`
+          );
+        }
+        throw retryErr;
+      }
+    }
+
+    throw new Error(
+      `another distill run is in progress (lock at ${lockPath}); remove it manually if stale`
+    );
   }
 }
 
+/**
+ * Release the file lock. Best-effort: swallows errors so it's safe to call
+ * from signal handlers and finally blocks.
+ */
 export function releaseLock(lockPath: string): void {
   try {
     if (existsSync(lockPath)) {
@@ -969,6 +1153,13 @@ const MODEL = "qwen3:8b";
 
 type WriteStream = (s: string) => void;
 
+/**
+ * CLI entry point. Parses argv, dispatches to --session or normal mode,
+ * and returns an exit code (0 = success, 1 = failure, 130/143 = signal).
+ *
+ * Gotcha: registers SIGINT/SIGTERM handlers for lock cleanup and removes them
+ * in a finally block — safe to call multiple times (e.g., in tests).
+ */
 export async function main(
   argv: string[] = Bun.argv,
   stdout: WriteStream = (s) => process.stdout.write(s),
@@ -985,7 +1176,7 @@ export async function main(
       return 0;
     }
 
-    // Fix #6/#7: Flag validation errors
+    // Flag validation errors
     if (args.flagError) {
       stderr(`Error: ${args.flagError}\n\n${USAGE}`);
       return 1;
@@ -1003,7 +1194,7 @@ export async function main(
 
     const logPath = join(stateDir, "runs.jsonl");
 
-    // Fix #5: finalize helper — writes JSONL record then returns exit code
+    // finalize helper — writes JSONL record then returns exit code
     async function finalize(record: RunRecord, exitCode: 0 | 1): Promise<number> {
       try {
         await appendRunLog(logPath, record);
@@ -1123,7 +1314,7 @@ export async function main(
 
     // ── Normal mode ──────────────────────────────────────────────────────────
 
-    // Fix #2: Acquire file lock for normal mode
+    // Acquire file lock for normal mode
     let lockPath: string | null = null;
     try {
       lockPath = acquireLock(stateDir);
@@ -1133,13 +1324,18 @@ export async function main(
       return 1;
     }
 
-    // Register cleanup handlers for lock release
+    // Register cleanup handlers for lock release.
+    // Store refs so we can remove them in the finally block — prevents handler
+    // accumulation when main() is called multiple times (e.g., in tests).
     const cleanupLock = () => {
       if (lockPath) releaseLock(lockPath);
     };
-    process.on("exit", cleanupLock);
-    process.on("SIGINT", () => { cleanupLock(); process.exit(130); });
-    process.on("SIGTERM", () => { cleanupLock(); process.exit(143); });
+    const onExit = () => cleanupLock();
+    const onSigint = () => { cleanupLock(); process.exit(130); };
+    const onSigterm = () => { cleanupLock(); process.exit(143); };
+    process.on("exit", onExit);
+    process.on("SIGINT", onSigint);
+    process.on("SIGTERM", onSigterm);
 
     try {
       // Health check (always in normal mode)
@@ -1160,7 +1356,6 @@ export async function main(
       const dbPath = findOpenCodeDb();
       if (!dbPath) {
         stderr("Could not locate OpenCode SQLite database.\n");
-        // Fix #5: Write JSONL record for early failures
         return await finalize({
           ts: new Date().toISOString(),
           ts_ms: Date.now(),
@@ -1181,7 +1376,6 @@ export async function main(
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         stderr(`Failed to open database: ${msg}\n`);
-        // Fix #5: Write JSONL record for DB open failure
         return await finalize({
           ts: new Date().toISOString(),
           ts_ms: Date.now(),
@@ -1203,7 +1397,6 @@ export async function main(
         db.close();
         const msg = err instanceof Error ? err.message : String(err);
         stderr(`Failed to select sessions: ${msg}\n`);
-        // Fix #5: Write JSONL record for session-select failure
         const phase = err instanceof SchemaError ? "schema-invariant-violation" : "session-select-failure";
         return await finalize({
           ts: new Date().toISOString(),
@@ -1224,7 +1417,9 @@ export async function main(
 
       // 0 sessions: no-op success
       if (sessions.length === 0) {
-        stderr("no new sessions to distill\n");
+        const cursorIso = new Date(effectiveTimestamp ?? 0).toISOString();
+        const windowEndIso = new Date().toISOString();
+        stderr(`no new sessions to distill (cursor at ${cursorIso}, window ends ${windowEndIso})\n`);
         const durationMs = Date.now() - startMs;
         const record: RunRecord = {
           ts: new Date().toISOString(),
@@ -1250,7 +1445,7 @@ export async function main(
         return 0;
       }
 
-      // Fix #4: Process sessions through Ollama with chunked inference.
+      // Process sessions through Ollama with chunked inference.
       // Per-chunk independence is intentional — see chunkSegments() comment block.
       const sessionResults: SessionResult[] = [];
       const errors: RunError[] = [];
@@ -1259,7 +1454,8 @@ export async function main(
       let reportBlocksGenerated = 0;
 
       for (const s of sessions) {
-        // Fix #3: Sessions with per-segment truncation are treated as failures for cursor purposes
+        // Sessions with per-segment truncation are treated as failures for cursor purposes:
+        // the model saw incomplete content, so we don't advance past this session.
         if (s.stats.segments_truncated > 0) {
           errors.push({
             session_id: s.id,
@@ -1308,10 +1504,9 @@ export async function main(
           title = `Session ${s.id}`;
         } else if (allChunksSucceeded) {
           title = `Session ${s.id} (${chunks.length} chunks)`;
-        } else if (chunkBlocks.length > 0) {
-          title = `Session ${s.id} (${chunkBlocks.length}/${chunks.length} chunks succeeded)`;
         } else {
-          title = `Session ${s.id} (failed)`;
+          // Partial failure: some chunks succeeded (chunkBlocks.length > 0 guaranteed by gate below)
+          title = `Session ${s.id} (${chunkBlocks.length}/${chunks.length} chunks succeeded)`;
         }
 
         if (chunkBlocks.length > 0) {
@@ -1333,8 +1528,8 @@ export async function main(
         }
       }
 
-      // Fix #1: Advance cursor only through the longest contiguous successful prefix
-      // Walk sessions in time order; stop at first failure
+      // Advance cursor only through the longest contiguous successful prefix.
+      // Walk sessions in time order; stop at first failure.
       let cursorAdvanceTo: number = cursor.last_run_timestamp ?? 0;
       for (let i = 0; i < sessions.length; i++) {
         if (sessionSucceeded[i]) {
@@ -1379,12 +1574,39 @@ export async function main(
 
       return success ? 0 : 1;
     } finally {
-      // Fix #2: Always release lock
+      // Always release lock and deregister handlers to prevent accumulation
+      // when main() is called multiple times (e.g., in tests).
       if (lockPath) releaseLock(lockPath);
+      process.off("exit", onExit);
+      process.off("SIGINT", onSigint);
+      process.off("SIGTERM", onSigterm);
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     stderr(`Fatal error: ${msg}\n`);
+    // Best-effort: append a fatal RunRecord to JSONL so all distillation activity is auditable.
+    // Don't let JSONL write failure mask the original error.
+    try {
+      const stateDir =
+        process.env.OLLAMA_DISTILL_STATE_DIR ??
+        join(homedir(), ".local/state/ollama-distill");
+      const logPath = join(stateDir, "runs.jsonl");
+      const fatalRecord: RunRecord = {
+        ts: new Date().toISOString(),
+        ts_ms: Date.now(),
+        duration_ms: Date.now() - startMs,
+        mode: "normal",
+        model: MODEL,
+        sessions_read: 0,
+        report_blocks_generated: 0,
+        report_path: "",
+        success: false,
+        errors: [{ session_id: "", phase: "fatal", message: msg }],
+      };
+      await appendRunLog(logPath, fatalRecord);
+    } catch {
+      // Ignore JSONL write failure in fatal path
+    }
     return 1;
   }
 }

--- a/.dotfiles/docs/brainstorms/2026-05-21-local-ollama-distillation-requirements.md
+++ b/.dotfiles/docs/brainstorms/2026-05-21-local-ollama-distillation-requirements.md
@@ -108,6 +108,9 @@ The hardware constrains the cure: local LLMs cannot become another always-on sub
 
 - R16. No input collected by the pipeline is sent to any cloud service. All processing happens locally via Ollama.
 - R17. Pipeline never writes to `opencode.db`. SQLite connection is opened with `PRAGMA query_only=ON`; planning verifies the chosen runtime (Bun's `bun:sqlite` or Python `sqlite3`) enforces this at the connection layer and fails closed if the pragma can't be set.
+- R18. The pipeline acquires a file lock before processing to prevent concurrent batch runs from corrupting the cursor or report.
+- R19. The JSONL audit log records every distillation run (batch and session mode) so all activity is auditable from one place.
+- R20. `--session <id>` mode does not advance the cursor and does not acquire the run lock, so a single-session distillation is safe to run alongside a normal batch. It still writes to the JSONL audit log so all distillation activity is auditable from one place.
 
 ---
 

--- a/.dotfiles/docs/plans/2026-05-22-001-feat-local-ollama-distillation-plan.md
+++ b/.dotfiles/docs/plans/2026-05-22-001-feat-local-ollama-distillation-plan.md
@@ -78,7 +78,7 @@ Origin: `docs/brainstorms/2026-05-21-local-ollama-distillation-requirements.md`
 - **No Modelfile** (resolves OQ2). Ollama HTTP API options pass `think: false`, `temperature: 0.3`, `num_ctx: 32768`.
 - **No "also-ran" tail** (resolves OQ5). R5 quality-rules prompt eliminates padding.
 - **Simplified cursor (revision-1 finding F1):** `cursor.json` stores only `{ last_run_timestamp: number | null }`. No overflow tracking — the recency filter (`WHERE session.time_updated > <last_run_timestamp>`) naturally re-surfaces any sessions not processed in the previous run. R7's per-run cap (50/1.5MB) selects a subset of matching sessions ordered ASC by `time_updated`; on success, the cursor advances to the `time_updated` of the LAST processed session (NOT to `now()`), so unprocessed sessions remain visible to the next run. No state can be silently skipped.
-- **`--session=<id>` is non-mutating (revision-1 finding F3):** When `--session` is passed, the pipeline processes exactly that session and exits. Does NOT read cursor, does NOT update cursor, does NOT write to the default daily report file. Output goes to stdout by default; pass `--out=<path>` to redirect to a file. JSONL log records the run with a `mode: "session"` field so it's distinguishable from regular runs.
+- **`--session=<id>` does not advance cursor (R20):** When `--session` is passed, the pipeline processes exactly that session and exits. Does NOT read cursor, does NOT update cursor, does NOT acquire the run lock, and does NOT write to the default daily report file. Output goes to stdout by default; pass `--out=<path>` to redirect to a file. JSONL log records the run with a `mode: "session"` field so all distillation activity is auditable from one place.
 - **`--since=<value>` is a recency-filter override that does NOT mutate cursor:** Behaves the same as a regular run except `last_run_timestamp` is read from the flag rather than the cursor. Cursor still updates after success per the simplified-cursor rule. This is the correct behavior for one-off catch-ups (you may want to backfill the last 30 days without losing your normal-cadence cursor position). If a user wants to BOTH backfill AND reset the cursor, they delete `cursor.json` first.
 - **Schema-invariant check at startup (revision-1 finding F4):** Replaces the brittle hash check with explicit column-presence assertions. On open, query `PRAGMA table_info('session')`, `('message')`, `('part')` and verify expected columns exist (`session.id, project_id, parent_id, time_updated`; `message.id, session_id, time_created, data`; `part.id, message_id, message_id, time_created, data`). If ANY expected column is missing, **fail closed** with `SchemaError` and exit code 3. This is fail-closed (not warn-only) because the parser produces silent garbage on missing columns.
 - **Skip the `agent` part type** even though it carries text — structured subagent context, not user/assistant conversation text. Per brainstorm R6.
@@ -151,7 +151,7 @@ State directory created at runtime (untracked):
 │    ~/.local/state/ollama-distill/cursor.json                        │
 │       → { last_run_timestamp }                                      │
 │    --since overrides for the run (cursor still advances)            │
-│    --session bypasses cursor entirely (non-mutating)                │
+│    --session does not advance cursor (R20)                          │
 │    GET /api/tags → if fails, exit 1 with actionable error           │
 │                                                                     │
 │  Phase B: open SQLite (read-only, verified, schema-checked)         │
@@ -301,7 +301,7 @@ State directory created at runtime (untracked):
 - Simple positional + `--flag=value` parsing via `Bun.argv` (no full arg-parsing lib)
 - Flags:
   - `--since=<value>` — recency filter override; accepts ISO date, `Nd` relative, or epoch ms. Cursor still updates after success.
-  - `--session=<id>` — non-mutating: process exactly one session; does NOT read or write cursor; output to stdout unless `--out` provided; JSONL logged with `mode: "session"`.
+    - `--session=<id>` — does not advance cursor (R20): process exactly one session; does NOT read or write cursor; does NOT acquire run lock; output to stdout unless `--out` provided; JSONL logged with `mode: "session"`.
   - `--out=<path>` — override report destination (or output target in --session mode).
   - `--extract-only` — debug: print extracted transcript, skip Ollama. Does NOT update cursor.
   - `--help` — usage.
@@ -316,7 +316,7 @@ State directory created at runtime (untracked):
 **Test scenarios:**
 - **Flag parsing happy path:** `--since=2026-05-15 --out=/tmp/r.md` → `{ since: <ms>, out: "/tmp/r.md" }`
 - **`--since` formats accepted:** `7d`, `2026-05-15`, `1747267200000` all parse correctly
-- **`--session` non-mutating:** passing `--session=ses_xxx` runs against that one session, does NOT touch cursor.json, output goes to stdout when no --out
+- **`--session` does not advance cursor (R20):** passing `--session=ses_xxx` runs against that one session, does NOT touch cursor.json, does NOT acquire run lock; output goes to stdout when no --out
 - **`--session` + `--out`:** output redirected to specified file, JSONL records `mode: "session"`
 - **No ollama:** mock fetch on `/api/tags` returns ECONNREFUSED → exit 1 with actionable stderr message
 - **Schema error in extract:** mock extract throws SchemaError → exit 1 + JSONL records the error


### PR DESCRIPTION
Hardens the local Ollama distillation pipeline after three iterations of
layered fixes. No behavior change for the happy path; new defensive checks
and correctness fixes for failure modes that weren't previously tested.

## What changed

### Production code

| Area | Change |
| ---- | ------ |
| Lock file | Stale-lock auto-recovery via `kill(pid, 0)` probe; unlink + retry once on dead PID, empty file, or malformed content. Prior behavior required manual `rm` after any crash. |
| Signal handlers | Now stored, registered once per `main()` invocation, removed in `finally`. Was leaking 3 listeners per call. |
| Cursor file | `isCursor()` type guard rejects negative timestamps, non-numeric fields, and shapes that previously bypassed the bootstrap fall-through. |
| Ollama response | Extracted `isOllamaChatResponse` type guard replacing 7 chained `as`-casts. |
| Report writer | `lstatSync` symlink defense; switched from read-concat-rewrite to `appendFileSync` (lock serializes runs). |
| MessageSegment | Discriminated union on `kind: text \| reasoning`; fixes an info-loss bug where `renderChunkTranscript` dropped the `[reasoning]` label that `extractTranscript` emits. |
| Fatal-error path | Appends a JSONL audit record before exit. |
| Diagnostics | "No new sessions" message now reports cursor + window bounds. |
| `--help` | Expanded with env vars, exit codes, output paths, `-h` alias, per-flag examples. |
| `parseArgs` | Accepts both `--flag=value` and `--flag value` forms. |
| Cleanup | Dead code removed (unused parameter, empty branch, dead title branch); stale comments swept; backlink added to `bun-sqlite-readonly-wal-pattern.md`. |
| JSDoc | Added to the 14 previously-undocumented public exports. |

### Tests

- 89 -> 102 (+13 new).
- New coverage: stale-lock recovery (4 cases), process-listener stability, malformed-200 Ollama response, exact chunk-boundary cases, `segments_truncated` cursor exclusion, cursor non-advancement bounds.
- Renamed `--session non-mutating` test to `--session does not advance cursor` with positive assertions on the JSONL-is-written contract.

### Docs

- R20 wording revised in the brainstorm and plan. The contract is "session mode does not advance cursor", not "session mode writes nowhere persistent" -- the JSONL audit log applies to every distill invocation.

## Out of scope (deferred to v1.4)

- Empty Ollama response is still treated as a chunk failure. Strict semantic stays.
- Retry on transient Ollama HTTP errors. No retry today; one HTTP 500 fails a chunk.
- Incremental checkpointing across sessions during long runs.
- Streaming session selection (current code materializes the full window into memory).

## Verification

- 102/102 tests pass.
- gitleaks clean.
- No behavior change for the happy path; defensive fixes only.