### PR TITLE
chore(opencode): update config presets and agent settings

### DIFF
--- a/.config/opencode/magic-context.jsonc
+++ b/.config/opencode/magic-context.jsonc
@@ -32,7 +32,8 @@
     "inject_docs": true
   },
   "sidekick": {
-    "disabled": true
+    "disabled": true,
+    "disable": true
   },
   "cache_ttl": {
     "default": "5m",
@@ -56,7 +57,6 @@
   "caveman_text_compression": {
     "enabled": false
   },
-
   "history_budget_percentage": 0.15,
   "historian_timeout_ms": 420000,
   "memory": {
@@ -76,5 +76,6 @@
   "system_prompt_injection": {
     "enabled": true,
     "skip_signatures": ["You are the Council agent — a multi-LLM"]
-  }
+  },
+  "auto_update": false
 }

--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -4,7 +4,7 @@
   "presets": {
     "openai": {
       "orchestrator": {
-        "model": "openai/gpt-5.5-fast",
+        "model": "openai/gpt-5.5",
         "skills": ["*"],
         "mcps": ["*", "!context7"]
       },
@@ -79,7 +79,7 @@
     },
     "copilot": {
       "orchestrator": {
-        "model": "openai/gpt-5.5-fast",
+        "model": "openai/gpt-5.5",
         "skills": ["*"],
         "mcps": ["*", "!context7"]
       },

--- a/.config/opencode/systematic.jsonc
+++ b/.config/opencode/systematic.jsonc
@@ -20,6 +20,9 @@
     }
   },
   "agents": {
+    "spec-flow-analyzer": {
+      "model": "anthropic/claude-sonnet-4-6"
+    },
     "systematic-implementer": {
       "model": "anthropic/claude-sonnet-4-6"
     }


### PR DESCRIPTION
- magic-context: add redundant `disable` key alongside `disabled` for sidekick, remove blank line, and set `auto_update: false`
- oh-my-opencode-slim: upgrade orchestrator model from `gpt-5.5-fast` to `gpt-5.5` in both `openai` and `copilot` presets
- systematic: add `spec-flow-analyzer` agent pinned to `claude-sonnet-4-6`