### PR TITLE
feat(ollama-distill): batch v1.4 follow-ups

### DIFF
--- a/.config/opencode/scripts/ollama-distill.test.ts
+++ b/.config/opencode/scripts/ollama-distill.test.ts
@@ -22,6 +22,8 @@ import {
   releaseLock,
   chunkSegments,
   renderChunkTranscript,
+  dedupeChunkBlocks,
+  activeLockPaths,
   type ExtractStats,
   type RunRecord,
   type MessageSegment,
@@ -1806,7 +1808,7 @@ describe("v1.2 end-to-end chunked inference", () => {
       if (urlStr.includes("/api/chat")) {
         ollamaCallCount++;
         return new Response(
-          JSON.stringify({ message: { content: `## Chunk ${ollamaCallCount} Summary\n\nContent here.` } }),
+          JSON.stringify({ message: { content: `## Chunk ${ollamaCallCount === 1 ? "Alpha" : "Beta"} Summary\n\nContent here.` } }),
           { status: 200 }
         );
       }
@@ -1828,8 +1830,8 @@ describe("v1.2 end-to-end chunked inference", () => {
       expect(existsSync(reportPath)).toBe(true);
       const reportContent = readFileSync(reportPath, "utf8");
       expect(reportContent).toContain("(2 chunks)");
-      expect(reportContent).toContain("Chunk 1 Summary");
-      expect(reportContent).toContain("Chunk 2 Summary");
+      expect(reportContent).toContain("Chunk Alpha Summary");
+      expect(reportContent).toContain("Chunk Beta Summary");
 
       // Cursor should be advanced (session succeeded)
       const cursor = JSON.parse(readFileSync(join(stateDir, "cursor.json"), "utf8"));
@@ -2024,8 +2026,9 @@ describe("v1.2 smoke fixes", () => {
         if (ollamaCallCount >= 4) {
           return new Response("Internal Server Error", { status: 500 });
         }
+        const titles = ["Alpha", "Beta", "Gamma"];
         return new Response(
-          JSON.stringify({ message: { content: `## Block ${ollamaCallCount}\n\nContent.` } }),
+          JSON.stringify({ message: { content: `## ${titles[ollamaCallCount - 1]} Block\n\nContent.` } }),
           { status: 200 }
         );
       }
@@ -2043,9 +2046,9 @@ describe("v1.2 smoke fixes", () => {
       // Report should exist and contain the partial blocks
       expect(existsSync(reportPath)).toBe(true);
       const reportContent = readFileSync(reportPath, "utf8");
-      expect(reportContent).toContain("Block 1");
-      expect(reportContent).toContain("Block 2");
-      expect(reportContent).toContain("Block 3");
+      expect(reportContent).toContain("Alpha Block");
+      expect(reportContent).toContain("Beta Block");
+      expect(reportContent).toContain("Gamma Block");
       // Title should indicate partial success
       expect(reportContent).toContain("chunks succeeded");
 
@@ -2064,8 +2067,8 @@ describe("v1.2 smoke fixes", () => {
     }
   });
 
-  // Fix D: total-failure session — report_path is still resolved in JSONL
-  test("Fix D: total-failure (chunk 1 fails) → sessionResults empty, report_path still resolved in JSONL", async () => {
+  // Fix D: total-failure session — report_path is "" in JSONL (no file written, Item B behavior)
+  test("Fix D: total-failure (chunk 1 fails) → sessionResults empty, report_path is '' in JSONL", async () => {
     const stateDir = join(tmpdir(), "distill-total-fail-d-" + Math.random().toString(36).slice(2));
     const dbPath = join(tmpdir(), "distill-total-fail-d-" + Math.random().toString(36).slice(2) + ".db");
     const now = Date.now();
@@ -2093,12 +2096,13 @@ describe("v1.2 smoke fixes", () => {
       const code = await main(["bun", "script.ts", `--out=${reportPath}`], () => {}, () => {});
       expect(code).toBe(1);
 
-      // JSONL: report_path must be the resolved path, not ""
+      // JSONL: report_path is "" because no results were written (Item B behavior)
       const logPath = join(stateDir, "runs.jsonl");
       const record = JSON.parse(readFileSync(logPath, "utf8").trim());
       expect(record.success).toBe(false);
-      expect(record.report_path).toBe(reportPath);
-      expect(record.report_path).not.toBe("");
+      expect(record.report_path).toBe("");
+      // Report file should NOT exist (no results to write)
+      expect(existsSync(reportPath)).toBe(false);
     } finally {
       globalThis.fetch = originalFetch;
       delete process.env.OLLAMA_DISTILL_STATE_DIR;
@@ -2403,5 +2407,337 @@ describe("chunkSegments exact-boundary edge cases", () => {
     const seg2 = makeSegment(charCount + 1);
     const chunks = chunkSegments([seg1, seg2], targetChars);
     expect(chunks.length).toBe(2);
+  });
+});
+
+// ─── v1.4 Item A: --max-sessions flag ────────────────────────────────────────
+
+describe("parseArgs --max-sessions", () => {
+  test("--max-sessions=5 → maxSessions: 5", () => {
+    const result = parseArgs(["--max-sessions=5"]);
+    expect(result.flagError).toBeUndefined();
+    expect(result.maxSessions).toBe(5);
+  });
+
+  test("--max-sessions 5 (space form) → maxSessions: 5", () => {
+    const result = parseArgs(["--max-sessions", "5"]);
+    expect(result.flagError).toBeUndefined();
+    expect(result.maxSessions).toBe(5);
+  });
+
+  test("--max-sessions=0 → flagError", () => {
+    const result = parseArgs(["--max-sessions=0"]);
+    expect(result.flagError).toMatch(/Invalid --max-sessions/);
+  });
+
+  test("--max-sessions=-1 → flagError", () => {
+    const result = parseArgs(["--max-sessions=-1"]);
+    expect(result.flagError).toMatch(/Invalid --max-sessions/);
+  });
+
+  test("--max-sessions=abc → flagError", () => {
+    const result = parseArgs(["--max-sessions=abc"]);
+    expect(result.flagError).toMatch(/Invalid --max-sessions/);
+  });
+
+  test("--max-sessions=1.5 → flagError", () => {
+    const result = parseArgs(["--max-sessions=1.5"]);
+    expect(result.flagError).toMatch(/Invalid --max-sessions/);
+  });
+
+  test("duplicate --max-sessions=3 --max-sessions=5 → flagError", () => {
+    const result = parseArgs(["--max-sessions=3", "--max-sessions=5"]);
+    expect(result.flagError).toMatch(/Duplicate flag: --max-sessions/);
+  });
+});
+
+describe("--max-sessions integration", () => {
+  test("3 sessions in DB, --max-sessions=2 → only 2 processed, sessions_read=2 in JSONL", async () => {
+    const stateDir = join(tmpdir(), "distill-maxsess-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-maxsess-" + Math.random().toString(36).slice(2) + ".db");
+    const now = Date.now();
+
+    // Create 3 sessions
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT, parent_id TEXT, time_created INTEGER, time_updated INTEGER);
+      CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+      CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+    `);
+    for (let i = 1; i <= 3; i++) {
+      db.run("INSERT INTO session VALUES (?, NULL, NULL, ?, ?)", [`ses_ms${i}`, now - (4 - i) * 1000, now - (4 - i) * 1000]);
+      db.run("INSERT INTO message VALUES (?, ?, ?, ?)", [`msg_ms${i}`, `ses_ms${i}`, now - (4 - i) * 1000, JSON.stringify({ role: "user" })]);
+      db.run("INSERT INTO part VALUES (?, ?, ?, ?, ?)", [`part_ms${i}`, `msg_ms${i}`, `ses_ms${i}`, now - (4 - i) * 1000, JSON.stringify({ type: "text", text: `Content ${i}` })]);
+    }
+    db.close();
+
+    let ollamaCallCount = 0;
+    globalThis.fetch = async (url: string | URL | Request, _init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : (url as Request).url;
+      if (urlStr.includes("/api/tags")) return new Response(JSON.stringify({ models: [] }), { status: 200 });
+      if (urlStr.includes("/api/chat")) {
+        ollamaCallCount++;
+        return new Response(JSON.stringify({ message: { content: `## Summary ${ollamaCallCount}\n\nDone.` } }), { status: 200 });
+      }
+      throw new Error(`Unexpected URL: ${urlStr}`);
+    };
+
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(["bun", "script.ts", "--max-sessions=2"], () => {}, () => {});
+      expect(code).toBe(0);
+
+      const logPath = join(stateDir, "runs.jsonl");
+      const record = JSON.parse(readFileSync(logPath, "utf8").trim());
+      expect(record.sessions_read).toBe(2);
+      expect(ollamaCallCount).toBe(2);
+    } finally {
+      globalThis.fetch = (globalThis as { _originalFetch?: typeof fetch })._originalFetch ?? globalThis.fetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+});
+
+// ─── v1.4 Item B: empty sessionResults writeReport guard ─────────────────────
+
+describe("Item B: empty sessionResults guard", () => {
+  test("all sessions hit truncation → sessionResults empty → no report file written, report_path=''", async () => {
+    const stateDir = join(tmpdir(), "distill-itemb-trunc-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-itemb-trunc-" + Math.random().toString(36).slice(2) + ".db");
+    const now = Date.now();
+
+    // Create a session with a segment that will be truncated (segments_truncated > 0)
+    // We simulate this by creating a DB with a very large part that exceeds SEGMENT_HARD_CAP
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT, parent_id TEXT, time_created INTEGER, time_updated INTEGER);
+      CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+      CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+    `);
+    db.run("INSERT INTO session VALUES (?, NULL, NULL, ?, ?)", ["ses_trunc", now - 1000, now - 1000]);
+    db.run("INSERT INTO message VALUES (?, ?, ?, ?)", ["msg_trunc", "ses_trunc", now - 1000, JSON.stringify({ role: "user" })]);
+    // 71K chars — exceeds SEGMENT_HARD_CAP (70K), triggers segments_truncated > 0
+    const bigText = "X".repeat(71_000);
+    db.run("INSERT INTO part VALUES (?, ?, ?, ?, ?)", ["part_trunc", "msg_trunc", "ses_trunc", now - 1000, JSON.stringify({ type: "text", text: bigText })]);
+    db.close();
+
+    globalThis.fetch = async (url: string | URL | Request, _init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : (url as Request).url;
+      if (urlStr.includes("/api/tags")) return new Response(JSON.stringify({ models: [] }), { status: 200 });
+      throw new Error(`Unexpected URL: ${urlStr}`);
+    };
+
+    const reportPath = join(stateDir, "trunc-report.md");
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(["bun", "script.ts", `--out=${reportPath}`], () => {}, () => {});
+      expect(code).toBe(1); // truncation = failure
+
+      // Report file must NOT exist
+      expect(existsSync(reportPath)).toBe(false);
+
+      // JSONL: report_path must be ""
+      const logPath = join(stateDir, "runs.jsonl");
+      const record = JSON.parse(readFileSync(logPath, "utf8").trim());
+      expect(record.report_path).toBe("");
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+});
+
+// ─── v1.4 Item C: cleanup-handler refactor ───────────────────────────────────
+
+describe("Item C: module-level cleanup handler", () => {
+  test("process.listenerCount('exit') stays at 1 across multiple main() calls", async () => {
+    // The module-level handler is registered once; calling main() multiple times
+    // must not add more listeners.
+    const before = process.listenerCount("exit");
+
+    // We need a DB + state dir to get past the lock acquisition
+    const stateDir = join(tmpdir(), "distill-itemc-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-itemc-" + Math.random().toString(36).slice(2) + ".db");
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT, parent_id TEXT, time_created INTEGER, time_updated INTEGER);
+      CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+      CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+    `);
+    db.close();
+
+    globalThis.fetch = async (url: string | URL | Request, _init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : (url as Request).url;
+      if (urlStr.includes("/api/tags")) return new Response(JSON.stringify({ models: [] }), { status: 200 });
+      throw new Error(`Unexpected URL: ${urlStr}`);
+    };
+
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      // Call main() 3 times — each should complete without adding exit listeners
+      await main(["bun", "script.ts"], () => {}, () => {});
+      await main(["bun", "script.ts"], () => {}, () => {});
+      await main(["bun", "script.ts"], () => {}, () => {});
+
+      const after = process.listenerCount("exit");
+      // Should not have grown (module-level handler registered once)
+      expect(after).toBe(before);
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+
+  test("activeLockPaths is empty after normal-mode main() completes (lock released in finally)", async () => {
+    const stateDir = join(tmpdir(), "distill-itemc2-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-itemc2-" + Math.random().toString(36).slice(2) + ".db");
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT, parent_id TEXT, time_created INTEGER, time_updated INTEGER);
+      CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+      CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+    `);
+    db.close();
+
+    globalThis.fetch = async (url: string | URL | Request, _init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : (url as Request).url;
+      if (urlStr.includes("/api/tags")) return new Response(JSON.stringify({ models: [] }), { status: 200 });
+      throw new Error(`Unexpected URL: ${urlStr}`);
+    };
+
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      await main(["bun", "script.ts"], () => {}, () => {});
+      // After completion, the lock path must have been removed from the Set
+      expect(activeLockPaths.size).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
+});
+
+// ─── v1.4 Item D: dedupeChunkBlocks ──────────────────────────────────────────
+
+describe("dedupeChunkBlocks", () => {
+  test("empty input → empty output", () => {
+    expect(dedupeChunkBlocks([])).toEqual([]);
+  });
+
+  test("two identical ## Title sub-blocks → second dropped", () => {
+    const block1 = "## My Title\n\nSome content here.";
+    const block2 = "## My Title\n\nDuplicate content.";
+    const result = dedupeChunkBlocks([block1, block2]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toContain("My Title");
+  });
+
+  test("## Title A and ## Title A! (punctuation only diff) → second dropped (distance 0 after normalization)", () => {
+    const block1 = "## Title A\n\nContent.";
+    const block2 = "## Title A!\n\nOther content.";
+    const result = dedupeChunkBlocks([block1, block2]);
+    expect(result).toHaveLength(1);
+  });
+
+  test("## Title A and ## Tytle A (Levenshtein distance 2) → second dropped", () => {
+    const block1 = "## Title A\n\nContent.";
+    const block2 = "## Tytle A\n\nOther content.";
+    const result = dedupeChunkBlocks([block1, block2]);
+    expect(result).toHaveLength(1);
+  });
+
+  test("## Title A and ## Title BCDEF (Levenshtein distance > 2) → both kept", () => {
+    const block1 = "## Title A\n\nContent.";
+    const block2 = "## Title BCDEF\n\nOther content.";
+    const result = dedupeChunkBlocks([block1, block2]);
+    expect(result).toHaveLength(2);
+  });
+
+  test("block with multiple ## sub-sections, only middle one is a dup → middle dropped, others kept", () => {
+    const block1 = "## Alpha Section\n\nFirst content.\n\n## Refactoring Notes\n\nSecond content.";
+    // block2 has Refactoring Notes (dup) sandwiched between unique sections
+    const block2 = "## Deployment Steps\n\nThird.\n\n## Refactoring Notes\n\nDuplicate.\n\n## Performance Metrics\n\nFourth.";
+    const result = dedupeChunkBlocks([block1, block2]);
+    // block1 kept as-is; block2 has Refactoring Notes dropped but Deployment Steps and Performance Metrics kept
+    const joined = result.join("\n\n");
+    expect(joined).toContain("Alpha Section");
+    expect(joined).toContain("Refactoring Notes"); // from block1
+    expect(joined).toContain("Deployment Steps");
+    expect(joined).not.toContain("Duplicate."); // the dup Refactoring Notes content dropped
+    expect(joined).toContain("Performance Metrics");
+  });
+
+  // ─── v1.4 follow-up: length-proportional threshold + numbered-sequence exemption ───
+
+  test("numbered exemption: ## Step 1 and ## Step 2 → both KEPT", () => {
+    const result = dedupeChunkBlocks([
+      "## Step 1\n\nFirst step.",
+      "## Step 2\n\nSecond step.",
+    ]);
+    expect(result).toHaveLength(2);
+  });
+
+  test("numbered exemption: ## Decision 1 and ## Decision 2 → both KEPT", () => {
+    const result = dedupeChunkBlocks([
+      "## Decision 1\n\nFirst decision.",
+      "## Decision 2\n\nSecond decision.",
+    ]);
+    expect(result).toHaveLength(2);
+  });
+
+  test("threshold 0 (len < 5): ## ab and ## cd → both KEPT (distance 2 > 0)", () => {
+    const result = dedupeChunkBlocks([
+      "## ab\n\nContent A.",
+      "## cd\n\nContent B.",
+    ]);
+    expect(result).toHaveLength(2);
+  });
+
+  test("threshold 0 (len < 5): ## abc and ## abd → both KEPT (distance 1 > 0)", () => {
+    const result = dedupeChunkBlocks([
+      "## abc\n\nContent A.",
+      "## abd\n\nContent B.",
+    ]);
+    expect(result).toHaveLength(2);
+  });
+
+  test("threshold 1 (len 5-9): ## abcde and ## abcdf → second DEDUPED (distance 1 ≤ 1)", () => {
+    const result = dedupeChunkBlocks([
+      "## abcde\n\nContent A.",
+      "## abcdf\n\nContent B.",
+    ]);
+    expect(result).toHaveLength(1);
+  });
+
+  test("threshold 1 (len 9): ## abcdefghi and ## abcdefghj → second DEDUPED (distance 1 ≤ 1)", () => {
+    const result = dedupeChunkBlocks([
+      "## abcdefghi\n\nContent A.",
+      "## abcdefghj\n\nContent B.",
+    ]);
+    expect(result).toHaveLength(1);
+  });
+
+  test("threshold 2 (len ≥ 10): ## abcdefghij and ## abcdefghi → second DEDUPED (distance 1 ≤ 2)", () => {
+    const result = dedupeChunkBlocks([
+      "## abcdefghij\n\nContent A.",
+      "## abcdefghi\n\nContent B.",
+    ]);
+    expect(result).toHaveLength(1);
   });
 });

--- a/.config/opencode/scripts/ollama-distill.test.ts
+++ b/.config/opencode/scripts/ollama-distill.test.ts
@@ -2500,6 +2500,57 @@ describe("--max-sessions integration", () => {
       if (existsSync(dbPath)) unlinkSync(dbPath);
     }
   });
+
+  test("60 sessions in DB, --max-sessions=55 → 55 processed (cap honored above default 50)", async () => {
+    const stateDir = join(tmpdir(), "distill-maxsess55-" + Math.random().toString(36).slice(2));
+    const dbPath = join(tmpdir(), "distill-maxsess55-" + Math.random().toString(36).slice(2) + ".db");
+    const now = Date.now();
+
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT, parent_id TEXT, time_created INTEGER, time_updated INTEGER);
+      CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+      CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+    `);
+    for (let i = 1; i <= 60; i++) {
+      const sid = `ses_ms55_${String(i).padStart(3, "0")}`;
+      const mid = `msg_ms55_${String(i).padStart(3, "0")}`;
+      const pid = `part_ms55_${String(i).padStart(3, "0")}`;
+      db.run("INSERT INTO session VALUES (?, NULL, NULL, ?, ?)", [sid, now - (61 - i) * 1000, now - (61 - i) * 1000]);
+      db.run("INSERT INTO message VALUES (?, ?, ?, ?)", [mid, sid, now - (61 - i) * 1000, JSON.stringify({ role: "user" })]);
+      db.run("INSERT INTO part VALUES (?, ?, ?, ?, ?)", [pid, mid, sid, now - (61 - i) * 1000, JSON.stringify({ type: "text", text: `Content ${i}` })]);
+    }
+    db.close();
+
+    let ollamaCallCount = 0;
+    globalThis.fetch = async (url: string | URL | Request, _init?: RequestInit) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : (url as Request).url;
+      if (urlStr.includes("/api/tags")) return new Response(JSON.stringify({ models: [] }), { status: 200 });
+      if (urlStr.includes("/api/chat")) {
+        ollamaCallCount++;
+        return new Response(JSON.stringify({ message: { content: `## Summary ${ollamaCallCount}\n\nDone.` } }), { status: 200 });
+      }
+      throw new Error(`Unexpected URL: ${urlStr}`);
+    };
+
+    process.env.OLLAMA_DISTILL_STATE_DIR = stateDir;
+    process.env.OPENCODE_DB_PATH = dbPath;
+
+    try {
+      const code = await main(["bun", "script.ts", "--max-sessions=55"], () => {}, () => {});
+      expect(code).toBe(0);
+
+      const logPath = join(stateDir, "runs.jsonl");
+      const record = JSON.parse(readFileSync(logPath, "utf8").trim());
+      expect(record.sessions_read).toBe(55);
+      expect(ollamaCallCount).toBe(55);
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.OLLAMA_DISTILL_STATE_DIR;
+      delete process.env.OPENCODE_DB_PATH;
+      if (existsSync(dbPath)) unlinkSync(dbPath);
+    }
+  });
 });
 
 // ─── v1.4 Item B: empty sessionResults writeReport guard ─────────────────────
@@ -2739,5 +2790,16 @@ describe("dedupeChunkBlocks", () => {
       "## abcdefghi\n\nContent B.",
     ]);
     expect(result).toHaveLength(1);
+  });
+
+  test("keeps all-numeric titles distinct (numbered-sequence exemption: stem '' shared, normalized differs)", () => {
+    const result = dedupeChunkBlocks([
+      "## 1\n\nFoo\n",
+      "## 2\n\nBar\n",
+    ]);
+    expect(result).toHaveLength(2);
+    const joined = result.join("");
+    expect(joined).toContain("Foo");
+    expect(joined).toContain("Bar");
   });
 });

--- a/.config/opencode/scripts/ollama-distill.ts
+++ b/.config/opencode/scripts/ollama-distill.ts
@@ -478,7 +478,9 @@ export function renderChunkTranscript(segments: MessageSegment[]): string {
 
 /**
  * Compute Levenshtein distance between two strings.
- * Bounded implementation — returns early once distance exceeds `maxDist`.
+ * Length-difference short-circuit: returns `maxDist + 1` immediately if
+ * `|a.length - b.length| > maxDist`. Inner DP loop is not bounded; runs in
+ * full O(n×m) for inputs that pass the length check.
  */
 function levenshtein(a: string, b: string, maxDist = 2): number {
   if (a === b) return 0;
@@ -1516,7 +1518,7 @@ export async function main(
 
       let selectionResult: SelectionResult;
       try {
-        selectionResult = await selectSessions(db, effectiveTimestamp);
+        selectionResult = await selectSessions(db, effectiveTimestamp, args.maxSessions);
       } catch (err) {
         db.close();
         const msg = err instanceof Error ? err.message : String(err);
@@ -1538,12 +1540,6 @@ export async function main(
       db.close();
 
       let { sessions } = selectionResult;
-
-      // Apply --max-sessions cap if provided
-      if (args.maxSessions !== undefined && sessions.length > args.maxSessions) {
-        stderr(`Capping run at ${args.maxSessions} of ${sessions.length} selected sessions (--max-sessions)\n`);
-        sessions = sessions.slice(0, args.maxSessions);
-      }
 
       // 0 sessions: no-op success
       if (sessions.length === 0) {

--- a/.config/opencode/scripts/ollama-distill.ts
+++ b/.config/opencode/scripts/ollama-distill.ts
@@ -89,6 +89,25 @@ const EXPECTED_COLUMNS: Record<string, string[]> = {
   part: ["id", "message_id", "session_id", "time_created", "data"],
 };
 
+// ─── Module-level lock cleanup handlers ──────────────────────────────────────
+// Registered once at module load to avoid MaxListenersExceededWarning when
+// main() is called multiple times (e.g., in tests). Each normal-mode run adds
+// its lockPath to this Set; the finally block removes it after explicit release.
+
+export const activeLockPaths = new Set<string>();
+
+process.on("exit", () => {
+  for (const p of activeLockPaths) releaseLock(p);
+});
+process.on("SIGINT", () => {
+  for (const p of activeLockPaths) releaseLock(p);
+  process.exit(130);
+});
+process.on("SIGTERM", () => {
+  for (const p of activeLockPaths) releaseLock(p);
+  process.exit(143);
+});
+
 // ─── SQLite Busy Retry Helper ─────────────────────────────────────────────────
 
 /**
@@ -455,6 +474,95 @@ export function renderChunkTranscript(segments: MessageSegment[]): string {
     .join("\n");
 }
 
+// ─── Cross-chunk dedup ────────────────────────────────────────────────────────
+
+/**
+ * Compute Levenshtein distance between two strings.
+ * Bounded implementation — returns early once distance exceeds `maxDist`.
+ */
+function levenshtein(a: string, b: string, maxDist = 2): number {
+  if (a === b) return 0;
+  if (Math.abs(a.length - b.length) > maxDist) return maxDist + 1;
+  const prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  const curr = new Array<number>(b.length + 1);
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      curr[j] = a[i - 1] === b[j - 1]
+        ? prev[j - 1]
+        : 1 + Math.min(prev[j - 1], prev[j], curr[j - 1]);
+    }
+    for (let j = 0; j <= b.length; j++) prev[j] = curr[j];
+  }
+  return prev[b.length];
+}
+
+/** Normalize a title for fuzzy comparison: lowercase, strip non-alphanumeric. */
+function normalizeTitle(title: string): string {
+  return title.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/**
+ * Deduplicate near-duplicate `## <title>` sub-sections across chunk blocks.
+ *
+ * Each block is a multi-line Markdown string. Sub-sections are delimited by
+ * `## ` headers. For each sub-section, the normalized title is compared
+ * against all previously seen titles using two guards:
+ *
+ * 1. **Numbered-sequence exemption**: if two titles share the same stem but
+ *    differ only in a trailing digit suffix (e.g. `step1` vs `step2`), they
+ *    are always kept distinct — numbered sequences are never deduped.
+ *
+ * 2. **Length-proportional Levenshtein threshold**: short titles require a
+ *    near-exact match to be considered duplicates.
+ *    - normalized length < 5  → threshold 0 (exact match only)
+ *    - normalized length 5–9  → threshold 1
+ *    - normalized length ≥ 10 → threshold 2
+ *
+ * Empty blocks (after section removal) are filtered out.
+ */
+export function dedupeChunkBlocks(blocks: string[]): string[] {
+  const seenTitles = new Set<string>();
+
+  return blocks.map((block) => {
+    // Split block into sub-sections on ## headers (keep delimiter)
+    const sections = block.split(/(?=^## )/m);
+    const kept: string[] = [];
+
+    for (const section of sections) {
+      const headerMatch = /^## (.+)/m.exec(section);
+      if (!headerMatch) {
+        // No ## header — keep as-is (preamble text, etc.)
+        kept.push(section);
+        continue;
+      }
+      const normalized = normalizeTitle(headerMatch[1]);
+      // Strip trailing digits to detect numbered sequences (e.g. "step1", "step2")
+      const stem = normalized.replace(/\d+$/, "");
+
+      let isDup = false;
+      for (const seen of seenTitles) {
+        const seenStem = seen.replace(/\d+$/, "");
+        // Numbered-sequence exemption: same stem, different full string → keep distinct
+        if (stem === seenStem && normalized !== seen) continue;
+        // Length-proportional threshold: conservative for short titles
+        const minLen = Math.min(seen.length, normalized.length);
+        const threshold = Math.min(2, Math.floor(minLen / 5));
+        if (levenshtein(normalized, seen, threshold) <= threshold) {
+          isDup = true;
+          break;
+        }
+      }
+      if (!isDup) {
+        seenTitles.add(normalized);
+        kept.push(section);
+      }
+    }
+
+    return kept.join("");
+  }).filter((b) => b.trim() !== "");
+}
+
 // ─── Cursor ───────────────────────────────────────────────────────────────────
 
 export type Cursor = {
@@ -818,6 +926,7 @@ export type ParsedArgs = {
   out?: string;
   extractOnly: boolean;
   help: boolean;
+  maxSessions?: number; // cap on sessions processed in normal mode
   unknownFlag?: string;
   flagError?: string;   // validation error for invalid flag values
 };
@@ -928,6 +1037,26 @@ export function parseArgs(argv: string[]): ParsedArgs {
       result.out = value;
       continue;
     }
+    if (arg.startsWith("--max-sessions=") || arg === "--max-sessions") {
+      if (seenFlags.has("--max-sessions")) {
+        result.flagError = `Duplicate flag: --max-sessions`;
+        return result;
+      }
+      seenFlags.add("--max-sessions");
+      const value = arg === "--max-sessions" ? consumeNext("--max-sessions") : arg.slice("--max-sessions=".length);
+      if (value === null) return result;
+      if (value === "") {
+        result.flagError = `Empty value for --max-sessions. Use --max-sessions=<N>.`;
+        return result;
+      }
+      const n = Number(value);
+      if (!Number.isInteger(n) || n <= 0) {
+        result.flagError = `Invalid --max-sessions value: '${value}'. Must be a positive integer (e.g. --max-sessions=2).`;
+        return result;
+      }
+      result.maxSessions = n;
+      continue;
+    }
     if (arg.startsWith("--")) {
       result.unknownFlag = arg;
       break;
@@ -996,6 +1125,9 @@ OPTIONS:
   --extract-only      Print extracted transcript(s) to stdout; skip Ollama call.
                       Useful for debugging the extractor.
                       Example: --extract-only --session=ses_01jxyz...
+  --max-sessions=<N>  Cap the number of sessions processed in a normal-mode run.
+                      Default: unlimited. Useful to limit runtime on large backlogs.
+                      Example: --max-sessions=2
 
 ENVIRONMENT VARIABLES:
   OLLAMA_DISTILL_STATE_DIR   Override state directory (default: ~/.local/state/ollama-distill)
@@ -1324,18 +1456,10 @@ export async function main(
       return 1;
     }
 
-    // Register cleanup handlers for lock release.
-    // Store refs so we can remove them in the finally block — prevents handler
-    // accumulation when main() is called multiple times (e.g., in tests).
-    const cleanupLock = () => {
-      if (lockPath) releaseLock(lockPath);
-    };
-    const onExit = () => cleanupLock();
-    const onSigint = () => { cleanupLock(); process.exit(130); };
-    const onSigterm = () => { cleanupLock(); process.exit(143); };
-    process.on("exit", onExit);
-    process.on("SIGINT", onSigint);
-    process.on("SIGTERM", onSigterm);
+    // Register this lock path with the module-level cleanup Set.
+    // The module-level SIGINT/SIGTERM/exit handlers (registered once at module load)
+    // iterate activeLockPaths — no per-call handler registration needed.
+    activeLockPaths.add(lockPath);
 
     try {
       // Health check (always in normal mode)
@@ -1413,7 +1537,13 @@ export async function main(
       }
       db.close();
 
-      const { sessions } = selectionResult;
+      let { sessions } = selectionResult;
+
+      // Apply --max-sessions cap if provided
+      if (args.maxSessions !== undefined && sessions.length > args.maxSessions) {
+        stderr(`Capping run at ${args.maxSessions} of ${sessions.length} selected sessions (--max-sessions)\n`);
+        sessions = sessions.slice(0, args.maxSessions);
+      }
 
       // 0 sessions: no-op success
       if (sessions.length === 0) {
@@ -1514,7 +1644,7 @@ export async function main(
           sessionResults.push({
             sessionId: s.id,
             title,
-            ollamaOutput: chunkBlocks.join("\n\n"),
+            ollamaOutput: dedupeChunkBlocks(chunkBlocks).join("\n\n"),
           });
           reportBlocksGenerated += chunkBlocks.length;
         }
@@ -1540,11 +1670,14 @@ export async function main(
         }
       }
 
-      // Write report — always call when there's a resolved path; empty sessionResults = header-only file
+      // Write report — only when there are results to write; skip on zero results
+      // to avoid accumulating header-only files or trailing separators on all-failure days.
       const dateStr = new Date().toISOString().slice(0, 10);
       const reportPath = args.out ?? join(stateDir, "reports", `${dateStr}.md`);
 
-      await writeReport(reportPath, sessionResults);
+      if (sessionResults.length > 0) {
+        await writeReport(reportPath, sessionResults);
+      }
 
       const durationMs = Date.now() - startMs;
       const success = errors.length === 0;
@@ -1557,7 +1690,7 @@ export async function main(
         model: MODEL,
         sessions_read: sessions.length,
         report_blocks_generated: reportBlocksGenerated,
-        report_path: reportPath,
+        report_path: sessionResults.length > 0 ? reportPath : "",
         success,
         errors,
       };
@@ -1574,12 +1707,12 @@ export async function main(
 
       return success ? 0 : 1;
     } finally {
-      // Always release lock and deregister handlers to prevent accumulation
-      // when main() is called multiple times (e.g., in tests).
-      if (lockPath) releaseLock(lockPath);
-      process.off("exit", onExit);
-      process.off("SIGINT", onSigint);
-      process.off("SIGTERM", onSigterm);
+      // Explicitly release lock and remove from the module-level Set.
+      // The module-level signal handlers will no longer see this path.
+      if (lockPath) {
+        activeLockPaths.delete(lockPath);
+        releaseLock(lockPath);
+      }
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Four small ollama-distill follow-ups batched into one v1.4 release.

## What's changed

### `--max-sessions=<N>` flag
A normal run distills every session in the window. Real Marcus sessions on this hardware take 33-90 minutes each to chunk + summarize, so a 7-day window of 8 sessions is a 6-8 hour batch — impractical to run synchronously. The new flag caps how many sessions a run will process before stopping. Default unlimited; use `--max-sessions=2` to bound a single invocation, then re-run on the next cursor window.

### Empty-result `writeReport` skip
Previously a run where every selected session failed (Ollama down, all-truncated, etc.) still wrote a report file with just a header — or worse, an appended timestamp separator with no body content on subsequent runs. Now `writeReport` is skipped when `sessionResults.length === 0` and the JSONL run record carries `report_path: ""` instead.

### Module-level cleanup handlers
The `process.on('exit'/SIGINT/SIGTERM)` registrations have moved out of `main()` into a single module-load block. Each `main()` invocation now adds its lock path to a shared `Set<string>` and removes it in the `finally` block. Eliminates `MaxListenersExceededWarning` when the test suite calls `main()` repeatedly.

### Cross-chunk duplicate sub-section dedup
Long sessions get split into chunks before summarization. Each chunk is summarized independently, so the model occasionally emits duplicate or near-duplicate `## <title>` sub-sections across chunks. A post-processing pass walks the chunk output, normalizes each `## <title>`, and drops sub-sections whose normalized title is within a length-proportional Levenshtein distance of an earlier seen title. Numbered sequences (`## Step 1`, `## Step 2`) are explicitly exempted from dedup so the model's intentional enumerations stay intact.

## Verification

- 126 tests (was 102) — 24 added for the new behaviors
- No external deps, no formatter changes, no schema changes
- gitleaks clean on the diff
