### PR TITLE
fix(zsh): reload zsh/complist to restore menuselect keymap after bindkey -d

### DIFF
--- a/.config/zsh/plugins/keybindings.plugin.zsh
+++ b/.config/zsh/plugins/keybindings.plugin.zsh
@@ -44,10 +44,17 @@ bindkey '^[[3;5~' kill-word
 # [Shift-Tab] - Move to the previous completion
 zmodload zsh/complist
 bindkey '^[[Z'    reverse-menu-complete
-# The `menuselect` keymap is created by compinit, which runs after this plugin is
-# sourced (the completion plugin loads later). Defer the menuselect binding to the
-# first precmd so the keymap exists by the time we bind it.
+# zsh-utils/editor runs `bindkey -d` at source time, which destroys the
+# `menuselect` keymap (created by zsh/complist) and wipes the main-keymap bind
+# below. A plain `zmodload zsh/complist` is a no-op once the module is loaded, so
+# it cannot recreate the keymap. Repair at the first precmd: reload complist to
+# recreate `menuselect`, then re-apply both binds.
 _keybindings_bind_menuselect() {
+  if ! bindkey -l menuselect >/dev/null 2>&1; then
+    zmodload -u zsh/complist 2>/dev/null && zmodload zsh/complist 2>/dev/null
+    bindkey -l menuselect >/dev/null 2>&1 || bindkey -N menuselect
+  fi
+  bindkey '^[[Z' reverse-menu-complete
   bindkey -M menuselect '^[[Z' reverse-menu-complete
   add-zsh-hook -d precmd _keybindings_bind_menuselect
   unfunction _keybindings_bind_menuselect


### PR DESCRIPTION
## What

Repair the `menuselect` keymap at the first prompt so Shift-Tab works in completion menus and the `no such keymap 'menuselect'` startup error stops.

## Why

A prior change deferred the `bindkey -M menuselect` call to a `precmd` hook, but it still failed. Root cause: the `zsh-utils` editor plugin runs `bindkey -d` at source time, which **destroys** the `menuselect` keymap (created by `zsh/complist`) along with the main-keymap Shift-Tab binding. Once `zsh/complist` is already loaded, a plain `zmodload zsh/complist` is a no-op and cannot recreate the keymap — so the deferred bind hit a keymap that no longer existed.

## How

The precmd hook now detects a missing `menuselect` keymap and reloads the module (`zmodload -u zsh/complist && zmodload zsh/complist`, with a `bindkey -N menuselect` fallback) to recreate it, then re-applies the Shift-Tab binding in both the `main` and `menuselect` keymaps (both were wiped by `bindkey -d`). The hook self-removes after running once.

## Verification

Reproduced the exact failure and confirmed the repair in an isolated shell:

- after `bindkey -d`: `menuselect` keymap gone, main `^[[Z` undefined
- after the repair hook: `menuselect` recreated, `^[[Z` bound to `reverse-menu-complete` in both `main` and `menuselect`, hook exits 0

`zsh -n` clean.