### PR TITLE
chore(opencode): tune runtime flags and model profiles

### DIFF
--- a/.config/bash/exports
+++ b/.config/bash/exports
@@ -382,7 +382,9 @@ export OMO_DISABLE_POSTHOG=1
 
 # OpenCode
 
+export OPENCODE_DISABLE_FFF=1
 export OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true
+export OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER=true
 export OPENCODE_EXPERIMENTAL_WEBSOCKETS=true
 
 # Ollama — short keep-alive so models unload after each on-demand run

--- a/.config/opencode/magic-context.jsonc
+++ b/.config/opencode/magic-context.jsonc
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/cortexkit/magic-context/master/assets/magic-context.schema.json",
   "historian": {
-    "model": "openai/gpt-5.5",
-    "fallback_models": ["anthropic/claude-sonnet-4-6", "github-copilot/claude-sonnet-4.6"],
+    "model": "opencode-go/deepseek-v4-flash",
+    "fallback_models": ["openai/gpt-5.5", "anthropic/claude-sonnet-4-6", "github-copilot/claude-sonnet-4.6"],
     "temperature": 0.1,
     "variant": "medium",
     "tools": {
@@ -41,14 +41,17 @@
     "anthropic/claude-opus-4-6": "59m",
     "anthropic/claude-opus-4-7": "59m",
     "anthropic/claude-opus-4-8": "59m",
-    "anthropic/claude-fable-5": "59m"
+    "anthropic/claude-fable-5": "59m",
+    "openai/gpt-5.5": "10m",
+    "openai/gpt-5.5-fast": "10m"
   },
   "execute_threshold_percentage": {
     "default": 65,
     "anthropic/claude-sonnet-4-6": 55,
     "anthropic/claude-opus-4-6": 55,
     "anthropic/claude-opus-4-7": 55,
-    "openai/gpt-5.5": 80
+    "openai/gpt-5.5": 80,
+    "openai/gpt-5.5-fast": 80
   },
   "execute_threshold_tokens": {
     "github-copilot/claude-opus-4.7": 80000,
@@ -77,5 +80,8 @@
     "enabled": true,
     "skip_signatures": ["You are the Council agent — a multi-LLM"]
   },
-  "auto_update": false
+  "auto_update": false,
+  "embedding": {
+    "provider": "off"
+  }
 }

--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -5,6 +5,7 @@
     "openai": {
       "orchestrator": {
         "model": "openai/gpt-5.5",
+        "variant": "high",
         "skills": ["*"],
         "mcps": ["*", "!context7"]
       },
@@ -80,6 +81,7 @@
     "copilot": {
       "orchestrator": {
         "model": "openai/gpt-5.5",
+        "variant": "high",
         "skills": ["*"],
         "mcps": ["*", "!context7"]
       },


### PR DESCRIPTION
- add OpenCode env toggles in bash exports:
  - set `OPENCODE_DISABLE_FFF=1`
  - set `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER=true`
- switch magic-context historian primary model to `opencode-go/deepseek-v4-flash`
- add `openai/gpt-5.5` as first historian fallback and extend thresholds:
  - set short context windows for `openai/gpt-5.5` and `openai/gpt-5.5-fast`
  - define execute threshold percentages for `openai/gpt-5.5-fast`
- disable embeddings in magic-context via `"embedding": { "provider": "off" }`
- set orchestrator variant to `high` for `openai` and `copilot` profiles in oh-my-opencode-slim