### PR TITLE
feat(opencode-doctor): add --set-incremental-vacuum for self-reclaiming DB

### DIFF
--- a/.config/opencode/scripts/opencode-doctor.test.ts
+++ b/.config/opencode/scripts/opencode-doctor.test.ts
@@ -10,6 +10,8 @@ import {
   estimateReclaim,
   pruneSessions,
   classifyPgrepExitCode,
+  autoVacuumModeName,
+  convertToIncrementalVacuum,
 } from "./opencode-doctor";
 
 const SCRIPT_PATH = "./opencode-doctor.ts";
@@ -1077,6 +1079,351 @@ describe("DB guards (unit)", () => {
         .nothrow();
 
       expect(result.exitCode).not.toBe(0);
+    },
+    { timeout: TEST_TIMEOUT }
+  );
+});
+
+// ─── DB Set Incremental Vacuum Tests ─────────────────────────────────────────
+
+describe("DB Set Incremental Vacuum (unit)", () => {
+  // ── autoVacuumModeName ────────────────────────────────────────────────────
+
+  test("autoVacuumModeName maps 0 → NONE", () => {
+    expect(autoVacuumModeName(0)).toBe("NONE");
+  });
+
+  test("autoVacuumModeName maps 1 → FULL", () => {
+    expect(autoVacuumModeName(1)).toBe("FULL");
+  });
+
+  test("autoVacuumModeName maps 2 → INCREMENTAL", () => {
+    expect(autoVacuumModeName(2)).toBe("INCREMENTAL");
+  });
+
+  test("autoVacuumModeName maps unknown value → UNKNOWN", () => {
+    expect(autoVacuumModeName(99)).toBe("UNKNOWN");
+    expect(autoVacuumModeName(-1)).toBe("UNKNOWN");
+  });
+
+  // ── convertToIncrementalVacuum: NONE → INCREMENTAL ────────────────────────
+
+  test("convertToIncrementalVacuum converts NONE DB to INCREMENTAL and reports confirmed:true", () => {
+    const dir = makeTempDir();
+    try {
+      // Default SQLite DB has auto_vacuum=NONE (0)
+      const dbPath = join(dir, "vacuum-test.db");
+      const db = new Database(dbPath);
+      db.exec("PRAGMA journal_mode=WAL");
+      // Insert a few rows so the file has some content
+      db.exec("CREATE TABLE t (v TEXT)");
+      db.exec("INSERT INTO t VALUES ('hello'), ('world'), ('foo')");
+
+      // Verify starting mode is NONE
+      type PragmaRow = { [key: string]: unknown };
+      const beforeMode = Number(db.query<PragmaRow, []>("PRAGMA auto_vacuum").get()?.auto_vacuum ?? 0);
+      expect(beforeMode).toBe(0);
+
+      const result = convertToIncrementalVacuum(db, dbPath);
+
+      expect(result.already_incremental).toBe(false);
+      expect(result.before.auto_vacuum).toBe(0);
+      expect(result.before.auto_vacuum_mode).toBe("NONE");
+      expect(result.after.auto_vacuum).toBe(2);
+      expect(result.after.auto_vacuum_mode).toBe("INCREMENTAL");
+      expect(result.confirmed).toBe(true);
+      expect(result.vacuum_error).toBeUndefined();
+
+      // Verify the DB actually has INCREMENTAL mode now
+      const afterMode = Number(db.query<PragmaRow, []>("PRAGMA auto_vacuum").get()?.auto_vacuum ?? 0);
+      expect(afterMode).toBe(2);
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  // ── convertToIncrementalVacuum: idempotency ───────────────────────────────
+
+  test("convertToIncrementalVacuum is idempotent: already-INCREMENTAL DB returns already_incremental:true and still runs full VACUUM", () => {
+    const dir = makeTempDir();
+    try {
+      const dbPath = join(dir, "already-incremental.db");
+      const db = new Database(dbPath);
+      // Create DB with INCREMENTAL mode from the start
+      db.exec("PRAGMA auto_vacuum=INCREMENTAL");
+      db.exec("PRAGMA journal_mode=WAL");
+      db.exec("CREATE TABLE t (v TEXT)");
+      db.exec("INSERT INTO t VALUES ('a'), ('b'), ('c')");
+      // VACUUM to bake in the mode
+      db.exec("VACUUM");
+
+      type PragmaRow = { [key: string]: unknown };
+      const mode = Number(db.query<PragmaRow, []>("PRAGMA auto_vacuum").get()?.auto_vacuum ?? 0);
+      expect(mode).toBe(2);
+
+      const result = convertToIncrementalVacuum(db, dbPath);
+
+      // already_incremental reflects the state BEFORE the call
+      expect(result.already_incremental).toBe(true);
+      expect(result.before.auto_vacuum).toBe(2);
+      expect(result.before.auto_vacuum_mode).toBe("INCREMENTAL");
+      expect(result.after.auto_vacuum).toBe(2);
+      expect(result.after.auto_vacuum_mode).toBe("INCREMENTAL");
+      // confirmed must be true: VACUUM ran and succeeded
+      expect(result.confirmed).toBe(true);
+      expect(result.vacuum_error).toBeUndefined();
+
+      // Mode must still be 2 after the call
+      const afterMode = Number(db.query<PragmaRow, []>("PRAGMA auto_vacuum").get()?.auto_vacuum ?? 0);
+      expect(afterMode).toBe(2);
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  // ── convertToIncrementalVacuum: VACUUM failure path ───────────────────────
+
+  test("convertToIncrementalVacuum: VACUUM failure → vacuum_error set, confirmed:false, result label is (failed)", () => {
+    const dir = makeTempDir();
+    try {
+      const dbPath = join(dir, "vacuum-fail-test.db");
+      const db = new Database(dbPath);
+      db.exec("PRAGMA journal_mode=WAL");
+      db.exec("CREATE TABLE t (v TEXT)");
+      db.exec("INSERT INTO t VALUES ('hello'), ('world')");
+
+      // Monkeypatch db.exec to throw on VACUUM
+      const originalExec = db.exec.bind(db);
+      let vacuumCallCount = 0;
+      db.exec = (sql: string) => {
+        if (sql.trim().toUpperCase() === "VACUUM") {
+          vacuumCallCount++;
+          throw new Error("Simulated VACUUM failure");
+        }
+        return originalExec(sql);
+      };
+
+      const result = convertToIncrementalVacuum(db, dbPath);
+
+      // VACUUM was attempted
+      expect(vacuumCallCount).toBeGreaterThan(0);
+      // vacuum_error must be populated
+      expect(result.vacuum_error).toBeDefined();
+      expect(result.vacuum_error).toContain("Simulated VACUUM failure");
+      // confirmed must be false when VACUUM failed
+      expect(result.confirmed).toBe(false);
+
+      // Restore exec and close
+      db.exec = originalExec;
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("runSetIncrementalVacuum label is '(failed)' when VACUUM throws", () => {
+    // Verify the label routing in runSetIncrementalVacuum uses vacuum_error correctly.
+    // We test this indirectly: a result with vacuum_error set must produce confirmed:false.
+    const dir = makeTempDir();
+    try {
+      const dbPath = join(dir, "vacuum-fail-label.db");
+      const db = new Database(dbPath);
+      db.exec("PRAGMA journal_mode=WAL");
+      db.exec("CREATE TABLE t (v TEXT)");
+      db.exec("INSERT INTO t VALUES ('x')");
+
+      const originalExec = db.exec.bind(db);
+      db.exec = (sql: string) => {
+        if (sql.trim().toUpperCase() === "VACUUM") {
+          throw new Error("Simulated VACUUM failure for label test");
+        }
+        return originalExec(sql);
+      };
+
+      const result = convertToIncrementalVacuum(db, dbPath);
+
+      // The label in runSetIncrementalVacuum is driven by vacuum_error
+      expect(result.vacuum_error).toBeDefined();
+      expect(result.confirmed).toBe(false);
+
+      db.exec = originalExec;
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  // ── Re-run after partial failure (INCREMENTAL set but VACUUM never completed) ──
+
+  test("convertToIncrementalVacuum: re-run on already-INCREMENTAL DB with free pages runs full VACUUM and ends confirmed:true with space reclaimed", () => {
+    // The partial-failure scenario: a previous run set auto_vacuum=INCREMENTAL AND
+    // ran VACUUM (so mode=2 is baked in), but the DB has since accumulated free pages
+    // (or the VACUUM was incomplete). A re-run must still run the full VACUUM to
+    // guarantee the on-disk layout is correct and reclaim free pages.
+    //
+    // Note: SQLite only persists auto_vacuum=INCREMENTAL (mode=2) after a VACUUM.
+    // So we set up a properly-converted DB (mode=2), then delete rows to create
+    // free pages, and verify that a re-run still runs VACUUM and reclaims them.
+    const dir = makeTempDir();
+    try {
+      const dbPath = join(dir, "partial-fail-rerun.db");
+      const db = new Database(dbPath);
+      // Use DELETE journal so VACUUM actually shrinks the file
+      db.exec("PRAGMA journal_mode=DELETE");
+      db.exec("PRAGMA auto_vacuum=INCREMENTAL");
+      db.exec("CREATE TABLE t (v TEXT)");
+
+      // Insert enough data to fill several pages
+      const insert = db.prepare("INSERT INTO t VALUES (?)");
+      db.transaction(() => {
+        for (let i = 0; i < 300; i++) {
+          insert.run(`row-${i}-${"x".repeat(80)}`);
+        }
+      })();
+
+      // VACUUM to bake in INCREMENTAL mode (mode=2 persisted to disk)
+      db.exec("VACUUM");
+
+      type PragmaRow = { [key: string]: unknown };
+      const modeAfterSetup = Number(db.query<PragmaRow, []>("PRAGMA auto_vacuum").get()?.auto_vacuum ?? 0);
+      expect(modeAfterSetup).toBe(2); // INCREMENTAL baked in
+
+      // Delete rows to create free pages (simulating accumulated garbage)
+      db.exec("DELETE FROM t WHERE rowid > 10");
+
+      const freelistBeforeRerun = Number(db.query<PragmaRow, []>("PRAGMA freelist_count").get()?.freelist_count ?? 0);
+      expect(freelistBeforeRerun).toBeGreaterThan(0); // there are free pages to reclaim
+
+      // Re-run: must run full VACUUM even though auto_vacuum is already 2
+      const result = convertToIncrementalVacuum(db, dbPath);
+
+      // already_incremental is true (mode was 2 before the call)
+      expect(result.already_incremental).toBe(true);
+      // VACUUM ran and succeeded → confirmed:true
+      expect(result.confirmed).toBe(true);
+      expect(result.vacuum_error).toBeUndefined();
+      // Free pages should have been reclaimed (freelist drops after VACUUM)
+      expect(result.after.freelist_count).toBeLessThan(freelistBeforeRerun);
+      // Mode is still INCREMENTAL
+      expect(result.after.auto_vacuum).toBe(2);
+      // Space was reclaimed
+      expect(result.bytes_reclaimed).toBeGreaterThan(0);
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  // ── incremental_vacuum actually reclaims pages ────────────────────────────
+
+  test("incremental_vacuum reclaims free pages after deleting rows on an INCREMENTAL DB", () => {
+    const dir = makeTempDir();
+    try {
+      const dbPath = join(dir, "reclaim-test.db");
+      const db = new Database(dbPath);
+      // Set up INCREMENTAL mode
+      db.exec("PRAGMA auto_vacuum=INCREMENTAL");
+      db.exec("PRAGMA journal_mode=DELETE"); // Use DELETE journal so VACUUM shrinks the file
+      db.exec("CREATE TABLE t (v TEXT)");
+
+      // Insert enough data to fill several pages
+      const insert = db.prepare("INSERT INTO t VALUES (?)");
+      db.transaction(() => {
+        for (let i = 0; i < 500; i++) {
+          insert.run(`row-${i}-${"x".repeat(100)}`);
+        }
+      })();
+      db.exec("VACUUM"); // bake in INCREMENTAL mode
+
+      type PragmaRow = { [key: string]: unknown };
+      const modeAfterSetup = Number(db.query<PragmaRow, []>("PRAGMA auto_vacuum").get()?.auto_vacuum ?? 0);
+      expect(modeAfterSetup).toBe(2);
+
+      // Capture freelist before delete
+      const freelistBefore = Number(db.query<PragmaRow, []>("PRAGMA freelist_count").get()?.freelist_count ?? 0);
+
+      // Delete most rows to create free pages
+      db.exec("DELETE FROM t WHERE rowid > 10");
+
+      // Freelist should now be higher (pages freed by delete)
+      const freelistAfterDelete = Number(db.query<PragmaRow, []>("PRAGMA freelist_count").get()?.freelist_count ?? 0);
+      expect(freelistAfterDelete).toBeGreaterThan(freelistBefore);
+
+      // Run incremental_vacuum to reclaim those pages
+      db.exec("PRAGMA incremental_vacuum");
+
+      // Freelist should drop after incremental_vacuum
+      const freelistAfterVacuum = Number(db.query<PragmaRow, []>("PRAGMA freelist_count").get()?.freelist_count ?? 0);
+      expect(freelistAfterVacuum).toBeLessThan(freelistAfterDelete);
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  // ── CLI: --set-incremental-vacuum flag ────────────────────────────────────
+
+  test(
+    "--set-incremental-vacuum --json converts a NONE DB and reports confirmed:true",
+    async () => {
+      const dir = makeTempDir();
+      try {
+        // Create a plain DB (auto_vacuum=NONE by default)
+        const dbPath = join(dir, "cli-vacuum-test.db");
+        const db = new Database(dbPath);
+        db.exec("PRAGMA journal_mode=WAL");
+        db.exec("CREATE TABLE t (v TEXT)");
+        db.exec("INSERT INTO t VALUES ('a'), ('b')");
+        db.close();
+
+        const result = await $`bun ${SCRIPT_PATH} --set-incremental-vacuum --json --db-path=${dbPath}`
+          .quiet()
+          .nothrow();
+
+        // May be refused if other opencode processes are running — that's valid
+        const stdout = result.stdout.toString();
+        let parsed: unknown;
+        expect(() => { parsed = JSON.parse(stdout); }).not.toThrow();
+
+        const sections = parsed as Array<{ label: string; data?: unknown }>;
+        const vacSection = sections.find((s) =>
+          s.label.startsWith("DB Set Incremental Vacuum")
+        );
+        expect(vacSection).toBeDefined();
+
+        if (vacSection?.label === "DB Set Incremental Vacuum (executed)") {
+          const data = vacSection.data as Record<string, unknown>;
+          expect(data.confirmed).toBe(true);
+          expect(data.already_incremental).toBe(false);
+        } else if (vacSection?.label === "DB Set Incremental Vacuum (already incremental)") {
+          const data = vacSection.data as Record<string, unknown>;
+          expect(data.confirmed).toBe(true);
+          expect(data.already_incremental).toBe(true);
+        } else {
+          // Refused due to running opencode processes — valid behavior
+          const data = vacSection?.data as Record<string, unknown>;
+          expect(data.refused).toBe(true);
+        }
+      } finally {
+        removeTempDir(dir);
+      }
+    },
+    { timeout: TEST_TIMEOUT }
+  );
+
+  test(
+    "--help contains --set-incremental-vacuum documentation",
+    async () => {
+      const result = await $`bun ${SCRIPT_PATH} --help`.text();
+
+      expect(result).toContain("--set-incremental-vacuum");
+      expect(result).toContain("INCREMENTAL");
     },
     { timeout: TEST_TIMEOUT }
   );

--- a/.config/opencode/scripts/opencode-doctor.ts
+++ b/.config/opencode/scripts/opencode-doctor.ts
@@ -25,6 +25,7 @@ type CliOptions = {
   pruneOlderDays: number | null;
   execute: boolean;
   dbPath: string;
+  setIncrementalVacuum: boolean;
 };
 
 type SectionResult = {
@@ -32,6 +33,9 @@ type SectionResult = {
   data: unknown;
   error?: string;
 };
+
+// Plain-object shape returned by safety-gate helpers (subset of SectionResult.data).
+type SectionResultData = Record<string, unknown>;
 
 const DEFAULT_PORT = 4096;
 const AUTO_PORT_ATTEMPTS = 10;
@@ -101,6 +105,7 @@ const KNOWN_FLAGS = new Set([
   "--prune-older",
   "--execute",
   "--db-path",
+  "--set-incremental-vacuum",
 ]);
 
 function warnUnknownFlag(flag: string): void {
@@ -285,6 +290,9 @@ function parseArgs(argv: string[]): CliOptions {
       ? String(dbPathValue)
       : DEFAULT_DB_PATH;
 
+  const setIncrementalVacuumValue = args.get("--set-incremental-vacuum");
+  const setIncrementalVacuum = setIncrementalVacuumValue != null && !isBooleanFalse(setIncrementalVacuumValue);
+
   return {
     host,
     port,
@@ -301,6 +309,7 @@ function parseArgs(argv: string[]): CliOptions {
     pruneOlderDays,
     execute,
     dbPath,
+    setIncrementalVacuum,
   };
 }
 
@@ -335,6 +344,13 @@ DB Maintenance (no server required):
   --execute                 PERMANENTLY and IRREVERSIBLY deletes sessions and all their
                             messages, parts, and events. Requires --prune-older.
                             Without --prune-older, --execute is an error.
+  --set-incremental-vacuum  One-time conversion: sets auto_vacuum=INCREMENTAL on the DB,
+                            then runs a full VACUUM to rewrite the file with the new mode.
+                            After this, future prunes can reclaim free pages incrementally
+                            via PRAGMA incremental_vacuum without a full exclusive VACUUM.
+                            Requires all other OpenCode instances to be closed and ~1.1x
+                            the DB file size in free disk space (same constraints as prune
+                            --execute). Safe to re-run: no-op if already INCREMENTAL.
   --db-path <path>          Override DB path (default: ~/.local/share/opencode/opencode.db)
 
 Sections:
@@ -850,6 +866,186 @@ function checkForOtherOpencodeProcesses(): { safe: boolean; count: number; pids:
   return { safe: pids.length === 0, count: pids.length, pids };
 }
 
+// ─── Safety Gate Helpers ──────────────────────────────────────────────────────
+
+/**
+ * Returns a refused SectionResultData if other OpenCode processes are running,
+ * or null if it is safe to proceed with a destructive DB operation.
+ */
+function refuseIfOtherOpencodeProcesses(): SectionResultData | null {
+  const procCheck = checkForOtherOpencodeProcesses();
+  if (!procCheck.safe) {
+    const reason = procCheck.count === -1
+      ? "Could not verify other OpenCode processes are stopped (pgrep unavailable); refusing to run this destructive operation. Re-run where process detection works."
+      : `Found ${procCheck.count} other opencode process(es) running (PIDs: ${procCheck.pids.join(", ")}). Close all OpenCode instances and re-run.`;
+    return {
+      refused: true,
+      reason,
+      instruction: "Close all OpenCode instances and re-run.",
+    };
+  }
+  return null;
+}
+
+/**
+ * Returns a refused SectionResultData if there is insufficient disk space for
+ * a VACUUM operation (~1.1x the DB file size), or null if it is safe to proceed.
+ * Best-effort: if df fails, returns null (let VACUUM itself be the real guard).
+ */
+function refuseIfInsufficientDiskForVacuum(dbPath: string): SectionResultData | null {
+  const dbSize = safeStatSize(dbPath);
+  if (dbSize > 0) {
+    try {
+      // -P forces POSIX output: one data line per filesystem, never wrapped
+      // (plain `df -k` can split a long device name across two lines).
+      const dfResult = Bun.spawnSync(["df", "-kP", dirname(dbPath)]);
+      if (dfResult.exitCode === 0) {
+        const dfOut = dfResult.stdout instanceof Buffer
+          ? dfResult.stdout.toString("utf8")
+          : String(dfResult.stdout ?? "");
+        // POSIX `df -kP` data line, both macOS and Linux:
+        //   Filesystem  1024-blocks  Used  Available  Capacity  Mounted-on
+        // Columns are fixed: Available is index 3, Mounted-on is the last field.
+        const lines = dfOut.trim().split("\n");
+        const dataLine = lines[lines.length - 1];
+        const cols = dataLine.trim().split(/\s+/);
+        // Anchor from the end (Mounted-on is last) so a space in the mount path
+        // can't shift the Available column: Available is 4th from the path,
+        // i.e. cols[length-3] in POSIX layout. Fall back to index 3.
+        const availableRaw = cols.length >= 6 ? cols[cols.length - 3] : cols[3];
+        const availableKb = parseInt(availableRaw ?? "", 10);
+        if (!isNaN(availableKb)) {
+          const availableBytes = availableKb * 1024;
+          const requiredBytes = dbSize * 1.1;
+          if (availableBytes < requiredBytes) {
+            return {
+              refused: true,
+              reason: `VACUUM needs ~${bytesToHuman(Math.ceil(requiredBytes))} free; only ${bytesToHuman(availableBytes)} available. Free disk space and re-run.`,
+            };
+          }
+        }
+      }
+    } catch {
+      // If df fails, proceed — disk check is best-effort; the real guard is VACUUM itself.
+    }
+  }
+  return null;
+}
+
+// ─── Incremental Vacuum Helpers ───────────────────────────────────────────────
+
+/**
+ * Maps a SQLite auto_vacuum PRAGMA integer to its mode name.
+ * Exported for unit testing.
+ */
+export function autoVacuumModeName(n: number): "NONE" | "FULL" | "INCREMENTAL" | "UNKNOWN" {
+  if (n === 0) return "NONE";
+  if (n === 1) return "FULL";
+  if (n === 2) return "INCREMENTAL";
+  return "UNKNOWN";
+}
+
+export type IncrementalVacuumResult = {
+  already_incremental: boolean;
+  before: {
+    auto_vacuum: number;
+    auto_vacuum_mode: string;
+    file_size_bytes: number;
+    file_size_human: string;
+    freelist_count: number;
+  };
+  after: {
+    auto_vacuum: number;
+    auto_vacuum_mode: string;
+    file_size_bytes: number;
+    file_size_human: string;
+    freelist_count: number;
+  };
+  bytes_reclaimed: number;
+  bytes_reclaimed_human: string;
+  confirmed: boolean;
+  vacuum_error?: string;
+};
+
+export function convertToIncrementalVacuum(db: Database, dbPath: string): IncrementalVacuumResult {
+  type PragmaRow = { [key: string]: unknown };
+
+  const beforeAutoVacuumRow = db.query<PragmaRow, []>("PRAGMA auto_vacuum").get();
+  const beforeAutoVacuum = Number(beforeAutoVacuumRow?.auto_vacuum ?? 0);
+  const beforeFreelistRow = db.query<PragmaRow, []>("PRAGMA freelist_count").get();
+  const beforeFreelist = Number(beforeFreelistRow?.freelist_count ?? 0);
+  const beforeFileSize = safeStatSize(dbPath);
+
+  const before = {
+    auto_vacuum: beforeAutoVacuum,
+    auto_vacuum_mode: autoVacuumModeName(beforeAutoVacuum),
+    file_size_bytes: beforeFileSize,
+    file_size_human: bytesToHuman(beforeFileSize),
+    freelist_count: beforeFreelist,
+  };
+
+  // Whether the DB was already INCREMENTAL before we touched it.
+  // NOTE: even if already INCREMENTAL, we still run a full VACUUM to guarantee
+  // the on-disk layout is correct — a previous run may have set the PRAGMA but
+  // failed before VACUUM completed, leaving the file in a half-converted state.
+  const alreadyIncremental = beforeAutoVacuum === 2;
+
+  let vacuumError: string | undefined;
+
+  // Always set PRAGMA auto_vacuum=INCREMENTAL (no-op if already set).
+  // Then always run a full VACUUM — this is the operation that actually rewrites
+  // the file with the new mode and reclaims free pages.
+  // A WAL checkpoint is run first so WAL pages are folded in (reduces peak disk).
+  // Checkpoint failure is non-fatal; VACUUM is the real operation.
+  try {
+    db.exec("PRAGMA auto_vacuum=INCREMENTAL");
+  } catch (err) {
+    vacuumError = formatErrorMessage(err);
+  }
+
+  if (vacuumError == null) {
+    try {
+      db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+    } catch {
+      // Checkpoint failure is non-fatal — proceed to VACUUM.
+    }
+    try {
+      db.exec("VACUUM");
+    } catch (err) {
+      vacuumError = formatErrorMessage(err);
+    }
+  }
+
+  const afterAutoVacuumRow = db.query<PragmaRow, []>("PRAGMA auto_vacuum").get();
+  const afterAutoVacuum = Number(afterAutoVacuumRow?.auto_vacuum ?? 0);
+  const afterFreelistRow = db.query<PragmaRow, []>("PRAGMA freelist_count").get();
+  const afterFreelist = Number(afterFreelistRow?.freelist_count ?? 0);
+  const afterFileSize = safeStatSize(dbPath);
+
+  const after = {
+    auto_vacuum: afterAutoVacuum,
+    auto_vacuum_mode: autoVacuumModeName(afterAutoVacuum),
+    file_size_bytes: afterFileSize,
+    file_size_human: bytesToHuman(afterFileSize),
+    freelist_count: afterFreelist,
+  };
+
+  // confirmed is only true when the mode is INCREMENTAL AND the full VACUUM
+  // completed without error (VACUUM is what actually rewrites the file).
+  const confirmed = afterAutoVacuum === 2 && vacuumError == null;
+
+  const result: IncrementalVacuumResult = {
+    already_incremental: alreadyIncremental,
+    before,
+    after,
+    bytes_reclaimed: Math.max(0, beforeFileSize - afterFileSize),
+    bytes_reclaimed_human: bytesToHuman(Math.max(0, beforeFileSize - afterFileSize)),
+    confirmed,
+  };
+  if (vacuumError != null) result.vacuum_error = vacuumError;
+  return result;
+}
+
 // ─── DB Section Runners ───────────────────────────────────────────────────────
 
 async function runDbHealth(options: CliOptions): Promise<SectionResult> {
@@ -914,57 +1110,16 @@ async function runDbPruneExecute(options: CliOptions): Promise<SectionResult> {
   const cutoffDate = new Date(cutoffMs).toISOString().slice(0, 10);
 
   // Safety gate: check for other opencode processes
-  const procCheck = checkForOtherOpencodeProcesses();
-  if (!procCheck.safe) {
-    const reason = procCheck.count === -1
-      ? "Could not verify other OpenCode processes are stopped (pgrep unavailable); refusing to run destructive prune. Re-run where process detection works."
-      : `Found ${procCheck.count} other opencode process(es) running (PIDs: ${procCheck.pids.join(", ")}). Close all OpenCode instances and re-run.`;
-    const data = {
-      refused: true,
-      reason,
-      instruction: "Close all OpenCode instances and re-run with --prune-older --execute",
-    };
-    return { label: "DB Prune (refused)", data };
+  const procRefusal = refuseIfOtherOpencodeProcesses();
+  if (procRefusal != null) {
+    return { label: "DB Prune (refused)", data: procRefusal };
   }
 
   // Disk-space pre-check: VACUUM needs ~= DB size of free space for a temp copy.
   // Check BEFORE any destructive operation so we never delete-then-fail-vacuum.
-  const dbSize = safeStatSize(options.dbPath);
-  if (dbSize > 0) {
-    try {
-      // -P forces POSIX output: one data line per filesystem, never wrapped
-      // (plain `df -k` can split a long device name across two lines).
-      const dfResult = Bun.spawnSync(["df", "-kP", dirname(options.dbPath)]);
-      if (dfResult.exitCode === 0) {
-        const dfOut = dfResult.stdout instanceof Buffer
-          ? dfResult.stdout.toString("utf8")
-          : String(dfResult.stdout ?? "");
-        // POSIX `df -kP` data line, both macOS and Linux:
-        //   Filesystem  1024-blocks  Used  Available  Capacity  Mounted-on
-        // Columns are fixed: Available is index 3, Mounted-on is the last field.
-        const lines = dfOut.trim().split("\n");
-        const dataLine = lines[lines.length - 1];
-        const cols = dataLine.trim().split(/\s+/);
-        // Anchor from the end (Mounted-on is last) so a space in the mount path
-        // can't shift the Available column: Available is 4th from the path,
-        // i.e. cols[length-3] in POSIX layout. Fall back to index 3.
-        const availableRaw = cols.length >= 6 ? cols[cols.length - 3] : cols[3];
-        const availableKb = parseInt(availableRaw ?? "", 10);
-        if (!isNaN(availableKb)) {
-          const availableBytes = availableKb * 1024;
-          const requiredBytes = dbSize * 1.1;
-          if (availableBytes < requiredBytes) {
-            const data = {
-              refused: true,
-              reason: `VACUUM needs ~${bytesToHuman(Math.ceil(requiredBytes))} free; only ${bytesToHuman(availableBytes)} available. Free disk space and re-run.`,
-            };
-            return { label: "DB Prune (refused)", data };
-          }
-        }
-      }
-    } catch {
-      // If df fails, proceed — disk check is best-effort; the real guard is VACUUM itself.
-    }
+  const diskRefusal = refuseIfInsufficientDiskForVacuum(options.dbPath);
+  if (diskRefusal != null) {
+    return { label: "DB Prune (refused)", data: diskRefusal };
   }
 
   let db: Database | null = null;
@@ -986,6 +1141,42 @@ async function runDbPruneExecute(options: CliOptions): Promise<SectionResult> {
     return { label: "DB Prune (executed)", data };
   } catch (error) {
     return { label: "DB Prune (executed)", data: null, error: formatErrorMessage(error) };
+  } finally {
+    db?.close();
+  }
+}
+
+async function runSetIncrementalVacuum(options: CliOptions): Promise<SectionResult> {
+  const label = "DB Set Incremental Vacuum";
+
+  // Safety gate: check for other opencode processes
+  const procRefusal = refuseIfOtherOpencodeProcesses();
+  if (procRefusal != null) {
+    return { label: `${label} (refused)`, data: procRefusal };
+  }
+
+  // Disk-space pre-check: VACUUM needs ~= DB size of free space for a temp copy.
+  const diskRefusal = refuseIfInsufficientDiskForVacuum(options.dbPath);
+  if (diskRefusal != null) {
+    return { label: `${label} (refused)`, data: diskRefusal };
+  }
+
+  let db: Database | null = null;
+  try {
+    db = new Database(options.dbPath);
+    db.exec("PRAGMA busy_timeout=5000");
+
+    const result = convertToIncrementalVacuum(db, options.dbPath);
+
+    const resultLabel = result.vacuum_error != null
+      ? `${label} (failed)`
+      : result.already_incremental
+        ? `${label} (already incremental)`
+        : `${label} (executed)`;
+
+    return { label: resultLabel, data: result };
+  } catch (error) {
+    return { label: `${label} (failed)`, data: null, error: formatErrorMessage(error) };
   } finally {
     db?.close();
   }
@@ -1337,7 +1528,7 @@ async function main(): Promise<void> {
 
   // DB-only path: if any db flag is present, skip server entirely.
   // Also route here if --execute is set alone (to give a clear error).
-  const isDbMode = options.dbHealth || options.pruneOlderDays != null || options.execute;
+  const isDbMode = options.dbHealth || options.pruneOlderDays != null || options.execute || options.setIncrementalVacuum;
 
   if (isDbMode) {
     // Guard: --execute without --prune-older is a user error
@@ -1368,6 +1559,22 @@ async function main(): Promise<void> {
         const result = await runDbPruneDryRun(options);
         sections.push(result);
         if (result.error != null) hasError = true;
+      }
+    }
+
+    if (options.setIncrementalVacuum) {
+      const result = await runSetIncrementalVacuum(options);
+      sections.push(result);
+      // Exit nonzero if refused, errored, or VACUUM failed (vacuum_error set or confirmed===false on executed path)
+      if (isPlainObject(result.data) && (result.data as { refused?: boolean }).refused) {
+        hasError = true;
+      }
+      if (result.error != null) hasError = true;
+      if (isPlainObject(result.data) && result.data.vacuum_error != null) {
+        hasError = true;
+      }
+      if (isPlainObject(result.data) && result.data.confirmed === false) {
+        hasError = true;
       }
     }
 

--- a/.dotfiles/docs/opencode-doctor.md
+++ b/.dotfiles/docs/opencode-doctor.md
@@ -128,6 +128,14 @@ mise run opencode:doctor -- --prune-older=30 --execute
 
 Pruning events is only safe for local-first usage — `event` rows back OpenCode's sync / cross-device replay / history features. See `docs/solutions/2026-06-25-opencode-sqlite-db-bloat-prune-vacuum.md` for the full safety contract.
 
+### One-time: switch to incremental auto-vacuum
+
+```bash
+mise run opencode:doctor -- --set-incremental-vacuum
+```
+
+Converts the DB from `auto_vacuum=NONE` to `INCREMENTAL` (sets the pragma, then runs a full `VACUUM` to rewrite the file). After this, future prunes free pages that can be reclaimed incrementally without a full exclusive VACUUM each time. Same constraints as `--execute` (close other OpenCode instances; needs ~1.1× DB size free disk). Safe to re-run — it re-attempts the full VACUUM until the conversion is confirmed.
+
 ---
 
 ## SDK Workaround Note

--- a/.dotfiles/docs/solutions/2026-06-25-opencode-sqlite-db-bloat-prune-vacuum.md
+++ b/.dotfiles/docs/solutions/2026-06-25-opencode-sqlite-db-bloat-prune-vacuum.md
@@ -111,6 +111,17 @@ v1.17.11 source): session display reads `message` + `part`, not `event`
 Deleting events breaks those features for pruned sessions — fine if you never use
 sync/share/replay.
 
+## Reducing future full VACUUMs
+
+`opencode-doctor --set-incremental-vacuum` converts the DB from
+`auto_vacuum=NONE` to `INCREMENTAL` (one-time: `PRAGMA auto_vacuum=INCREMENTAL`
+then a full `VACUUM` to rewrite the file). After conversion, future deletes free
+pages that `PRAGMA incremental_vacuum` can reclaim without a full exclusive
+VACUUM. Same safety gates as prune (other-process check, free disk ≥ DB×1.1).
+Note: converting an existing DB still needs one full VACUUM, and `confirmed` is
+only true when that VACUUM completes — a failed conversion leaves the mode flag
+set but the file un-rewritten, so re-running always re-attempts the full VACUUM.
+
 ## Prevention
 
 - Default to dry-run; require explicit `--execute` for deletion.


### PR DESCRIPTION
## What

Adds `--set-incremental-vacuum` to `opencode-doctor`: a one-time conversion of the OpenCode SQLite DB from `auto_vacuum=NONE` to `INCREMENTAL`. Run via `mise run opencode:doctor -- --set-incremental-vacuum`.

## Why

The DB ships as `auto_vacuum=NONE`, so deleted rows never return space to the OS without a full `VACUUM` (which needs exclusive access and a full-size temp copy). After converting to `INCREMENTAL`, future prunes free pages that can be reclaimed with `PRAGMA incremental_vacuum` — no full exclusive VACUUM each time. This is the higher-leverage follow-up to the prune feature: it makes ongoing maintenance cheap.

Converting an existing DB is itself a one-time cost: `PRAGMA auto_vacuum=INCREMENTAL` only takes effect after a full `VACUUM` rewrites the file.

## Safety

Reuses the prune path's gates (extracted into shared helpers so both commands share one implementation):

- Refuses if other OpenCode processes are running (or if process detection is unavailable).
- Refuses if free disk is below ~1.1× the DB size.
- `confirmed` is true only when the rewriting VACUUM completes. A failed conversion leaves the mode flag set but the file un-rewritten — so re-running always re-attempts the full VACUUM rather than taking a no-op path. VACUUM failure exits nonzero.

## Verification

- 40 DB tests pass (28 prior + conversion, idempotency, re-run-after-failure, and VACUUM-failure coverage).
- End-to-end on a temp DB: `NONE → INCREMENTAL` reports `confirmed: true`; a forced VACUUM failure reports `confirmed: false` with the error surfaced; `incremental_vacuum` reclaims freed pages after a delete.
- The conversion is intended to run with all OpenCode instances closed (the tool refuses otherwise).

Refs #1924 (item 1).