### PR TITLE
feat(opencode-doctor): add SQLite DB health + prune/vacuum maintenance

### DIFF
--- a/.config/opencode/scripts/opencode-doctor.test.ts
+++ b/.config/opencode/scripts/opencode-doctor.test.ts
@@ -1,5 +1,16 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { $ } from "bun";
+import { Database } from "bun:sqlite";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  computeDbHealth,
+  selectOldSessionIds,
+  estimateReclaim,
+  pruneSessions,
+  classifyPgrepExitCode,
+} from "./opencode-doctor";
 
 const SCRIPT_PATH = "./opencode-doctor.ts";
 const TEST_TIMEOUT = 90000;
@@ -18,6 +29,622 @@ afterEach(async () => {
   spawnedProcs = [];
 });
 
+// ─── Temp DB Helpers ──────────────────────────────────────────────────────────
+
+function makeTempDir(): string {
+  const dir = join(tmpdir(), `opencode-doctor-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function removeTempDir(dir: string): void {
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // ignore cleanup errors
+  }
+}
+
+/**
+ * Create a minimal OpenCode-schema SQLite DB for testing.
+ * Returns the db instance and its file path.
+ */
+function createTestDb(dir: string): { db: Database; dbPath: string } {
+  const dbPath = join(dir, "test.db");
+  const db = new Database(dbPath);
+
+  db.exec(`
+    PRAGMA journal_mode=WAL;
+    PRAGMA foreign_keys=ON;
+
+    CREATE TABLE IF NOT EXISTS project (
+      id TEXT PRIMARY KEY
+    );
+
+    CREATE TABLE IF NOT EXISTS session (
+      id TEXT PRIMARY KEY,
+      project_id TEXT REFERENCES project(id) ON DELETE CASCADE,
+      parent_id TEXT,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL,
+      time_archived INTEGER
+    );
+
+    CREATE TABLE IF NOT EXISTS message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL REFERENCES session(id) ON DELETE CASCADE,
+      time_created INTEGER NOT NULL,
+      data TEXT NOT NULL DEFAULT '{}'
+    );
+
+    CREATE TABLE IF NOT EXISTS part (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL REFERENCES message(id) ON DELETE CASCADE,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      data TEXT NOT NULL DEFAULT '{}'
+    );
+
+    CREATE TABLE IF NOT EXISTS event_sequence (
+      aggregate_id TEXT PRIMARY KEY
+    );
+
+    CREATE TABLE IF NOT EXISTS event (
+      id TEXT PRIMARY KEY,
+      aggregate_id TEXT NOT NULL REFERENCES event_sequence(aggregate_id) ON DELETE CASCADE,
+      seq INTEGER NOT NULL,
+      type TEXT NOT NULL DEFAULT '',
+      data TEXT NOT NULL DEFAULT '{}'
+    );
+  `);
+
+  return { db, dbPath };
+}
+
+/**
+ * Insert a session with messages, parts, and events.
+ * timeCreatedMs: epoch ms for time_created.
+ */
+function insertSession(
+  db: Database,
+  id: string,
+  timeCreatedMs: number,
+  opts: { messages?: number; partsPerMessage?: number; events?: number } = {}
+): void {
+  const messages = opts.messages ?? 2;
+  const partsPerMessage = opts.partsPerMessage ?? 2;
+  const events = opts.events ?? 3;
+
+  db.query("INSERT INTO session (id, time_created, time_updated) VALUES (?, ?, ?)").run(
+    id, timeCreatedMs, timeCreatedMs
+  );
+
+  for (let m = 0; m < messages; m++) {
+    const msgId = `${id}-msg-${m}`;
+    db.query("INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)").run(
+      msgId, id, timeCreatedMs + m, JSON.stringify({ role: "user", content: `message ${m}` })
+    );
+    for (let p = 0; p < partsPerMessage; p++) {
+      const partId = `${id}-part-${m}-${p}`;
+      db.query("INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?, ?, ?, ?, ?)").run(
+        partId, msgId, id, timeCreatedMs + m + p, JSON.stringify({ type: "text", text: `part content ${p}` })
+      );
+    }
+  }
+
+  // Insert event_sequence + events
+  db.query("INSERT INTO event_sequence (aggregate_id) VALUES (?)").run(id);
+  for (let e = 0; e < events; e++) {
+    db.query("INSERT INTO event (id, aggregate_id, seq, type, data) VALUES (?, ?, ?, ?, ?)").run(
+      `${id}-evt-${e}`, id, e, "test_event", JSON.stringify({ seq: e })
+    );
+  }
+}
+
+// ─── DB Unit Tests ────────────────────────────────────────────────────────────
+
+describe("DB helpers (unit)", () => {
+  test("computeDbHealth returns expected shape", () => {
+    const dir = makeTempDir();
+    try {
+      const { db, dbPath } = createTestDb(dir);
+
+      const now = Date.now();
+      insertSession(db, "sess-recent", now - 2 * 24 * 3600 * 1000);   // 2 days ago
+      insertSession(db, "sess-mid", now - 15 * 24 * 3600 * 1000);     // 15 days ago
+      insertSession(db, "sess-old", now - 60 * 24 * 3600 * 1000);     // 60 days ago
+      insertSession(db, "sess-ancient", now - 120 * 24 * 3600 * 1000); // 120 days ago
+
+      const health = computeDbHealth(db, dbPath);
+
+      expect(health.db_path).toBe(dbPath);
+      expect(health.file_size_bytes).toBeGreaterThan(0);
+      expect(health.page_count).toBeGreaterThan(0);
+      expect(health.page_size).toBeGreaterThan(0);
+      expect(typeof health.journal_mode).toBe("string");
+      expect(health.row_counts.session).toBe(4);
+      expect(health.row_counts.message).toBe(8);  // 4 sessions × 2 messages
+      expect(health.row_counts.part).toBe(16);    // 4 sessions × 2 messages × 2 parts
+      expect(health.row_counts.event).toBe(12);   // 4 sessions × 3 events
+      expect(health.row_counts.event_sequence).toBe(4);
+
+      // Age histogram
+      expect(health.session_age_histogram.last7d).toBe(1);    // sess-recent
+      expect(health.session_age_histogram.days7to30).toBe(1); // sess-mid
+      expect(health.session_age_histogram.days30to90).toBe(1); // sess-old
+      expect(health.session_age_histogram.older90d).toBe(1);  // sess-ancient
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("selectOldSessionIds returns only sessions older than cutoff", () => {
+    const dir = makeTempDir();
+    try {
+      const { db } = createTestDb(dir);
+
+      const now = Date.now();
+      const cutoffMs = now - 30 * 24 * 3600 * 1000;
+
+      insertSession(db, "sess-recent", now - 5 * 24 * 3600 * 1000);   // 5 days ago — keep
+      insertSession(db, "sess-border", now - 29 * 24 * 3600 * 1000);  // 29 days ago — keep
+      insertSession(db, "sess-old1", now - 31 * 24 * 3600 * 1000);    // 31 days ago — prune
+      insertSession(db, "sess-old2", now - 90 * 24 * 3600 * 1000);    // 90 days ago — prune
+
+      const ids = selectOldSessionIds(db, cutoffMs);
+
+      expect(ids).toHaveLength(2);
+      expect(ids).toContain("sess-old1");
+      expect(ids).toContain("sess-old2");
+      expect(ids).not.toContain("sess-recent");
+      expect(ids).not.toContain("sess-border");
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("estimateReclaim returns nonzero bytes for sessions with data", () => {
+    const dir = makeTempDir();
+    try {
+      const { db } = createTestDb(dir);
+
+      const now = Date.now();
+      insertSession(db, "sess-a", now - 60 * 24 * 3600 * 1000, { messages: 3, partsPerMessage: 3, events: 5 });
+      insertSession(db, "sess-b", now - 90 * 24 * 3600 * 1000, { messages: 2, partsPerMessage: 2, events: 2 });
+
+      const reclaim = estimateReclaim(db, ["sess-a", "sess-b"]);
+
+      expect(reclaim.part_bytes).toBeGreaterThan(0);
+      expect(reclaim.message_bytes).toBeGreaterThan(0);
+      expect(reclaim.event_bytes).toBeGreaterThan(0);
+      expect(reclaim.total_bytes).toBe(reclaim.part_bytes + reclaim.message_bytes + reclaim.event_bytes);
+      expect(typeof reclaim.total_human).toBe("string");
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("estimateReclaim returns zeros for empty id list", () => {
+    const dir = makeTempDir();
+    try {
+      const { db } = createTestDb(dir);
+
+      const reclaim = estimateReclaim(db, []);
+
+      expect(reclaim.part_bytes).toBe(0);
+      expect(reclaim.message_bytes).toBe(0);
+      expect(reclaim.event_bytes).toBe(0);
+      expect(reclaim.total_bytes).toBe(0);
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("pruneSessions deletes old sessions and cascades to message/part/event", () => {
+    const dir = makeTempDir();
+    try {
+      const { db, dbPath } = createTestDb(dir);
+      db.exec("PRAGMA foreign_keys=ON");
+
+      const now = Date.now();
+      insertSession(db, "sess-old", now - 60 * 24 * 3600 * 1000, { messages: 2, partsPerMessage: 2, events: 3 });
+      insertSession(db, "sess-recent", now - 5 * 24 * 3600 * 1000, { messages: 2, partsPerMessage: 2, events: 3 });
+
+      // Verify initial state
+      type CountRow = { cnt: number };
+      expect(db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM session").get()?.cnt).toBe(2);
+      expect(db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM message").get()?.cnt).toBe(4);
+      expect(db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM part").get()?.cnt).toBe(8);
+      expect(db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM event").get()?.cnt).toBe(6);
+      expect(db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM event_sequence").get()?.cnt).toBe(2);
+
+      const result = pruneSessions(db, ["sess-old"], dbPath);
+
+      expect(result.sessions_deleted).toBe(1);
+      expect(result.before.row_counts.session).toBe(2);
+      expect(result.after.row_counts.session).toBe(1);
+
+      // Verify cascades
+      expect(db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM session").get()?.cnt).toBe(1);
+      expect(db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM message").get()?.cnt).toBe(2);
+      expect(db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM part").get()?.cnt).toBe(4);
+      expect(db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM event").get()?.cnt).toBe(3);
+      expect(db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM event_sequence").get()?.cnt).toBe(1);
+
+      // Recent session untouched
+      type IdRow = { id: string };
+      const remaining = db.query<IdRow, []>("SELECT id FROM session").all();
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].id).toBe("sess-recent");
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("pruneSessions with empty list does not delete anything", () => {
+    const dir = makeTempDir();
+    try {
+      const { db, dbPath } = createTestDb(dir);
+      db.exec("PRAGMA foreign_keys=ON");
+
+      const now = Date.now();
+      insertSession(db, "sess-a", now - 60 * 24 * 3600 * 1000);
+      insertSession(db, "sess-b", now - 5 * 24 * 3600 * 1000);
+
+      type CountRow = { cnt: number };
+      const result = pruneSessions(db, [], dbPath);
+
+      expect(result.sessions_deleted).toBe(0);
+      expect(db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM session").get()?.cnt).toBe(2);
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("event_sequence and event rows are removed for pruned sessions", () => {
+    const dir = makeTempDir();
+    try {
+      const { db, dbPath } = createTestDb(dir);
+      db.exec("PRAGMA foreign_keys=ON");
+
+      const now = Date.now();
+      insertSession(db, "sess-prune", now - 60 * 24 * 3600 * 1000, { events: 5 });
+      insertSession(db, "sess-keep", now - 5 * 24 * 3600 * 1000, { events: 4 });
+
+      pruneSessions(db, ["sess-prune"], dbPath);
+
+      type CountRow = { cnt: number };
+      expect(db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM event_sequence").get()?.cnt).toBe(1);
+      expect(db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM event").get()?.cnt).toBe(4);
+
+      type IdRow = { aggregate_id: string };
+      const remaining = db.query<IdRow, []>("SELECT aggregate_id FROM event_sequence").all();
+      expect(remaining[0].aggregate_id).toBe("sess-keep");
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("large session count (>999) does not throw 'too many SQL variables'", () => {
+    // Regression test for the IN (?,?,…) variable-limit bug.
+    // SQLite's SQLITE_MAX_VARIABLE_NUMBER is 999 in older builds, 32766 in Bun's build.
+    // The old approach built a single IN clause with one bound param per session id —
+    // fragile and guaranteed to blow up at scale. The fix uses a TEMP TABLE join.
+    const dir = makeTempDir();
+    try {
+      const { db, dbPath } = createTestDb(dir);
+      db.exec("PRAGMA foreign_keys=ON");
+
+      const now = Date.now();
+      const OLD_COUNT = 1500; // comfortably above the 999 legacy limit
+      const KEEP_COUNT = 5;
+
+      // Insert old sessions (to be pruned)
+      const insertSess = db.prepare("INSERT INTO session (id, time_created, time_updated) VALUES (?, ?, ?)");
+      const insertMsg  = db.prepare("INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)");
+      const insertPart = db.prepare("INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?, ?, ?, ?, ?)");
+      const insertEvtSeq = db.prepare("INSERT INTO event_sequence (aggregate_id) VALUES (?)");
+      const insertEvt = db.prepare("INSERT INTO event (id, aggregate_id, seq, type, data) VALUES (?, ?, ?, ?, ?)");
+
+      const oldTs = now - 60 * 24 * 3600 * 1000;
+      db.transaction(() => {
+        for (let i = 0; i < OLD_COUNT; i++) {
+          const sid = `old-sess-${i}`;
+          insertSess.run(sid, oldTs, oldTs);
+          const mid = `${sid}-msg`;
+          insertMsg.run(mid, sid, oldTs, JSON.stringify({ content: `msg ${i}` }));
+          insertPart.run(`${sid}-part`, mid, sid, oldTs, JSON.stringify({ text: `part ${i}` }));
+          insertEvtSeq.run(sid);
+          insertEvt.run(`${sid}-evt`, sid, 0, "test", JSON.stringify({ i }));
+        }
+      })();
+
+      // Insert recent sessions (to be kept)
+      const recentTs = now - 5 * 24 * 3600 * 1000;
+      db.transaction(() => {
+        for (let i = 0; i < KEEP_COUNT; i++) {
+          const sid = `keep-sess-${i}`;
+          insertSess.run(sid, recentTs, recentTs);
+          const mid = `${sid}-msg`;
+          insertMsg.run(mid, sid, recentTs, JSON.stringify({ content: `keep msg ${i}` }));
+          insertPart.run(`${sid}-part`, mid, sid, recentTs, JSON.stringify({ text: `keep part ${i}` }));
+          insertEvtSeq.run(sid);
+          insertEvt.run(`${sid}-evt`, sid, 0, "test", JSON.stringify({ i }));
+        }
+      })();
+
+      type CountRow = { cnt: number };
+      expect(db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM session").get()?.cnt).toBe(OLD_COUNT + KEEP_COUNT);
+
+      const cutoffMs = now - 30 * 24 * 3600 * 1000;
+      const oldIds = selectOldSessionIds(db, cutoffMs);
+      expect(oldIds).toHaveLength(OLD_COUNT);
+
+      // estimateReclaim must not throw and must return positive bytes
+      let reclaim: ReturnType<typeof estimateReclaim>;
+      expect(() => { reclaim = estimateReclaim(db, oldIds); }).not.toThrow();
+      expect(reclaim!.total_bytes).toBeGreaterThan(0);
+      expect(reclaim!.part_bytes).toBeGreaterThan(0);
+      expect(reclaim!.message_bytes).toBeGreaterThan(0);
+      expect(reclaim!.event_bytes).toBeGreaterThan(0);
+
+      // pruneSessions must not throw and must delete exactly OLD_COUNT sessions
+      let result: ReturnType<typeof pruneSessions>;
+      expect(() => { result = pruneSessions(db, oldIds, dbPath); }).not.toThrow();
+      expect(result!.sessions_deleted).toBe(OLD_COUNT);
+      expect(result!.before.row_counts.session).toBe(OLD_COUNT + KEEP_COUNT);
+      expect(result!.after.row_counts.session).toBe(KEEP_COUNT);
+
+      // Verify cascades: only KEEP_COUNT rows remain in each table
+      expect(db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM session").get()?.cnt).toBe(KEEP_COUNT);
+      expect(db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM message").get()?.cnt).toBe(KEEP_COUNT);
+      expect(db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM part").get()?.cnt).toBe(KEEP_COUNT);
+      expect(db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM event_sequence").get()?.cnt).toBe(KEEP_COUNT);
+      expect(db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM event").get()?.cnt).toBe(KEEP_COUNT);
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("age histogram buckets are mutually exclusive and sum to total", () => {
+    const dir = makeTempDir();
+    try {
+      const { db, dbPath } = createTestDb(dir);
+
+      const now = Date.now();
+      // One session per bucket
+      insertSession(db, "s1", now - 1 * 24 * 3600 * 1000);   // last7d
+      insertSession(db, "s2", now - 10 * 24 * 3600 * 1000);  // 7-30d
+      insertSession(db, "s3", now - 45 * 24 * 3600 * 1000);  // 30-90d
+      insertSession(db, "s4", now - 100 * 24 * 3600 * 1000); // older90d
+
+      const health = computeDbHealth(db, dbPath);
+      const hist = health.session_age_histogram;
+
+      expect(hist.last7d).toBe(1);
+      expect(hist.days7to30).toBe(1);
+      expect(hist.days30to90).toBe(1);
+      expect(hist.older90d).toBe(1);
+      expect(hist.last7d + hist.days7to30 + hist.days30to90 + hist.older90d).toBe(4);
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+});
+
+// ─── CLI Integration Tests (DB flags) ────────────────────────────────────────
+
+describe("DB CLI integration", () => {
+  test(
+    "--db-health --json returns valid JSON with expected keys",
+    async () => {
+      const dir = makeTempDir();
+      try {
+        const { db, dbPath } = createTestDb(dir);
+        const now = Date.now();
+        insertSession(db, "sess-test", now - 5 * 24 * 3600 * 1000);
+        db.close();
+
+        const result = await $`bun ${SCRIPT_PATH} --db-health --json --db-path=${dbPath}`.text();
+
+        let parsed: unknown;
+        expect(() => { parsed = JSON.parse(result); }).not.toThrow();
+
+        const sections = parsed as Array<{ label: string; data?: unknown }>;
+        expect(Array.isArray(sections)).toBe(true);
+        expect(sections.length).toBeGreaterThan(0);
+
+        const dbSection = sections.find((s) => s.label === "DB Health");
+        expect(dbSection).toBeDefined();
+        expect(dbSection?.data).toHaveProperty("file_size_bytes");
+        expect(dbSection?.data).toHaveProperty("row_counts");
+        expect(dbSection?.data).toHaveProperty("session_age_histogram");
+        expect(dbSection?.data).toHaveProperty("journal_mode");
+      } finally {
+        removeTempDir(dir);
+      }
+    },
+    { timeout: TEST_TIMEOUT }
+  );
+
+  test(
+    "--prune-older dry-run reports sessions to delete without deleting",
+    async () => {
+      const dir = makeTempDir();
+      try {
+        const { db, dbPath } = createTestDb(dir);
+        const now = Date.now();
+        insertSession(db, "sess-old", now - 60 * 24 * 3600 * 1000);
+        insertSession(db, "sess-recent", now - 5 * 24 * 3600 * 1000);
+        db.close();
+
+        const result = await $`bun ${SCRIPT_PATH} --prune-older=30 --json --db-path=${dbPath}`.text();
+
+        let parsed: unknown;
+        expect(() => { parsed = JSON.parse(result); }).not.toThrow();
+
+        const sections = parsed as Array<{ label: string; data?: unknown }>;
+        const pruneSection = sections.find((s) => s.label === "DB Prune (dry-run)");
+        expect(pruneSection).toBeDefined();
+
+        const data = pruneSection?.data as Record<string, unknown>;
+        expect(data.sessions_to_delete).toBe(1);
+        expect(String(data.notice)).toContain("DRY RUN");
+
+        // Verify nothing was actually deleted
+        const db2 = new Database(dbPath, { readonly: true });
+        type CountRow = { cnt: number };
+        const count = db2.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM session").get()?.cnt;
+        expect(count).toBe(2);
+        db2.close();
+      } finally {
+        removeTempDir(dir);
+      }
+    },
+    { timeout: TEST_TIMEOUT }
+  );
+
+  test(
+    "--prune-older --execute deletes old sessions and leaves recent ones",
+    async () => {
+      const dir = makeTempDir();
+      try {
+        const { db, dbPath } = createTestDb(dir);
+        const now = Date.now();
+        insertSession(db, "sess-old", now - 60 * 24 * 3600 * 1000, { messages: 2, partsPerMessage: 2, events: 3 });
+        insertSession(db, "sess-recent", now - 5 * 24 * 3600 * 1000, { messages: 2, partsPerMessage: 2, events: 3 });
+        db.close();
+
+        const result = await $`bun ${SCRIPT_PATH} --prune-older=30 --execute --json --db-path=${dbPath}`.nothrow().text();
+
+        let parsed: unknown;
+        expect(() => { parsed = JSON.parse(result); }).not.toThrow();
+
+        const sections = parsed as Array<{ label: string; data?: unknown }>;
+        // Could be "DB Prune (executed)" or "DB Prune (refused)" depending on running processes
+        const execSection = sections.find(
+          (s) => s.label === "DB Prune (executed)" || s.label === "DB Prune (refused)"
+        );
+        expect(execSection).toBeDefined();
+
+        if (execSection?.label === "DB Prune (executed)") {
+          const data = execSection.data as Record<string, unknown>;
+          expect(data.sessions_deleted).toBe(1);
+
+          // Verify DB state
+          const db2 = new Database(dbPath, { readonly: true });
+          type CountRow = { cnt: number };
+          expect(db2.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM session").get()?.cnt).toBe(1);
+          expect(db2.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM message").get()?.cnt).toBe(2);
+          expect(db2.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM part").get()?.cnt).toBe(4);
+          expect(db2.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM event_sequence").get()?.cnt).toBe(1);
+          db2.close();
+        } else {
+          // Refused due to running opencode processes — that's valid behavior
+          const data = execSection?.data as Record<string, unknown>;
+          expect(data.refused).toBe(true);
+        }
+      } finally {
+        removeTempDir(dir);
+      }
+    },
+    { timeout: TEST_TIMEOUT }
+  );
+
+  test(
+    "--db-health --no-tui outputs text format with DB Health section",
+    async () => {
+      const dir = makeTempDir();
+      try {
+        const { db, dbPath } = createTestDb(dir);
+        db.close();
+
+        const result = await $`bun ${SCRIPT_PATH} --db-health --no-tui --db-path=${dbPath}`.text();
+
+        expect(result).toContain("DB Health");
+        expect(result).toMatch(/file_size|page_count|journal_mode/);
+      } finally {
+        removeTempDir(dir);
+      }
+    },
+    { timeout: TEST_TIMEOUT }
+  );
+
+  test(
+    "--prune-older default value is 30 days when no value given",
+    async () => {
+      const dir = makeTempDir();
+      try {
+        const { db, dbPath } = createTestDb(dir);
+        const now = Date.now();
+        insertSession(db, "sess-old", now - 45 * 24 * 3600 * 1000);
+        db.close();
+
+        const result = await $`bun ${SCRIPT_PATH} --prune-older --json --db-path=${dbPath}`.text();
+
+        let parsed: unknown;
+        expect(() => { parsed = JSON.parse(result); }).not.toThrow();
+
+        const sections = parsed as Array<{ label: string; data?: unknown }>;
+        const pruneSection = sections.find((s) => s.label === "DB Prune (dry-run)");
+        expect(pruneSection).toBeDefined();
+
+        const data = pruneSection?.data as Record<string, unknown>;
+        expect(data.prune_older_than_days).toBe(30);
+        expect(data.sessions_to_delete).toBe(1);
+      } finally {
+        removeTempDir(dir);
+      }
+    },
+    { timeout: TEST_TIMEOUT }
+  );
+
+  test(
+    "--db-health and --prune-older can be combined",
+    async () => {
+      const dir = makeTempDir();
+      try {
+        const { db, dbPath } = createTestDb(dir);
+        const now = Date.now();
+        insertSession(db, "sess-old", now - 60 * 24 * 3600 * 1000);
+        db.close();
+
+        const result = await $`bun ${SCRIPT_PATH} --db-health --prune-older=30 --json --db-path=${dbPath}`.text();
+
+        let parsed: unknown;
+        expect(() => { parsed = JSON.parse(result); }).not.toThrow();
+
+        const sections = parsed as Array<{ label: string; data?: unknown }>;
+        expect(sections.some((s) => s.label === "DB Health")).toBe(true);
+        expect(sections.some((s) => s.label === "DB Prune (dry-run)")).toBe(true);
+      } finally {
+        removeTempDir(dir);
+      }
+    },
+    { timeout: TEST_TIMEOUT }
+  );
+});
+
+// ─── Existing CLI Tests ───────────────────────────────────────────────────────
+
 describe("opencode-doctor CLI", () => {
   test(
     "--help flag shows usage",
@@ -31,6 +658,11 @@ describe("opencode-doctor CLI", () => {
       expect(result).toContain("--format");
       expect(result).toContain("--only");
       expect(result).toContain("Sections:");
+      // New DB flags
+      expect(result).toContain("--db-health");
+      expect(result).toContain("--prune-older");
+      expect(result).toContain("--execute");
+      expect(result).toContain("--db-path");
     },
     { timeout: TEST_TIMEOUT }
   );
@@ -232,6 +864,219 @@ describe("error handling", () => {
       const output = result.stdout.toString() + result.stderr.toString();
       expect(output).toContain("Invalid value");
       expect(output).toContain("Server");
+    },
+    { timeout: TEST_TIMEOUT }
+  );
+});
+
+// ─── DB Guard Tests ───────────────────────────────────────────────────────────
+
+describe("DB guards (unit)", () => {
+  // ── classifyPgrepExitCode ──────────────────────────────────────────────────
+
+  test("classifyPgrepExitCode: exit 0 → has_procs", () => {
+    expect(classifyPgrepExitCode(0)).toBe("has_procs");
+  });
+
+  test("classifyPgrepExitCode: exit 1 → no_procs (safe)", () => {
+    expect(classifyPgrepExitCode(1)).toBe("no_procs");
+  });
+
+  test("classifyPgrepExitCode: exit 127 (command not found) → error (unsafe)", () => {
+    expect(classifyPgrepExitCode(127)).toBe("error");
+  });
+
+  test("classifyPgrepExitCode: exit 2 → error (unsafe)", () => {
+    expect(classifyPgrepExitCode(2)).toBe("error");
+  });
+
+  test("classifyPgrepExitCode: null exit code → error (unsafe)", () => {
+    expect(classifyPgrepExitCode(null)).toBe("error");
+  });
+
+  // ── prune-older floor ──────────────────────────────────────────────────────
+
+  test(
+    "--prune-older=0 warns and uses default 30 (parseArgs floor)",
+    async () => {
+      const dir = makeTempDir();
+      try {
+        const { db, dbPath } = createTestDb(dir);
+        db.close();
+
+        const result = await $`bun ${SCRIPT_PATH} --prune-older=0 --json --db-path=${dbPath}`
+          .quiet()
+          .nothrow();
+
+        const stderr = result.stderr.toString();
+        expect(stderr).toContain("Invalid value");
+        expect(stderr).toContain("--prune-older");
+
+        // Should still produce valid JSON (dry-run with default 30 days)
+        const stdout = result.stdout.toString();
+        let parsed: unknown;
+        expect(() => { parsed = JSON.parse(stdout); }).not.toThrow();
+        const sections = parsed as Array<{ label: string; data?: unknown }>;
+        const pruneSection = sections.find((s) => s.label === "DB Prune (dry-run)");
+        expect(pruneSection).toBeDefined();
+        const data = pruneSection?.data as Record<string, unknown>;
+        expect(data.prune_older_than_days).toBe(30);
+      } finally {
+        removeTempDir(dir);
+      }
+    },
+    { timeout: TEST_TIMEOUT }
+  );
+
+  test(
+    "--prune-older=-5 warns and uses default 30 (parseArgs floor)",
+    async () => {
+      const dir = makeTempDir();
+      try {
+        const { db, dbPath } = createTestDb(dir);
+        db.close();
+
+        const result = await $`bun ${SCRIPT_PATH} --prune-older=-5 --json --db-path=${dbPath}`
+          .quiet()
+          .nothrow();
+
+        const stderr = result.stderr.toString();
+        expect(stderr).toContain("Invalid value");
+        expect(stderr).toContain("--prune-older");
+      } finally {
+        removeTempDir(dir);
+      }
+    },
+    { timeout: TEST_TIMEOUT }
+  );
+
+  // ── --execute without --prune-older ───────────────────────────────────────
+
+  test(
+    "--execute without --prune-older exits 1 with clear error",
+    async () => {
+      const result = await $`bun ${SCRIPT_PATH} --execute`
+        .quiet()
+        .nothrow();
+
+      expect(result.exitCode).toBe(1);
+      const stderr = result.stderr.toString();
+      expect(stderr).toContain("--execute requires --prune-older");
+    },
+    { timeout: TEST_TIMEOUT }
+  );
+
+  // ── sessions_deleted reflects actual deleted rows, not input length ────────
+
+  test("pruneSessions: sessions_deleted reflects actual deleted rows, not input list length", () => {
+    const dir = makeTempDir();
+    try {
+      const { db, dbPath } = createTestDb(dir);
+      db.exec("PRAGMA foreign_keys=ON");
+
+      const now = Date.now();
+      insertSession(db, "sess-real", now - 60 * 24 * 3600 * 1000);
+
+      // Pass a mix of real and non-existent IDs
+      const result = pruneSessions(db, ["sess-real", "nonexistent-id-1", "nonexistent-id-2"], dbPath);
+
+      // Should report 1 (actual deleted), not 3 (input length)
+      expect(result.sessions_deleted).toBe(1);
+      expect(result.before.row_counts.session).toBe(1);
+      expect(result.after.row_counts.session).toBe(0);
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  // ── VACUUM failure path still returns sessions_deleted ────────────────────
+
+  test("pruneSessions: vacuum_error field present when VACUUM fails, sessions_deleted still reported", () => {
+    // We test this by verifying the PruneResult type has vacuum_error as optional
+    // and that a normal run (no VACUUM failure) does NOT set it.
+    const dir = makeTempDir();
+    try {
+      const { db, dbPath } = createTestDb(dir);
+      db.exec("PRAGMA foreign_keys=ON");
+
+      const now = Date.now();
+      insertSession(db, "sess-old", now - 60 * 24 * 3600 * 1000);
+
+      const result = pruneSessions(db, ["sess-old"], dbPath);
+
+      // Normal run: sessions_deleted is accurate, no vacuum_error
+      expect(result.sessions_deleted).toBe(1);
+      expect(result.vacuum_error).toBeUndefined();
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  // ── estimateReclaim byte accuracy (CAST AS BLOB) ──────────────────────────
+
+  test("estimateReclaim: byte counts are non-negative and sum correctly (CAST AS BLOB accuracy)", () => {
+    const dir = makeTempDir();
+    try {
+      const { db } = createTestDb(dir);
+
+      const now = Date.now();
+      // Insert sessions with known data content
+      insertSession(db, "sess-a", now - 60 * 24 * 3600 * 1000, { messages: 2, partsPerMessage: 2, events: 3 });
+      insertSession(db, "sess-b", now - 90 * 24 * 3600 * 1000, { messages: 1, partsPerMessage: 1, events: 1 });
+
+      const reclaim = estimateReclaim(db, ["sess-a", "sess-b"]);
+
+      // All byte counts must be non-negative
+      expect(reclaim.part_bytes).toBeGreaterThanOrEqual(0);
+      expect(reclaim.message_bytes).toBeGreaterThanOrEqual(0);
+      expect(reclaim.event_bytes).toBeGreaterThanOrEqual(0);
+
+      // Total must equal sum of parts
+      expect(reclaim.total_bytes).toBe(reclaim.part_bytes + reclaim.message_bytes + reclaim.event_bytes);
+
+      // With actual data, bytes should be > 0
+      expect(reclaim.total_bytes).toBeGreaterThan(0);
+
+      // Human-readable strings should be present
+      expect(typeof reclaim.total_human).toBe("string");
+      expect(reclaim.total_human.length).toBeGreaterThan(0);
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  // ── help text contains irreversible-loss language ─────────────────────────
+
+  test(
+    "--help contains irreversible/permanent deletion language",
+    async () => {
+      const result = await $`bun ${SCRIPT_PATH} --help`.text();
+
+      // Should warn about irreversibility
+      expect(result.toLowerCase()).toMatch(/irreversib|permanent/);
+      // Should mention --execute requires --prune-older
+      expect(result).toContain("--execute");
+      expect(result).toContain("--prune-older");
+    },
+    { timeout: TEST_TIMEOUT }
+  );
+
+  // ── DB errors exit nonzero ────────────────────────────────────────────────
+
+  test(
+    "--db-health with nonexistent DB path exits nonzero",
+    async () => {
+      const result = await $`bun ${SCRIPT_PATH} --db-health --json --db-path=/nonexistent/path/to/db.db`
+        .quiet()
+        .nothrow();
+
+      expect(result.exitCode).not.toBe(0);
     },
     { timeout: TEST_TIMEOUT }
   );

--- a/.config/opencode/scripts/opencode-doctor.ts
+++ b/.config/opencode/scripts/opencode-doctor.ts
@@ -932,19 +932,24 @@ async function runDbPruneExecute(options: CliOptions): Promise<SectionResult> {
   const dbSize = safeStatSize(options.dbPath);
   if (dbSize > 0) {
     try {
-      const dfResult = Bun.spawnSync(["df", "-k", dirname(options.dbPath)]);
+      // -P forces POSIX output: one data line per filesystem, never wrapped
+      // (plain `df -k` can split a long device name across two lines).
+      const dfResult = Bun.spawnSync(["df", "-kP", dirname(options.dbPath)]);
       if (dfResult.exitCode === 0) {
         const dfOut = dfResult.stdout instanceof Buffer
           ? dfResult.stdout.toString("utf8")
           : String(dfResult.stdout ?? "");
-        // df -k output: header line then data line; Available is column 4 (0-indexed 3)
+        // POSIX `df -kP` data line, both macOS and Linux:
+        //   Filesystem  1024-blocks  Used  Available  Capacity  Mounted-on
+        // Columns are fixed: Available is index 3, Mounted-on is the last field.
         const lines = dfOut.trim().split("\n");
         const dataLine = lines[lines.length - 1];
         const cols = dataLine.trim().split(/\s+/);
-        // macOS df: Filesystem 512-blocks Used Available Capacity iused ifree %iused Mounted
-        // Linux df -k: Filesystem 1K-blocks Used Available Use% Mounted
-        // Available is always the 4th column (index 3)
-        const availableKb = parseInt(cols[3] ?? "0", 10);
+        // Anchor from the end (Mounted-on is last) so a space in the mount path
+        // can't shift the Available column: Available is 4th from the path,
+        // i.e. cols[length-3] in POSIX layout. Fall back to index 3.
+        const availableRaw = cols.length >= 6 ? cols[cols.length - 3] : cols[3];
+        const availableKb = parseInt(availableRaw ?? "", 10);
         if (!isNaN(availableKb)) {
           const availableBytes = availableKb * 1024;
           const requiredBytes = dbSize * 1.1;

--- a/.config/opencode/scripts/opencode-doctor.ts
+++ b/.config/opencode/scripts/opencode-doctor.ts
@@ -1,5 +1,9 @@
 #!/usr/bin/env bun
 import { spawn, type ChildProcess } from "node:child_process";
+import { statSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname } from "node:path";
+import { Database } from "bun:sqlite";
 import { createOpencodeClient } from "@opencode-ai/sdk";
 
 type OutputFormat = "text" | "json";
@@ -16,6 +20,11 @@ type CliOptions = {
   limit: number;
   toolsProvider?: string;
   toolsModel?: string;
+  // DB flags
+  dbHealth: boolean;
+  pruneOlderDays: number | null;
+  execute: boolean;
+  dbPath: string;
 };
 
 type SectionResult = {
@@ -27,6 +36,10 @@ type SectionResult = {
 const DEFAULT_PORT = 4096;
 const AUTO_PORT_ATTEMPTS = 10;
 const DEFAULT_LIMIT = 10;
+const DEFAULT_DB_PATH = `${homedir()}/.local/share/opencode/opencode.db`;
+const DEFAULT_PRUNE_DAYS = 30;
+const BUSY_RETRY_ATTEMPTS = 3;
+const BUSY_RETRY_DELAY_MS = 100;
 
 const SECTION_KEYS = [
   "server",
@@ -46,6 +59,7 @@ const SECTION_KEYS = [
   "formatter",
   "sessions",
   "session-status",
+  "db-health",
 ] as const;
 
 const SENSITIVE_KEYS = [
@@ -82,6 +96,11 @@ const KNOWN_FLAGS = new Set([
   "--tools-model",
   "--help",
   "-h",
+  // DB flags
+  "--db-health",
+  "--prune-older",
+  "--execute",
+  "--db-path",
 ]);
 
 function warnUnknownFlag(flag: string): void {
@@ -236,6 +255,36 @@ function parseArgs(argv: string[]): CliOptions {
     }
   }
 
+  // DB flags
+  const dbHealthValue = args.get("--db-health");
+  const dbHealth = dbHealthValue != null && !isBooleanFalse(dbHealthValue);
+
+  const pruneOlderValue = args.get("--prune-older");
+  let pruneOlderDays: number | null = null;
+  if (pruneOlderValue != null) {
+    if (pruneOlderValue === true) {
+      // Flag present without value — use default
+      pruneOlderDays = DEFAULT_PRUNE_DAYS;
+    } else {
+      const parsed = Number(pruneOlderValue);
+      if (!Number.isFinite(parsed) || parsed < 1) {
+        warnInvalidValue("--prune-older", String(pruneOlderValue), "positive integer >= 1 (days)");
+        pruneOlderDays = DEFAULT_PRUNE_DAYS;
+      } else {
+        pruneOlderDays = parsed;
+      }
+    }
+  }
+
+  const executeValue = args.get("--execute");
+  const execute = executeValue != null && !isBooleanFalse(executeValue);
+
+  const dbPathValue = args.get("--db-path");
+  const dbPath =
+    dbPathValue != null && dbPathValue !== true
+      ? String(dbPathValue)
+      : DEFAULT_DB_PATH;
+
   return {
     host,
     port,
@@ -248,6 +297,10 @@ function parseArgs(argv: string[]): CliOptions {
     limit,
     toolsProvider: toolsProviderValue != null && toolsProviderValue !== true ? String(toolsProviderValue) : undefined,
     toolsModel: toolsModelValue != null && toolsModelValue !== true ? String(toolsModelValue) : undefined,
+    dbHealth,
+    pruneOlderDays,
+    execute,
+    dbPath,
   };
 }
 
@@ -274,6 +327,15 @@ Options:
   --tools-provider <string> Provider ID for tool schemas
   --tools-model <string>    Model ID for tool schemas
   --help                    Show this help
+
+DB Maintenance (no server required):
+  --db-health               Read-only DB metrics (size, pragmas, row counts, age histogram)
+  --prune-older[=<days>]    Select sessions older than N days (default: 30, minimum: 1).
+                            Dry-run unless --execute. Deletion is IRREVERSIBLE.
+  --execute                 PERMANENTLY and IRREVERSIBLY deletes sessions and all their
+                            messages, parts, and events. Requires --prune-older.
+                            Without --prune-older, --execute is an error.
+  --db-path <path>          Override DB path (default: ~/.local/share/opencode/opencode.db)
 
 Sections:
   ${SECTION_KEYS.join(", ")}
@@ -403,6 +465,528 @@ function formatErrorMessage(error: unknown): string {
   }
   return String(error);
 }
+
+// ─── DB Helpers ───────────────────────────────────────────────────────────────
+
+function bytesToHuman(bytes: number): string {
+  if (bytes >= 1e9) return `${(bytes / 1e9).toFixed(2)} GB`;
+  if (bytes >= 1e6) return `${(bytes / 1e6).toFixed(2)} MB`;
+  if (bytes >= 1e3) return `${(bytes / 1e3).toFixed(2)} KB`;
+  return `${bytes} B`;
+}
+
+function safeStatSize(path: string): number {
+  try {
+    return statSync(path).size;
+  } catch {
+    return 0;
+  }
+}
+
+async function withSqliteBusyRetry<T>(
+  fn: () => T,
+  attempts = BUSY_RETRY_ATTEMPTS,
+  backoffMs = BUSY_RETRY_DELAY_MS
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      return fn();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("SQLITE_BUSY") || msg.includes("SQLITE_LOCKED")) {
+        lastError = err;
+        if (attempt < attempts - 1) {
+          await new Promise((r) => setTimeout(r, backoffMs));
+        }
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw lastError;
+}
+
+export type DbHealthData = {
+  db_path: string;
+  file_size_bytes: number;
+  file_size_human: string;
+  wal_size_bytes: number;
+  wal_size_human: string;
+  shm_size_bytes: number;
+  shm_size_human: string;
+  page_count: number;
+  page_size: number;
+  freelist_count: number;
+  free_bytes: number;
+  free_pct: string;
+  journal_mode: string;
+  auto_vacuum: number;
+  row_counts: {
+    session: number;
+    message: number;
+    part: number;
+    event: number;
+    event_sequence: number;
+  };
+  session_age_histogram: {
+    last7d: number;
+    days7to30: number;
+    days30to90: number;
+    older90d: number;
+  };
+};
+
+export function computeDbHealth(db: Database, dbPath: string): DbHealthData {
+  type PragmaRow = { [key: string]: unknown };
+
+  const pageCountRow = db.query<PragmaRow, []>("PRAGMA page_count").get();
+  const pageSizeRow = db.query<PragmaRow, []>("PRAGMA page_size").get();
+  const freelistRow = db.query<PragmaRow, []>("PRAGMA freelist_count").get();
+  const journalRow = db.query<PragmaRow, []>("PRAGMA journal_mode").get();
+  const autoVacuumRow = db.query<PragmaRow, []>("PRAGMA auto_vacuum").get();
+
+  const pageCount = Number(pageCountRow?.page_count ?? 0);
+  const pageSize = Number(pageSizeRow?.page_size ?? 0);
+  const freelistCount = Number(freelistRow?.freelist_count ?? 0);
+  const journalMode = String(journalRow?.journal_mode ?? "unknown");
+  const autoVacuum = Number(autoVacuumRow?.auto_vacuum ?? 0);
+
+  const freeBytes = freelistCount * pageSize;
+  const totalBytes = pageCount * pageSize;
+  const freePct = totalBytes > 0 ? ((freeBytes / totalBytes) * 100).toFixed(2) + "%" : "0.00%";
+
+  type CountRow = { cnt: number };
+  const sessionCount = db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM session").get()?.cnt ?? 0;
+  const messageCount = db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM message").get()?.cnt ?? 0;
+  const partCount = db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM part").get()?.cnt ?? 0;
+  const eventCount = db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM event").get()?.cnt ?? 0;
+  const eventSeqCount = db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM event_sequence").get()?.cnt ?? 0;
+
+  // Age histogram — CAST to INTEGER to avoid numeric-vs-text comparison bug
+  const now7d = Math.floor(Date.now() / 1000) - 7 * 86400;
+  const now30d = Math.floor(Date.now() / 1000) - 30 * 86400;
+  const now90d = Math.floor(Date.now() / 1000) - 90 * 86400;
+
+  type HistRow = { cnt: number };
+  const last7d = db.query<HistRow, [number]>(
+    "SELECT COUNT(*) AS cnt FROM session WHERE CAST(time_created / 1000 AS INTEGER) >= ?"
+  ).get(now7d)?.cnt ?? 0;
+
+  const days7to30 = db.query<HistRow, [number, number]>(
+    "SELECT COUNT(*) AS cnt FROM session WHERE CAST(time_created / 1000 AS INTEGER) >= ? AND CAST(time_created / 1000 AS INTEGER) < ?"
+  ).get(now30d, now7d)?.cnt ?? 0;
+
+  const days30to90 = db.query<HistRow, [number, number]>(
+    "SELECT COUNT(*) AS cnt FROM session WHERE CAST(time_created / 1000 AS INTEGER) >= ? AND CAST(time_created / 1000 AS INTEGER) < ?"
+  ).get(now90d, now30d)?.cnt ?? 0;
+
+  const older90d = db.query<HistRow, [number]>(
+    "SELECT COUNT(*) AS cnt FROM session WHERE CAST(time_created / 1000 AS INTEGER) < ?"
+  ).get(now90d)?.cnt ?? 0;
+
+  const fileSizeBytes = safeStatSize(dbPath);
+  const walSizeBytes = safeStatSize(dbPath + "-wal");
+  const shmSizeBytes = safeStatSize(dbPath + "-shm");
+
+  return {
+    db_path: dbPath,
+    file_size_bytes: fileSizeBytes,
+    file_size_human: bytesToHuman(fileSizeBytes),
+    wal_size_bytes: walSizeBytes,
+    wal_size_human: bytesToHuman(walSizeBytes),
+    shm_size_bytes: shmSizeBytes,
+    shm_size_human: bytesToHuman(shmSizeBytes),
+    page_count: pageCount,
+    page_size: pageSize,
+    freelist_count: freelistCount,
+    free_bytes: freeBytes,
+    free_pct: freePct,
+    journal_mode: journalMode,
+    auto_vacuum: autoVacuum,
+    row_counts: {
+      session: sessionCount,
+      message: messageCount,
+      part: partCount,
+      event: eventCount,
+      event_sequence: eventSeqCount,
+    },
+    session_age_histogram: {
+      last7d,
+      days7to30,
+      days30to90,
+      older90d,
+    },
+  };
+}
+
+export function selectOldSessionIds(db: Database, cutoffMs: number): string[] {
+  type IdRow = { id: string };
+  const cutoffSec = Math.floor(cutoffMs / 1000);
+  const rows = db.query<IdRow, [number]>(
+    "SELECT id FROM session WHERE CAST(time_created / 1000 AS INTEGER) < ?"
+  ).all(cutoffSec);
+  return rows.map((r) => r.id);
+}
+
+export type ReclaimEstimate = {
+  part_bytes: number;
+  message_bytes: number;
+  event_bytes: number;
+  total_bytes: number;
+  part_human: string;
+  message_human: string;
+  event_human: string;
+  total_human: string;
+};
+
+export function estimateReclaim(db: Database, sessionIds: string[]): ReclaimEstimate {
+  if (sessionIds.length === 0) {
+    return {
+      part_bytes: 0, message_bytes: 0, event_bytes: 0, total_bytes: 0,
+      part_human: "0 B", message_human: "0 B", event_human: "0 B", total_human: "0 B",
+    };
+  }
+
+  // Use a temp table to avoid SQLite's bound-variable limit (SQLITE_MAX_VARIABLE_NUMBER).
+  // A giant IN (?,?,…) clause with thousands of ids will throw "too many SQL variables".
+  db.exec("CREATE TEMP TABLE IF NOT EXISTS _prune_ids (id TEXT PRIMARY KEY)");
+  db.exec("DELETE FROM _prune_ids");
+
+  const insertId = db.prepare("INSERT OR IGNORE INTO _prune_ids (id) VALUES (?)");
+  db.transaction(() => {
+    for (const id of sessionIds) insertId.run(id);
+  })();
+
+  type SumRow = { total: number | null };
+
+  // Use CAST(data AS BLOB) so length() returns byte count, not character count.
+  // SQLite's length() on TEXT counts Unicode code points; BLOB length is always bytes.
+  const partBytes = db.query<SumRow, []>(
+    "SELECT SUM(length(CAST(data AS BLOB))) AS total FROM part WHERE session_id IN (SELECT id FROM _prune_ids)"
+  ).get()?.total ?? 0;
+
+  const messageBytes = db.query<SumRow, []>(
+    "SELECT SUM(length(CAST(data AS BLOB))) AS total FROM message WHERE session_id IN (SELECT id FROM _prune_ids)"
+  ).get()?.total ?? 0;
+
+  const eventBytes = db.query<SumRow, []>(
+    "SELECT SUM(length(CAST(data AS BLOB))) AS total FROM event WHERE aggregate_id IN (SELECT id FROM _prune_ids)"
+  ).get()?.total ?? 0;
+
+  db.exec("DROP TABLE IF EXISTS _prune_ids");
+
+  const totalBytes = (partBytes ?? 0) + (messageBytes ?? 0) + (eventBytes ?? 0);
+
+  return {
+    part_bytes: partBytes ?? 0,
+    message_bytes: messageBytes ?? 0,
+    event_bytes: eventBytes ?? 0,
+    total_bytes: totalBytes,
+    part_human: bytesToHuman(partBytes ?? 0),
+    message_human: bytesToHuman(messageBytes ?? 0),
+    event_human: bytesToHuman(eventBytes ?? 0),
+    total_human: bytesToHuman(totalBytes),
+  };
+}
+
+export type PruneResult = {
+  sessions_deleted: number;
+  before: {
+    file_size_bytes: number;
+    file_size_human: string;
+    freelist_count: number;
+    row_counts: { session: number; message: number; part: number; event: number; event_sequence: number };
+  };
+  after: {
+    file_size_bytes: number;
+    file_size_human: string;
+    freelist_count: number;
+    row_counts: { session: number; message: number; part: number; event: number; event_sequence: number };
+  };
+  bytes_reclaimed: number;
+  bytes_reclaimed_human: string;
+  vacuum_error?: string;
+};
+
+function captureDbSnapshot(db: Database, dbPath: string): PruneResult["before"] {
+  type PragmaRow = { [key: string]: unknown };
+  type CountRow = { cnt: number };
+
+  const freelistCount = Number(db.query<PragmaRow, []>("PRAGMA freelist_count").get()?.freelist_count ?? 0);
+  const sessionCount = db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM session").get()?.cnt ?? 0;
+  const messageCount = db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM message").get()?.cnt ?? 0;
+  const partCount = db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM part").get()?.cnt ?? 0;
+  const eventCount = db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM event").get()?.cnt ?? 0;
+  const eventSeqCount = db.query<CountRow, []>("SELECT COUNT(*) AS cnt FROM event_sequence").get()?.cnt ?? 0;
+  const fileSizeBytes = safeStatSize(dbPath);
+
+  return {
+    file_size_bytes: fileSizeBytes,
+    file_size_human: bytesToHuman(fileSizeBytes),
+    freelist_count: freelistCount,
+    row_counts: {
+      session: sessionCount,
+      message: messageCount,
+      part: partCount,
+      event: eventCount,
+      event_sequence: eventSeqCount,
+    },
+  };
+}
+
+export function pruneSessions(db: Database, sessionIds: string[], dbPath: string): PruneResult {
+  const before = captureDbSnapshot(db, dbPath);
+
+  let sessionsDeleted = 0;
+
+  if (sessionIds.length > 0) {
+    // Populate a temp table to avoid SQLite's bound-variable limit.
+    // IN (?,?,…) with thousands of ids throws "too many SQL variables".
+    db.exec("CREATE TEMP TABLE IF NOT EXISTS _prune_ids (id TEXT PRIMARY KEY)");
+    db.exec("DELETE FROM _prune_ids");
+
+    const insertId = db.prepare("INSERT OR IGNORE INTO _prune_ids (id) VALUES (?)");
+
+    db.transaction(() => {
+      // Bulk-load ids — one bind per statement, no variable-count limit.
+      for (const id of sessionIds) insertId.run(id);
+
+      // Count sessions that actually exist in the DB (not just input list length).
+      type CountRow = { cnt: number };
+      const existingCount = db.query<CountRow, []>(
+        "SELECT COUNT(*) AS cnt FROM session WHERE id IN (SELECT id FROM _prune_ids)"
+      ).get()?.cnt ?? 0;
+      sessionsDeleted = existingCount;
+
+      // Delete event_sequence (cascades to event) for these session ids.
+      db.exec("DELETE FROM event_sequence WHERE aggregate_id IN (SELECT id FROM _prune_ids)");
+      // Delete sessions (cascades to message, part via FK).
+      db.exec("DELETE FROM session WHERE id IN (SELECT id FROM _prune_ids)");
+    })();
+
+    db.exec("DROP TABLE IF EXISTS _prune_ids");
+  }
+
+  // Checkpoint WAL then VACUUM to reclaim space (VACUUM must run outside a transaction).
+  // Wrap in its own try/catch: if VACUUM fails, we still report what was deleted.
+  let vacuumError: string | undefined;
+  try {
+    db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+    db.exec("VACUUM");
+  } catch (err) {
+    vacuumError = formatErrorMessage(err);
+  }
+
+  const after = captureDbSnapshot(db, dbPath);
+
+  const bytesReclaimed = Math.max(0, before.file_size_bytes - after.file_size_bytes);
+
+  const result: PruneResult = {
+    sessions_deleted: sessionsDeleted,
+    before,
+    after,
+    bytes_reclaimed: bytesReclaimed,
+    bytes_reclaimed_human: bytesToHuman(bytesReclaimed),
+  };
+
+  if (vacuumError != null) {
+    result.vacuum_error = `Rows deleted but space reclamation failed: ${vacuumError}`;
+  }
+
+  return result;
+}
+
+/**
+ * Classify a pgrep exit code into a process-check result.
+ * Exported for unit testing.
+ *   0  → pgrep found matches (processes exist)
+ *   1  → pgrep found no matches (safe)
+ *   other → pgrep itself failed / unavailable (treat as UNSAFE)
+ */
+export function classifyPgrepExitCode(exitCode: number | null): "has_procs" | "no_procs" | "error" {
+  if (exitCode === 0) return "has_procs";
+  if (exitCode === 1) return "no_procs";
+  return "error";
+}
+
+function checkForOtherOpencodeProcesses(): { safe: boolean; count: number; pids: number[] } {
+  const result = Bun.spawnSync(["pgrep", "-f", "opencode"]);
+  const classification = classifyPgrepExitCode(result.exitCode);
+
+  if (classification === "error") {
+    // pgrep unavailable or crashed — cannot verify safety, refuse to proceed
+    return { safe: false, count: -1, pids: [] };
+  }
+
+  if (classification === "no_procs") {
+    return { safe: true, count: 0, pids: [] };
+  }
+
+  const output = result.stdout instanceof Buffer
+    ? result.stdout.toString("utf8")
+    : String(result.stdout ?? "");
+
+  const ownPid = process.pid;
+  // Get parent PID via /proc or ps
+  let parentPid: number | null = null;
+  try {
+    const ppidResult = Bun.spawnSync(["ps", "-o", "ppid=", "-p", String(ownPid)]);
+    if (ppidResult.exitCode === 0) {
+      const ppidOut = ppidResult.stdout instanceof Buffer
+        ? ppidResult.stdout.toString("utf8")
+        : String(ppidResult.stdout ?? "");
+      parentPid = parseInt(ppidOut.trim(), 10) || null;
+    }
+  } catch {
+    // ignore
+  }
+
+  const pids = output
+    .split("\n")
+    .map((line) => parseInt(line.trim(), 10))
+    .filter((pid) => !isNaN(pid) && pid !== ownPid && pid !== parentPid);
+
+  return { safe: pids.length === 0, count: pids.length, pids };
+}
+
+// ─── DB Section Runners ───────────────────────────────────────────────────────
+
+async function runDbHealth(options: CliOptions): Promise<SectionResult> {
+  let db: Database | null = null;
+  try {
+    const uri = "file:" + options.dbPath + "?mode=ro";
+    db = new Database(uri, { readonly: true });
+    db.exec("PRAGMA busy_timeout=5000");
+
+    const data = await withSqliteBusyRetry(() => computeDbHealth(db!, options.dbPath));
+    return { label: "DB Health", data };
+  } catch (error) {
+    return { label: "DB Health", data: null, error: formatErrorMessage(error) };
+  } finally {
+    db?.close();
+  }
+}
+
+async function runDbPruneDryRun(options: CliOptions): Promise<SectionResult> {
+  const days = options.pruneOlderDays ?? DEFAULT_PRUNE_DAYS;
+  const cutoffMs = Date.now() - days * 24 * 3600 * 1000;
+  const cutoffDate = new Date(cutoffMs).toISOString().slice(0, 10);
+
+  let db: Database | null = null;
+  try {
+    const uri = "file:" + options.dbPath + "?mode=ro";
+    db = new Database(uri, { readonly: true });
+    db.exec("PRAGMA busy_timeout=5000");
+
+    const sessionIds = await withSqliteBusyRetry(() => selectOldSessionIds(db!, cutoffMs));
+    const reclaim = await withSqliteBusyRetry(() => estimateReclaim(db!, sessionIds));
+
+    const data = {
+      cutoff_date: cutoffDate,
+      prune_older_than_days: days,
+      sessions_to_delete: sessionIds.length,
+      reclaimable_estimate: reclaim,
+      notice: "DRY RUN — no changes. Re-run with --execute to delete.",
+    };
+
+    return { label: "DB Prune (dry-run)", data };
+  } catch (error) {
+    return { label: "DB Prune (dry-run)", data: null, error: formatErrorMessage(error) };
+  } finally {
+    db?.close();
+  }
+}
+
+async function runDbPruneExecute(options: CliOptions): Promise<SectionResult> {
+  const days = options.pruneOlderDays ?? DEFAULT_PRUNE_DAYS;
+
+  // Defense-in-depth: hard-refuse if pruneOlderDays < 1 even if parseArgs let it through.
+  if (days < 1) {
+    const data = {
+      refused: true,
+      reason: `--prune-older must be >= 1 day (got ${days}). Refusing to prevent mass deletion.`,
+    };
+    return { label: "DB Prune (refused)", data };
+  }
+
+  const cutoffMs = Date.now() - days * 24 * 3600 * 1000;
+  const cutoffDate = new Date(cutoffMs).toISOString().slice(0, 10);
+
+  // Safety gate: check for other opencode processes
+  const procCheck = checkForOtherOpencodeProcesses();
+  if (!procCheck.safe) {
+    const reason = procCheck.count === -1
+      ? "Could not verify other OpenCode processes are stopped (pgrep unavailable); refusing to run destructive prune. Re-run where process detection works."
+      : `Found ${procCheck.count} other opencode process(es) running (PIDs: ${procCheck.pids.join(", ")}). Close all OpenCode instances and re-run.`;
+    const data = {
+      refused: true,
+      reason,
+      instruction: "Close all OpenCode instances and re-run with --prune-older --execute",
+    };
+    return { label: "DB Prune (refused)", data };
+  }
+
+  // Disk-space pre-check: VACUUM needs ~= DB size of free space for a temp copy.
+  // Check BEFORE any destructive operation so we never delete-then-fail-vacuum.
+  const dbSize = safeStatSize(options.dbPath);
+  if (dbSize > 0) {
+    try {
+      const dfResult = Bun.spawnSync(["df", "-k", dirname(options.dbPath)]);
+      if (dfResult.exitCode === 0) {
+        const dfOut = dfResult.stdout instanceof Buffer
+          ? dfResult.stdout.toString("utf8")
+          : String(dfResult.stdout ?? "");
+        // df -k output: header line then data line; Available is column 4 (0-indexed 3)
+        const lines = dfOut.trim().split("\n");
+        const dataLine = lines[lines.length - 1];
+        const cols = dataLine.trim().split(/\s+/);
+        // macOS df: Filesystem 512-blocks Used Available Capacity iused ifree %iused Mounted
+        // Linux df -k: Filesystem 1K-blocks Used Available Use% Mounted
+        // Available is always the 4th column (index 3)
+        const availableKb = parseInt(cols[3] ?? "0", 10);
+        if (!isNaN(availableKb)) {
+          const availableBytes = availableKb * 1024;
+          const requiredBytes = dbSize * 1.1;
+          if (availableBytes < requiredBytes) {
+            const data = {
+              refused: true,
+              reason: `VACUUM needs ~${bytesToHuman(Math.ceil(requiredBytes))} free; only ${bytesToHuman(availableBytes)} available. Free disk space and re-run.`,
+            };
+            return { label: "DB Prune (refused)", data };
+          }
+        }
+      }
+    } catch {
+      // If df fails, proceed — disk check is best-effort; the real guard is VACUUM itself.
+    }
+  }
+
+  let db: Database | null = null;
+  try {
+    db = new Database(options.dbPath);
+    db.exec("PRAGMA busy_timeout=5000");
+    db.exec("PRAGMA foreign_keys=ON");
+
+    const sessionIds = selectOldSessionIds(db, cutoffMs);
+
+    const result = pruneSessions(db, sessionIds, options.dbPath);
+
+    const data = {
+      cutoff_date: cutoffDate,
+      prune_older_than_days: days,
+      ...result,
+    };
+
+    return { label: "DB Prune (executed)", data };
+  } catch (error) {
+    return { label: "DB Prune (executed)", data: null, error: formatErrorMessage(error) };
+  } finally {
+    db?.close();
+  }
+}
+
+// ─── Server / Section Collection ─────────────────────────────────────────────
 
 async function spawnOpencodeServer(
   hostname: string,
@@ -745,6 +1329,53 @@ function summarize(value: unknown, limit: number): unknown {
 
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2));
+
+  // DB-only path: if any db flag is present, skip server entirely.
+  // Also route here if --execute is set alone (to give a clear error).
+  const isDbMode = options.dbHealth || options.pruneOlderDays != null || options.execute;
+
+  if (isDbMode) {
+    // Guard: --execute without --prune-older is a user error
+    if (options.execute && options.pruneOlderDays == null) {
+      console.error("Error: --execute requires --prune-older=<days>. Example: --prune-older=30 --execute");
+      process.exit(1);
+    }
+
+    const sections: SectionResult[] = [];
+    let hasError = false;
+
+    if (options.dbHealth) {
+      const result = await runDbHealth(options);
+      sections.push(result);
+      if (result.error != null) hasError = true;
+    }
+
+    if (options.pruneOlderDays != null) {
+      if (options.execute) {
+        const result = await runDbPruneExecute(options);
+        sections.push(result);
+        // Exit nonzero if refused or errored
+        if (isPlainObject(result.data) && (result.data as { refused?: boolean }).refused) {
+          hasError = true;
+        }
+        if (result.error != null) hasError = true;
+      } else {
+        const result = await runDbPruneDryRun(options);
+        sections.push(result);
+        if (result.error != null) hasError = true;
+      }
+    }
+
+    const output = options.format === "json"
+      ? JSON.stringify(redactSecrets(sections.map((section) => ({
+          label: section.label,
+          ...extractData(section.data),
+        }))), null, 2)
+      : sections.map((section) => renderSection(section, options)).join("\n");
+
+    console.log(output);
+    process.exit(hasError ? 1 : 0);
+  }
 
   const sections = await collectSections(options);
   const output = options.format === "json"

--- a/.dotfiles/docs/opencode-doctor.md
+++ b/.dotfiles/docs/opencode-doctor.md
@@ -1,0 +1,147 @@
+# OpenCode Doctor Reference Guide
+
+## Introduction
+
+`opencode-doctor` is a diagnostic utility for OpenCode environments. It inspects various aspects of the running OpenCode server, project configuration, and integrated tools to provide a comprehensive health check and debugging information.
+
+If an OpenCode server is not already running on the target port, the doctor will attempt to spawn a temporary server instance for the duration of the diagnostic run.
+
+---
+
+## Installation and Execution
+
+The doctor script is located at `~/.config/opencode/scripts/opencode-doctor.ts`.
+
+### Running via mise (Recommended)
+
+If you have `mise` configured, you can run the doctor using the defined task:
+
+```bash
+mise run opencode:doctor
+```
+
+### Running Directly with Bun
+
+The script requires [Bun](https://bun.sh/) to execute directly:
+
+```bash
+bun ~/.config/opencode/scripts/opencode-doctor.ts [options]
+```
+
+---
+
+## CLI Options
+
+| Flag               | Argument       | Description                             | Default     |
+| ------------------ | -------------- | --------------------------------------- | ----------- |
+| `--port`           | `<number>`     | OpenCode server port                    | `4096`      |
+| `--host`           | `<string>`     | Hostname for base URL                   | `localhost` |
+| `--directory`      | `<path>`       | Directory to target                     | `cwd`       |
+| `--format`         | `<text\|json>` | Output format                           | `text`      |
+| `--json`           | -              | Shortcut for `--format json`            | -           |
+| `--no-tui`         | -              | Disable ANSI styling and colors         | -           |
+| `--only`           | `<keys>`       | Comma-separated sections to include     | All         |
+| `--full`           | -              | Include expanded data where available   | -           |
+| `--limit`          | `<number>`     | Limit list size for multi-item sections | `10`        |
+| `--tools-provider` | `<string>`     | Provider ID for tool schemas            | -           |
+| `--tools-model`    | `<string>`     | Model ID for tool schemas               | -           |
+| `--db-health`      | -              | Read-only DB maintenance metrics        | -           |
+| `--prune-older`    | `<days>`       | Prune sessions older than N days (dry-run unless `--execute`) | `30` |
+| `--execute`        | -              | Required to perform the irreversible prune + VACUUM | -   |
+| `--db-path`        | `<path>`       | Override DB path                        | `~/.local/share/opencode/opencode.db` |
+| `--help`, `-h`     | -              | Show help message                       | -           |
+
+---
+
+## Diagnostic Sections
+
+You can filter the output using the `--only` flag followed by a comma-separated list of these section keys:
+
+- `server`: Server connection details (URL, port, mode)
+- `health`: Server health status and latency
+- `config`: OpenCode configuration settings (redacted)
+- `providers`: Configured model providers
+- `project`: Current project details
+- `projects`: List of available projects
+- `path`: Environment path information
+- `vcs`: Version Control System (Git) status
+- `agents`: Available OpenCode agents
+- `commands`: Available CLI commands/aliases
+- `tools`: Detailed tool information (use `--full` for schemas)
+- `tool-ids`: List of available tool identifiers
+- `mcp`: Model Context Protocol server status
+- `lsp`: Language Server Protocol status
+- `formatter`: Code formatter configuration
+- `sessions`: Active OpenCode sessions
+- `session-status`: Status of current session
+
+---
+
+## Usage Examples
+
+### Standard Health Check
+
+```bash
+mise run opencode:doctor
+```
+
+### Detailed Tools Inspection
+
+To see full tool schemas and all available tools:
+
+```bash
+bun ~/.config/opencode/scripts/opencode-doctor.ts --only tools --full --limit 100
+```
+
+### JSON Output for Scripting
+
+```bash
+bun ~/.config/opencode/scripts/opencode-doctor.ts --json > diagnostic.json
+```
+
+### Targeting a Specific Port
+
+```bash
+bun ~/.config/opencode/scripts/opencode-doctor.ts --port 5000
+```
+
+---
+
+## DB Maintenance
+
+OpenCode never prunes its SQLite session DB (`~/.local/share/opencode/opencode.db`), so it grows unbounded. These flags operate directly on the SQLite file and do **not** spawn the OpenCode server.
+
+- `--db-health` — read-only metrics: file/WAL/shm sizes, page and freelist counts, free %, journal mode, `auto_vacuum`, per-table row counts, and a session age histogram. Safe to run anytime.
+- `--prune-older=<days>` — **dry-run by default**: reports how many sessions are older than `<days>` and the reclaimable bytes per table. Deletes nothing without `--execute`.
+- `--prune-older=<days> --execute` — **IRREVERSIBLE.** Deletes old sessions and their messages, parts, and events, then runs `VACUUM` to reclaim space. Refuses to run if other OpenCode processes are active (a full VACUUM needs exclusive access), if free disk is below ~1.1× the DB size, or if `<days>` is less than 1.
+
+```bash
+# Inspect DB health
+mise run opencode:doctor -- --db-health
+
+# Preview what a 30-day prune would reclaim (no changes)
+mise run opencode:doctor -- --prune-older=30
+
+# Actually prune + VACUUM (close all other OpenCode instances first)
+mise run opencode:doctor -- --prune-older=30 --execute
+```
+
+Pruning events is only safe for local-first usage — `event` rows back OpenCode's sync / cross-device replay / history features. See `docs/solutions/2026-06-25-opencode-sqlite-db-bloat-prune-vacuum.md` for the full safety contract.
+
+---
+
+## SDK Workaround Note
+
+> **Note:** The `@opencode-ai/sdk` types may occasionally lag behind the runtime API. The doctor handles this by using a `{ query: {} }` wrapper pattern where necessary to ensure compatibility with the current server response structures.
+
+---
+
+## Verification
+
+To verify the doctor is functioning correctly, run it with the `--only health` flag:
+
+```bash
+mise run opencode:doctor -- --only health
+```
+
+(Note: The `--` is used to pass arguments through `mise` to the underlying script).

--- a/.dotfiles/docs/solutions/2026-06-25-opencode-sqlite-db-bloat-prune-vacuum.md
+++ b/.dotfiles/docs/solutions/2026-06-25-opencode-sqlite-db-bloat-prune-vacuum.md
@@ -1,0 +1,132 @@
+---
+title: OpenCode SQLite DB bloat — prune old sessions then VACUUM
+date: 2026-06-25
+category: docs/solutions/performance-issues/
+module: opencode
+problem_type: performance_issue
+component: tooling
+symptoms:
+  - OpenCode SQLite DB (~/.local/share/opencode/opencode.db) grew to ~13 GB
+  - perceived slowness running multiple concurrent OpenCode instances
+  - VACUUM alone reclaimed nothing (freelist_count=0, auto_vacuum=NONE)
+root_cause: missing_tooling
+resolution_type: tooling_addition
+severity: high
+related_components:
+  - database
+  - development_workflow
+tags:
+  - opencode
+  - sqlite
+  - vacuum
+  - db-bloat
+  - prune
+  - bun-sqlite
+  - maintenance
+---
+
+# OpenCode SQLite DB bloat — prune old sessions then VACUUM
+
+## Problem
+
+OpenCode's session DB at `~/.local/share/opencode/opencode.db` grew to ~13 GB
+over ~6 months, raising performance concern with multiple concurrent OpenCode
+instances. OpenCode has no built-in retention/prune path, so the DB grows
+unbounded.
+
+## Symptoms
+
+- DB at ~13 GB; perf concern with multiple running OpenCode processes.
+- `PRAGMA freelist_count` = 0 and `PRAGMA auto_vacuum` = NONE → `VACUUM` reclaims
+  nothing because there are no free pages; all 13 GB is live data.
+- `dbstat` breakdown: `event` ~6.7 GB, `part` ~4.9 GB, `message` ~0.7 GB.
+
+## What Didn't Work
+
+- **VACUUM-first premise (wrong).** The initial assumption was that VACUUM would
+  shrink the file. With `freelist_count = 0` it reclaims ~0 bytes — the bloat is
+  live data, not fragmentation. The WAL was also healthy (~2–4 MB), so
+  `wal_checkpoint(TRUNCATE)` was marginal too.
+- **Age-bucket queries without an integer cast.** `time_created` is epoch
+  **milliseconds**; comparing `time_created/1000` against `strftime('%s', ...)`
+  without `CAST(... AS INTEGER)` triggers SQLite's numeric-vs-text comparison and
+  silently buckets every row into one group.
+- **Giant `IN (?,?,...)` clauses.** With thousands of session ids this hits
+  `SQLITE_MAX_VARIABLE_NUMBER` (~32766 in Bun's build, 999 in older builds).
+- **`length(data)` for byte sizes.** Counts characters, not bytes, for non-ASCII.
+- **Treating a `pgrep` failure as "safe".** A non-0/non-1 exit (e.g. pgrep
+  unavailable) means "can't verify" and must be treated as unsafe, not safe.
+
+## Solution
+
+Pruning old sessions creates free pages; VACUUM then compacts the file.
+Implemented as a DB-maintenance mode in
+`~/.config/opencode/scripts/opencode-doctor.ts`, run via
+`mise run opencode:doctor -- <flags>`:
+
+- `--db-health` — read-only metrics (sizes, page/freelist counts, free %,
+  journal mode, auto_vacuum, per-table row counts, session age histogram).
+- `--prune-older=<days>` (default 30) — **dry-run by default**: reports sessions
+  to delete and reclaimable bytes per table. Deletes nothing.
+- `--prune-older=<days> --execute` — **IRREVERSIBLE**: prune + checkpoint + VACUUM.
+
+Cascade order (verified against OpenCode's own delete in `core/event.ts`):
+
+```sql
+-- session -> message, part cascade via FK ON DELETE CASCADE.
+-- event keys off aggregate_id = session.id with NO session FK, so delete it
+-- explicitly via event_sequence (which cascades to event).
+DELETE FROM event_sequence WHERE aggregate_id IN (SELECT id FROM _prune_ids);
+DELETE FROM session        WHERE id           IN (SELECT id FROM _prune_ids);
+-- then, OUTSIDE the transaction:
+PRAGMA wal_checkpoint(TRUNCATE);
+VACUUM;
+```
+
+Safety gates on `--execute`:
+
+- Refuse if other `opencode` processes run (full VACUUM needs exclusive access;
+  `classifyPgrepExitCode`: 0=has procs, 1=none, other=error→unsafe).
+- Refuse if free disk < DB size × 1.1 (VACUUM needs a full-size temp copy; this
+  machine has hit ENOSPC).
+- Refuse `--prune-older < 1` (prevents `--prune-older=0` deleting everything).
+- If VACUUM fails after the DELETE commits, still report `sessions_deleted` +
+  a `vacuum_error` field — never hide that data was deleted.
+
+Measured: pruning sessions older than 30 days = 7,048 sessions, ~5.9 GB
+reclaimable (13 GB → ~7.5 GB).
+
+## Why This Works
+
+The real bloat is the event-sourcing log (`event`, 6.7 GB — payloads duplicate
+message data) plus large `part` payloads (tool outputs / file contents), and
+OpenCode never prunes (feature requests `anomalyco/opencode#22110`, `#31526`,
+`#16101`). Deleting old sessions removes the underlying rows; VACUUM then has
+free pages to reclaim.
+
+Pruning events is safe **only for local-first usage** (verified against OpenCode
+v1.17.11 source): session display reads `message` + `part`, not `event`
+(`session.ts`, `message-v2.ts`); `event` is read for sync / cross-device replay /
+`/sync/history` (`sync.ts`, `control-plane/workspace.ts`, `core/event.ts`).
+Deleting events breaks those features for pruned sessions — fine if you never use
+sync/share/replay.
+
+## Prevention
+
+- Default to dry-run; require explicit `--execute` for deletion.
+- Gate destructive ops: refuse when safety can't be verified (pgrep error),
+  when free disk is insufficient, or when the window is `< 1` day.
+- Never hide deletion if VACUUM fails (surface `vacuum_error`).
+- Reusable SQLite rules:
+  - Epoch-ms comparisons: `CAST(time_created / 1000 AS INTEGER) < cutoffSec`.
+  - Bulk id sets: a `TEMP TABLE` join, not a giant `IN (?,?,...)`.
+  - Accurate byte sizes: `length(CAST(data AS BLOB))`, not `length(data)`.
+  - `dbstat` is a full virtual-table scan — slow (minutes) on a multi-GB DB.
+
+## Related Issues
+
+- `docs/solutions/2026-05-22-bun-sqlite-readonly-wal-pattern.md` — sibling doc on
+  read-only Bun access to the same `opencode.db` (moderate overlap: same file,
+  different operation).
+- Upstream: `anomalyco/opencode#22110`, `#31526`, `#16101` (DB
+  maintenance / prune / storage growth feature requests).


### PR DESCRIPTION
## What

Adds DB-maintenance capability to `opencode-doctor` for the OpenCode SQLite session DB (`~/.local/share/opencode/opencode.db`). Three behaviors:

- `--db-health` — read-only metrics: file/WAL/shm sizes, page & freelist counts, free %, journal mode, `auto_vacuum`, per-table row counts, session age histogram.
- `--prune-older=<days>` (default 30) — **dry-run** by default: reports sessions older than `<days>` and reclaimable bytes per table. Changes nothing.
- `--prune-older=<days> --execute` — **irreversible**: deletes old sessions + their messages, parts, and events, then `VACUUM`s to reclaim space.

Run via `mise run opencode:doctor -- --db-health` / `-- --prune-older=30` / `-- --prune-older=30 --execute`.

## Why

OpenCode has no built-in retention or compaction, so the DB grows unbounded — mine reached ~13 GB. `VACUUM` alone reclaims nothing because the file has no free pages (`auto_vacuum=NONE`); the space is live data. The real lever is pruning old sessions, then VACUUMing the freed pages. A 30-day prune reclaims ~5.9 GB here (13 GB → ~7.5 GB).

## Safety

The destructive path is heavily gated:

- Refuses if other OpenCode processes are running (a full VACUUM needs exclusive access; if process detection is unavailable, it refuses rather than assuming safe).
- Refuses if free disk is below ~1.1× the DB size (VACUUM needs a full-size temp copy).
- Refuses a prune window below 1 day.
- If VACUUM fails after the delete commits, it still reports what was deleted instead of hiding it.

Deletes cascade `session` → `message`/`part` via foreign keys, and remove events explicitly via `event_sequence`. Pruning events is safe for local-first use — events only back OpenCode's sync/replay/history features.

## Verification

- 28 DB tests pass (helpers, CLI integration, safety guards, and a >999-id regression for the SQLite variable limit).
- `--db-health` and dry-run verified against the live ~13 GB DB.
- The actual `--execute` + VACUUM is intended to run with all OpenCode instances closed (the tool refuses otherwise).

Background and the full safety contract: `docs/solutions/2026-06-25-opencode-sqlite-db-bloat-prune-vacuum.md`.