### PR TITLE
chore(opencode): update .gitignore and magic-context.jsonc

### DIFF
--- a/.config/.gitignore
+++ b/.config/.gitignore
@@ -29,7 +29,7 @@
 /opencode/profiles/*
 !/opencode/profiles/default/
 /opencode/skills/superpowers
-/opencode/anthropic-auth.json
+/opencode/anthropic-auth*.json
 /opencode/antigravity-accounts.json
 /opencode/package-lock.json
 /opencode/oh-my-openagent.json.*

--- a/.config/opencode/magic-context.jsonc
+++ b/.config/opencode/magic-context.jsonc
@@ -40,7 +40,8 @@
     "anthropic/claude-sonnet-4-6": "59m",
     "anthropic/claude-opus-4-6": "59m",
     "anthropic/claude-opus-4-7": "59m",
-    "anthropic/claude-opus-4-8": "59m"
+    "anthropic/claude-opus-4-8": "59m",
+    "anthropic/claude-fable-5": "59m"
   },
   "execute_threshold_percentage": {
     "default": 65,


### PR DESCRIPTION
- Updated .gitignore to include all anthropic-auth JSON files.
- Added anthropic/claude-fable-5 to magic-context.jsonc with a cache TTL of 59 minutes.