### PR TITLE
chore(opencode): switch review/research to gpt-5.5-fast

### DIFF
--- a/.config/opencode/agents/research.md
+++ b/.config/opencode/agents/research.md
@@ -1,7 +1,7 @@
 ---
 description: External research via web search, library documentation, and code examples using Context7, Grep.app, and Exa
 mode: subagent
-model: openai/gpt-5.6-luna-fast
+model: openai/gpt-5.5-fast
 temperature: 0.1
 permission:
   edit: deny

--- a/.config/opencode/systematic.jsonc
+++ b/.config/opencode/systematic.jsonc
@@ -16,7 +16,7 @@
       "variant": "low"
     },
     "review": {
-      "model": "opencode-go/deepseek-v4-flash",
+      "model": "openai/gpt-5.5-fast",
       "variant": "high"
     }
   },


### PR DESCRIPTION
- Change research subagent default model from `openai/gpt-5.6-luna-fast` to `openai/gpt-5.5-fast`
- Update systematic `review` category model from `opencode-go/deepseek-v4-flash` to `openai/gpt-5.5-fast`