### PR TITLE
chore(opencode): upgrade oh-my-opencode-slim to v2.1.1

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -2,7 +2,7 @@
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
     "@cortexkit/opencode-anthropic-auth@1.15.1",
-    "oh-my-opencode-slim@1.1.2",
+    "oh-my-opencode-slim@2.1.1",
     "@cortexkit/opencode-magic-context@0.32.0",
     "@cortexkit/aft-opencode@0.46.0",
     "@fro.bot/systematic@2.33.2"


### PR DESCRIPTION
Upgrades oh-my-opencode-slim 1.1.2 → 2.1.1. v2 brings scheduler-first orchestration, background agents, deepwork, council read-only hardening, model-array fallbacks, and per-councillor fallback chains. Existing preset config validates unchanged against the v2.1.1 schema. The v1 cache-stability fixes (#415/#419/#416 upstream) are in v2's lineage, with continued cache-hygiene work in v2.1.1 (#662 upstream).

Post-merge: clear the cached package (rm -rf ~/.cache/opencode/packages/oh-my-opencode-slim*) and restart OpenCode; verify prompt-cache reads stay flat across turns in a fresh session.