### PR TITLE
chore(opencode): update preset skills and fixer defaults

### DIFF
--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -11,7 +11,7 @@
       "oracle": {
         "model": "openai/gpt-5.5-fast",
         "variant": "high",
-        "skills": [],
+        "skills": ["ce:*", "systematic:*"],
         "mcps": []
       },
       "council": {
@@ -35,10 +35,7 @@
         "mcps": []
       },
       "fixer": {
-        "model": "openai/gpt-5.4-mini",
-        "variant": "low",
-        "skills": [],
-        "mcps": []
+        "model": "github-copilot/claude-sonnet-4.6"
       }
     },
     "opencode-go": {
@@ -50,7 +47,7 @@
       "oracle": {
         "model": "opencode-go/deepseek-v4-pro",
         "variant": "max",
-        "skills": [],
+        "skills": ["ce:*", "systematic:*"],
         "mcps": []
       },
       "council": {
@@ -75,9 +72,7 @@
       },
       "fixer": {
         "model": "opencode-go/deepseek-v4-flash",
-        "variant": "high",
-        "skills": [],
-        "mcps": []
+        "variant": "high"
       }
     },
     "copilot": {
@@ -89,7 +84,7 @@
       "oracle": {
         "model": "openai/gpt-5.5-fast",
         "variant": "high",
-        "skills": [],
+        "skills": ["ce:*", "systematic:*"],
         "mcps": []
       },
       "council": {
@@ -113,9 +108,7 @@
         "mcps": []
       },
       "fixer": {
-        "model": "github-copilot/claude-sonnet-4.6",
-        "skills": [],
-        "mcps": []
+        "model": "github-copilot/claude-sonnet-4.6"
       }
     },
     "mixed": {
@@ -127,7 +120,7 @@
       "oracle": {
         "model": "openai/gpt-5.5-fast",
         "variant": "high",
-        "skills": [],
+        "skills": ["ce:*", "systematic:*"],
         "mcps": []
       },
       "council": {
@@ -150,9 +143,7 @@
         "mcps": []
       },
       "fixer": {
-        "model": "github-copilot/claude-sonnet-4.6",
-        "skills": [],
-        "mcps": []
+        "model": "github-copilot/claude-sonnet-4.6"
       }
     }
   },


### PR DESCRIPTION
- Add ce:* and systematic:* skills to oracle presets (openai, opencode-go, copilot, mixed)
- Simplify fixer blocks by removing empty skills/mcps fields in copilot and mixed
- Switch openai fixer model to github-copilot/claude-sonnet-4.6