### PR TITLE
chore(opencode): tune agent skills and search

### DIFF
--- a/.config/opencode/aft.jsonc
+++ b/.config/opencode/aft.jsonc
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/cortexkit/aft/main/assets/aft.schema.json",
   "restrict_to_project_root": false,
-  "search_index": true,
-  "semantic_search": true,
+  "search_index": false,
+  "semantic_search": false,
   "bash": {
     "rewrite": true,
     "compress": true,

--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -31,12 +31,12 @@
       },
       "designer": {
         "model": "github-copilot/gemini-3.1-pro-preview",
-        "skills": ["agent-browser", "systematic:*"],
+        "skills": ["agent-browser", "impeccable", "systematic:*"],
         "mcps": []
       },
       "fixer": {
         "model": "anthropic/claude-sonnet-4-6",
-        "skills": ["systematic:*"]
+        "skills": ["agent-browser", "impeccable", "systematic:*"]
       }
     },
     "opencode-go": {
@@ -68,13 +68,13 @@
       "designer": {
         "model": "opencode-go/kimi-k2.6",
         "variant": "medium",
-        "skills": ["agent-browser", "systematic:*"],
+        "skills": ["agent-browser", "impeccable", "systematic:*"],
         "mcps": []
       },
       "fixer": {
         "model": "opencode-go/deepseek-v4-flash",
         "variant": "high",
-        "skills": ["systematic:*"]
+        "skills": ["agent-browser", "impeccable", "systematic:*"]
       }
     },
     "copilot": {
@@ -106,12 +106,12 @@
       },
       "designer": {
         "model": "github-copilot/gemini-3.1-pro-preview",
-        "skills": ["agent-browser", "systematic:*"],
+        "skills": ["agent-browser", "impeccable", "systematic:*"],
         "mcps": []
       },
       "fixer": {
         "model": "github-copilot/claude-sonnet-4.6",
-        "skills": ["systematic:*"]
+        "skills": ["agent-browser", "impeccable", "systematic:*"]
       }
     },
     "mixed": {
@@ -143,12 +143,12 @@
       },
       "designer": {
         "model": "github-copilot/gemini-3.1-pro-preview",
-        "skills": ["agent-browser", "systematic:*"],
+        "skills": ["agent-browser", "impeccable", "systematic:*"],
         "mcps": []
       },
       "fixer": {
         "model": "anthropic/claude-sonnet-4-6",
-        "skills": ["systematic:*"]
+        "skills": ["agent-browser", "impeccable", "systematic:*"]
       }
     }
   },


### PR DESCRIPTION
- disable `search_index` and `semantic_search` in `aft.jsonc`
- add `impeccable` skill to `designer` profiles across providers
- add `agent-browser` and `impeccable` skills to `fixer` profiles
- keep model selections unchanged while standardizing skill sets