### PR TITLE
chore(opencode): tune fixer variant and bump plugins

### DIFF
--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -37,6 +37,7 @@
       },
       "fixer": {
         "model": "anthropic/claude-sonnet-5",
+        "variant": "low",
         "skills": ["agent-browser", "impeccable", "systematic:*"]
       }
     },
@@ -151,6 +152,7 @@
       },
       "fixer": {
         "model": "anthropic/claude-sonnet-5",
+        "variant": "low",
         "skills": ["agent-browser", "impeccable", "systematic:*"]
       }
     }

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -3,8 +3,8 @@
   "plugin": [
     "@cortexkit/opencode-anthropic-auth@1.12.2",
     "oh-my-opencode-slim@1.1.2",
-    "@cortexkit/opencode-magic-context@0.30.4",
-    "@cortexkit/aft-opencode@0.42.0",
+    "@cortexkit/opencode-magic-context@0.30.5",
+    "@cortexkit/aft-opencode@0.43.1",
     "@fro.bot/systematic@2.32.1"
   ],
   "mcp": {

--- a/.config/opencode/systematic.jsonc
+++ b/.config/opencode/systematic.jsonc
@@ -29,6 +29,7 @@
     },
     "systematic-implementer": {
       "model": "anthropic/claude-sonnet-5",
+      "variant": "low",
       "temperature": 0.1
     }
   }


### PR DESCRIPTION
- set fixer variant to low in oh-my-opencode-slim profile (both fixer blocks)
- set systematic-implementer variant to low in systematic profile
- bump @cortexkit/opencode-magic-context from 0.30.4 to 0.30.5
- bump @cortexkit/aft-opencode from 0.42.0 to 0.43.1