### PR TITLE
chore(opencode): retune models and auth plugin

### DIFF
--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -4,14 +4,14 @@
   "presets": {
     "openai": {
       "orchestrator": {
-        "model": "openai/gpt-5.5",
+        "model": "openai/gpt-5.5-fast",
         "skills": ["*"],
         "mcps": ["*", "!context7"]
       },
       "oracle": {
-        "model": "openai/gpt-5.5",
+        "model": "openai/gpt-5.5-fast",
         "variant": "high",
-        "skills": ["simplify"],
+        "skills": [],
         "mcps": []
       },
       "council": {
@@ -50,7 +50,7 @@
       "oracle": {
         "model": "opencode-go/deepseek-v4-pro",
         "variant": "max",
-        "skills": ["simplify"],
+        "skills": [],
         "mcps": []
       },
       "council": {
@@ -82,14 +82,14 @@
     },
     "copilot": {
       "orchestrator": {
-        "model": "openai/gpt-5.5",
+        "model": "openai/gpt-5.5-fast",
         "skills": ["*"],
         "mcps": ["*", "!context7"]
       },
       "oracle": {
-        "model": "openai/gpt-5.5",
+        "model": "openai/gpt-5.5-fast",
         "variant": "high",
-        "skills": ["simplify"],
+        "skills": [],
         "mcps": []
       },
       "council": {
@@ -125,9 +125,9 @@
         "mcps": ["*", "!context7"]
       },
       "oracle": {
-        "model": "openai/gpt-5.5",
+        "model": "openai/gpt-5.5-fast",
         "variant": "high",
-        "skills": ["simplify"],
+        "skills": [],
         "mcps": []
       },
       "council": {

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
-    "@cortexkit/opencode-anthropic-auth@1.2.2",
+    "@marcusrbrown/opencode-anthropic-auth@1.2.2-mb.1",
     "oh-my-opencode-slim@1.1.1",
     "@cortexkit/opencode-magic-context@0.21.8",
     "@cortexkit/aft-opencode@0.29.1",


### PR DESCRIPTION
- Switch multiple preset orchestrator and oracle entries to openai/gpt-5.5-fast
- Remove oracle simplify skill assignments in affected presets
- Replace anthropic auth plugin with @marcusrbrown/opencode-anthropic-auth@1.2.2-mb.1