### PR TITLE
chore(opencode): switch designers to gemini-3.5-flash

### DIFF
--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -43,7 +43,7 @@
     },
     "opencode-go": {
       "orchestrator": {
-        "model": "opencode-go/kimi-k2.6",
+        "model": "opencode-go/kimi-k2.7",
         "skills": ["*"],
         "mcps": ["*", "!context7"]
       },
@@ -68,7 +68,7 @@
         "mcps": []
       },
       "designer": {
-        "model": "opencode-go/kimi-k2.6",
+        "model": "opencode-go/kimi-k2.7",
         "variant": "medium",
         "skills": ["agent-browser", "impeccable", "systematic:*"],
         "mcps": []
@@ -146,7 +146,8 @@
         "mcps": []
       },
       "designer": {
-        "model": "github-copilot/gemini-3.1-pro-preview",
+        "model": "opencode-go/kimi-k2.7",
+        "variant": "medium",
         "skills": ["agent-browser", "impeccable", "systematic:*"],
         "mcps": []
       },

--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -43,7 +43,7 @@
     },
     "opencode-go": {
       "orchestrator": {
-        "model": "opencode-go/kimi-k2.7",
+        "model": "opencode-go/kimi-k2.6",
         "skills": ["*"],
         "mcps": ["*", "!context7"]
       },
@@ -68,7 +68,7 @@
         "mcps": []
       },
       "designer": {
-        "model": "opencode-go/kimi-k2.7",
+        "model": "opencode-go/kimi-k2.6",
         "variant": "medium",
         "skills": ["agent-browser", "impeccable", "systematic:*"],
         "mcps": []
@@ -146,8 +146,7 @@
         "mcps": []
       },
       "designer": {
-        "model": "opencode-go/kimi-k2.7",
-        "variant": "medium",
+        "model": "github-copilot/gemini-3.5-flash",
         "skills": ["agent-browser", "impeccable", "systematic:*"],
         "mcps": []
       },

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -3,8 +3,8 @@
   "plugin": [
     "@cortexkit/opencode-anthropic-auth@1.12.2",
     "oh-my-opencode-slim@1.1.2",
-    "@cortexkit/opencode-magic-context@0.30.5",
-    "@cortexkit/aft-opencode@0.43.1",
+    "@cortexkit/opencode-magic-context@0.30.6",
+    "@cortexkit/aft-opencode@0.45.0",
     "@fro.bot/systematic@2.32.1"
   ],
   "mcp": {


### PR DESCRIPTION
- update opencode-go orchestrator model from opencode-go/kimi-k2.6 to opencode-go/kimi-k2.7
- update opencode-go designer model from opencode-go/kimi-k2.6 to opencode-go/kimi-k2.7
- change secondary designer model from github-copilot/gemini-3.1-pro-preview to opencode-go/kimi-k2.7
- add medium variant to the secondary designer configuration
- bump @cortexkit/opencode-magic-context from 0.30.5 to 0.30.6
- bump @cortexkit/aft-opencode from 0.43.1 to 0.45.0