### PR TITLE
fix(zsh): restore Homebrew PATH after mise activation and defer menuselect bind

### DIFF
--- a/.config/bash/exports
+++ b/.config/bash/exports
@@ -89,6 +89,16 @@ if [[ "$HOST_OS" == "darwin" ]]; then
     [ ! -x "$PREFIX/bin/brew" ] && PREFIX="/usr/local"
     if [ -x "$PREFIX/bin/brew" ]; then
         eval "$("$PREFIX"/bin/brew shellenv)"
+        # mise captures the pre-activation PATH into an exported __MISE_ORIG_PATH once,
+        # then reuses it as the base on every shell (it survives exec/subshells). A shell
+        # that froze a Homebrew-less base makes every later shell rebuild PATH from it and
+        # drop $PREFIX/bin. Clear a stale base so mise re-captures this brew-correct PATH.
+        if [ -n "${__MISE_ORIG_PATH-}" ]; then
+            case ":$__MISE_ORIG_PATH:" in
+                *":$PREFIX/bin:"*) ;;
+                *) unset __MISE_ORIG_PATH __MISE_DIFF __MISE_SESSION ;;
+            esac
+        fi
     fi
 fi
 

--- a/.config/zsh/plugins/keybindings.plugin.zsh
+++ b/.config/zsh/plugins/keybindings.plugin.zsh
@@ -44,7 +44,16 @@ bindkey '^[[3;5~' kill-word
 # [Shift-Tab] - Move to the previous completion
 zmodload zsh/complist
 bindkey '^[[Z'    reverse-menu-complete
-bindkey -M menuselect '^[[Z' reverse-menu-complete
+# The `menuselect` keymap is created by compinit, which runs after this plugin is
+# sourced (the completion plugin loads later). Defer the menuselect binding to the
+# first precmd so the keymap exists by the time we bind it.
+_keybindings_bind_menuselect() {
+  bindkey -M menuselect '^[[Z' reverse-menu-complete
+  add-zsh-hook -d precmd _keybindings_bind_menuselect
+  unfunction _keybindings_bind_menuselect
+}
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _keybindings_bind_menuselect
 
 # Edit the command line in $EDITOR
 autoload -U edit-command-line


### PR DESCRIPTION
## What

Fixes two interactive-shell regressions that surface on `exec zsh`:

1. **`brew` falls off PATH.** `mise` captures the pre-activation PATH into an exported `__MISE_ORIG_PATH` once, then reuses it as the base on every shell — and it survives `exec` and subshells. A shell that once froze a Homebrew-less PATH made every subsequent shell rebuild PATH from that stale base and drop `/opt/homebrew/bin`, even though `brew shellenv` re-adds it earlier in init. `exports` now detects a frozen base that lacks the brew prefix and clears it (`__MISE_ORIG_PATH`/`__MISE_DIFF`/`__MISE_SESSION`) so mise re-captures the brew-correct PATH. Self-healing: already-broken shells recover on the next `exec zsh`.

2. **`no such keymap 'menuselect'`.** The `menuselect` keymap is created by `compinit`, which runs after the keybindings plugin is sourced. The `bindkey -M menuselect` call is now deferred to the first `precmd`, by which point the keymap exists; the hook self-removes after binding.

## Why this shape

`mise` only captures the original PATH when `__MISE_ORIG_PATH` is unset and offers no reset command, so clearing the stale base before re-activation is the supported way to force a clean re-capture. The brew guard is conditional — it only clears a base that's actually missing the prefix, so a correct base is never disturbed.

## Verification

- `brew shellenv` PATH restore replayed from a stripped base: `/opt/homebrew/bin` restored.
- Stale brew-less `__MISE_ORIG_PATH` → after sourcing `exports`: var cleared, brew on PATH, and brew survives a subsequent mise re-capture.
- Correct base is preserved (no false clears).
- menuselect: `no such keymap` error no longer emitted on shell startup.
- `bash -n` / `zsh -n` clean on both files; gitleaks clean.

Binding presence for Shift-Tab in menu selection is best confirmed in a real terminal post-merge (non-interactive harnesses don't run the precmd cycle).