### PR TITLE
chore(opencode): bump plugin versions

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -3,8 +3,8 @@
   "plugin": [
     "@cortexkit/opencode-anthropic-auth@1.10.1",
     "oh-my-opencode-slim@1.1.2",
-    "@cortexkit/opencode-magic-context@0.25.0",
-    "@cortexkit/aft-opencode@0.39.2",
+    "@cortexkit/opencode-magic-context@0.26.0",
+    "@cortexkit/aft-opencode@0.39.4",
     "opencode-copilot-delegate@0.12.0",
     "@fro.bot/systematic@2.32.0"
   ],

--- a/.config/opencode/tui.json
+++ b/.config/opencode/tui.json
@@ -3,8 +3,8 @@
   "theme": "catppuccin",
   "plugin": [
     "oh-my-opencode-slim@1.1.2",
-    "@cortexkit/opencode-magic-context@0.25.0",
-    "@cortexkit/aft-opencode@0.39.2",
+    "@cortexkit/opencode-magic-context@0.26.0",
+    "@cortexkit/aft-opencode@0.39.4",
     "opencode-copilot-delegate@0.12.0"
   ]
 }


### PR DESCRIPTION
- @cortexkit/opencode-magic-context upgraded from 0.25.0 to 0.26.0
- @cortexkit/aft-opencode upgraded from 0.39.2 to 0.39.4