### PR TITLE
chore(opencode): bump plugins and fixer skills

### DIFF
--- a/.config/opencode/magic-context.jsonc
+++ b/.config/opencode/magic-context.jsonc
@@ -52,7 +52,15 @@
     "github-copilot/claude-opus-4.7": 80000,
     "github-copilot/claude-sonnet-4.6": 95000
   },
-  "experimental": {
+  "temporal_awareness": true,
+  "caveman_text_compression": {
+    "enabled": false
+  },
+
+  "history_budget_percentage": 0.15,
+  "historian_timeout_ms": 420000,
+  "memory": {
+    "injection_budget_tokens": 6000,
     "auto_search": {
       "enabled": true,
       "min_prompt_chars": 20,
@@ -62,16 +70,7 @@
       "enabled": true,
       "since_days": 365,
       "max_commits": 2000
-    },
-    "temporal_awareness": true,
-    "caveman_text_compression": {
-      "enabled": false
     }
-  },
-  "history_budget_percentage": 0.15,
-  "historian_timeout_ms": 420000,
-  "memory": {
-    "injection_budget_tokens": 6000
   },
   "auto_drop_tool_age": 30,
   "system_prompt_injection": {

--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -35,7 +35,8 @@
         "mcps": []
       },
       "fixer": {
-        "model": "anthropic/claude-sonnet-4-6"
+        "model": "anthropic/claude-sonnet-4-6",
+        "skills": ["systematic:*"]
       }
     },
     "opencode-go": {
@@ -72,7 +73,8 @@
       },
       "fixer": {
         "model": "opencode-go/deepseek-v4-flash",
-        "variant": "high"
+        "variant": "high",
+        "skills": ["systematic:*"]
       }
     },
     "copilot": {
@@ -108,7 +110,8 @@
         "mcps": []
       },
       "fixer": {
-        "model": "github-copilot/claude-sonnet-4.6"
+        "model": "github-copilot/claude-sonnet-4.6",
+        "skills": ["systematic:*"]
       }
     },
     "mixed": {
@@ -143,7 +146,8 @@
         "mcps": []
       },
       "fixer": {
-        "model": "anthropic/claude-sonnet-4-6"
+        "model": "anthropic/claude-sonnet-4-6",
+        "skills": ["systematic:*"]
       }
     }
   },

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -3,8 +3,8 @@
   "plugin": [
     "@marcusrbrown/opencode-anthropic-auth@1.2.5-mb.3",
     "oh-my-opencode-slim@1.1.1",
-    "@cortexkit/opencode-magic-context@0.21.8",
-    "@cortexkit/aft-opencode@0.32.0",
+    "@cortexkit/opencode-magic-context@0.22.3",
+    "@cortexkit/aft-opencode@0.35.3",
     "opencode-copilot-delegate@0.12.0",
     "@fro.bot/systematic@2.24.0"
   ],

--- a/.config/opencode/tui.json
+++ b/.config/opencode/tui.json
@@ -3,8 +3,8 @@
   "theme": "catppuccin",
   "plugin": [
     "oh-my-opencode-slim@1.1.1",
-    "@cortexkit/opencode-magic-context@0.21.8",
-    "@cortexkit/aft-opencode@0.32.0",
+    "@cortexkit/opencode-magic-context@0.22.3",
+    "@cortexkit/aft-opencode@0.35.3",
     "opencode-copilot-delegate@0.12.0"
   ]
 }


### PR DESCRIPTION
- Bump plugin versions:
  - @cortexkit/opencode-magic-context from 0.21.8 to 0.22.3
  - @cortexkit/aft-opencode from 0.32.0 to 0.35.3
- Update plugin pins in both opencode and tui configs for consistency
- Enable systematic skills for all fixer profiles in oh-my-opencode-slim
- Reorganize magic-context config so memory auto-search/vcs settings live under memory