### PR TITLE
chore(opencode): hold @cortexkit/aft-opencode at 0.32.0

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -4,7 +4,7 @@
     "@marcusrbrown/opencode-anthropic-auth@1.2.5-mb.2",
     "oh-my-opencode-slim@1.1.1",
     "@cortexkit/opencode-magic-context@0.21.8",
-    "@cortexkit/aft-opencode@0.33.0",
+    "@cortexkit/aft-opencode@0.32.0",
     "opencode-copilot-delegate@0.12.0",
     "@fro.bot/systematic@2.24.0"
   ],

--- a/.config/opencode/tui.json
+++ b/.config/opencode/tui.json
@@ -4,7 +4,7 @@
   "plugin": [
     "oh-my-opencode-slim@1.1.1",
     "@cortexkit/opencode-magic-context@0.21.8",
-    "@cortexkit/aft-opencode@0.33.0",
+    "@cortexkit/aft-opencode@0.32.0",
     "opencode-copilot-delegate@0.12.0"
   ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -79,6 +79,11 @@
       extends: ['github>bfra-me/renovate-config:automerge.json5#5.2.1'],
       groupName: null,
       dependencyDashboardApproval: false
+    },
+    {
+      description: 'Hold @cortexkit/aft-opencode at 0.32.0; v0.33.0 has regressions.',
+      matchPackageNames: ['@cortexkit/aft-opencode'],
+      allowedVersions: '0.32.0'
     }
   ],
   prCreation: 'immediate',


### PR DESCRIPTION
## What

Pin \`@cortexkit/aft-opencode\` to \`0.32.0\` in three places:

- \`.config/opencode/opencode.json\` — local plugin pin (reverted from 0.33.0)
- \`.config/opencode/tui.json\` — local plugin pin (reverted from 0.33.0)
- \`.github/renovate.json5\` — \`allowedVersions: '0.32.0'\` ceiling for this package

## Why

v0.33.0 introduces a regression in shell tool wrapping: filesystem operations that previously ran silently (e.g. \`find\` walks, redirects to \`/dev/null\`) now trigger repeated macOS TCC permission prompts. The behavior is intrusive enough to crash the editor and block normal session work.

Holding at 0.32.0 until an upstream fix lands.

## How the pieces work together

1. \`opencode.json\` and \`tui.json\` pins are the immediate downgrade levers — they take effect on OpenCode restart.
2. The Renovate \`allowedVersions: '0.32.0'\` rule sits *after* the existing \`@cortexkit/aft*\` automerge rule, so it filters out 0.33.0+ before the automerge rule can act. Without this, Renovate would re-open and auto-merge the 0.33.0 bump, silently undoing the local pin.
3. The ceiling is exact (\`'0.32.0'\`) rather than \`'<0.33.0'\` — change later if a 0.32.x hotfix needs to flow.

## Verification

- gitleaks: clean
- Tree: clean before commit (staged changes only)
- File parses: \`renovate.json5\` reads cleanly post-edit