### PR TITLE
chore(renovate): ungroup non-major updates for accurate single-package PR titles

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -64,6 +64,11 @@
       followTag: 'latest'
     },
     {
+      description: 'Ungroup non-major updates so single-package PRs get accurate titles instead of the inherited group:allNonMajor name.',
+      matchUpdateTypes: ['minor', 'patch'],
+      groupName: null
+    },
+    {
       description: ['Automerge unstable minor updates of some packages.'],
       matchCurrentVersion: '/^v?0/',
       matchPackageNames: [


### PR DESCRIPTION
## What

Add a local Renovate rule that ungroups non-major (minor/patch) updates so each dependency gets its own PR with an accurate title, instead of the inherited `group:allNonMajor` group name.

## Why

The shared config preset extends `group:allNonMajor`, which assigns a fixed group name ("all non-major dependencies") and branch (`renovate/all-minor-patch`) to every minor/patch update. When only one package has a pending update, the PR is still titled "update all non-major dependencies to vX" — misleading for a single-package change. Renovate has no native mechanism to unwrap a group down to its lone member, so ungrouping is the only way to get accurate per-package titles.

Scoped to this repo only; the shared preset is unchanged. Mirrors the preset's own `groupName: null` ungroup rule for v0.x packages.

## Verification

- JSON5 valid
- Rule matches minor/patch updates and nulls the inherited group name