### PR TITLE
chore(opencode): update plugins and model routing config

### DIFF
--- a/.config/opencode/aft.jsonc
+++ b/.config/opencode/aft.jsonc
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/cortexkit/aft/master/assets/aft.schema.json",
   "restrict_to_project_root": false,
   "search_index": true,
   "semantic_search": true,

--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -121,7 +121,7 @@
         "mcps": ["*", "!context7"]
       },
       "oracle": {
-        "model": "openai/gpt-5.5-fast",
+        "model": "github-copilot/gemini-3.5-flash",
         "variant": "high",
         "skills": ["systematic:*"],
         "mcps": []
@@ -130,7 +130,8 @@
         "model": "openai/gpt-5.5-fast"
       },
       "librarian": {
-        "model": "anthropic/claude-haiku-4-5",
+        "model": "github-copilot/gpt-5.4-mini",
+        "variant": "low",
         "skills": [],
         "mcps": ["websearch", "context7", "grep_app", "tavily"]
       },

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
-    "@marcusrbrown/opencode-anthropic-auth@1.2.5-mb.3",
-    "oh-my-opencode-slim@1.1.1",
-    "@cortexkit/opencode-magic-context@0.22.4",
-    "@cortexkit/aft-opencode@0.35.4",
+    "@cortexkit/opencode-anthropic-auth@1.7.0",
+    "oh-my-opencode-slim@1.1.2",
+    "@cortexkit/opencode-magic-context@0.22.5",
+    "@cortexkit/aft-opencode@0.36.1",
     "opencode-copilot-delegate@0.12.0",
     "@fro.bot/systematic@2.31.0"
   ],

--- a/.config/opencode/systematic.jsonc
+++ b/.config/opencode/systematic.jsonc
@@ -8,15 +8,16 @@
       "model": "github-copilot/gemini-3.1-pro-preview"
     },
     "document-review": {
-      "model": "openai/gpt-5.4-mini",
+      "model": "github-copilot/gpt-5.4-mini",
       "variant": "low"
     },
     "research": {
-      "model": "openai/gpt-5.4-mini",
+      "model": "opencode-go/minimax-m2.7",
       "variant": "low"
     },
     "review": {
-      "model": "openai/gpt-5.5-fast"
+      "model": "opencode-go/deepseek-v4-flash",
+      "variant": "high"
     }
   },
   "agents": {

--- a/.config/opencode/tui.json
+++ b/.config/opencode/tui.json
@@ -2,9 +2,9 @@
   "$schema": "https://opencode.ai/tui.json",
   "theme": "catppuccin",
   "plugin": [
-    "oh-my-opencode-slim@1.1.1",
-    "@cortexkit/opencode-magic-context@0.22.4",
-    "@cortexkit/aft-opencode@0.35.4",
+    "oh-my-opencode-slim@1.1.2",
+    "@cortexkit/opencode-magic-context@0.22.5",
+    "@cortexkit/aft-opencode@0.36.1",
     "opencode-copilot-delegate@0.12.0"
   ]
 }


### PR DESCRIPTION
- add AFT schema declaration in .config/opencode/aft.jsonc
- bump opencode/tui plugin versions:
  - oh-my-opencode-slim 1.1.1 -> 1.1.2
  - @cortexkit/opencode-magic-context 0.22.4 -> 0.22.5
  - @cortexkit/aft-opencode 0.35.4 -> 0.36.1
- switch .config/opencode/opencode.json plugins to newer upstream packages, including @cortexkit/opencode-anthropic-auth@1.7.0
- retune oh-my-opencode-slim preset models:
  - oracle -> github-copilot/gemini-3.5-flash
  - librarian -> github-copilot/gpt-5.4-mini with low variant
- update systematic.jsonc profile models for document-review, research, and review