### PR TITLE
feat(skills): add openai-imagegen skill for gpt-image models

### DIFF
--- a/.agents/skills/openai-imagegen/SKILL.md
+++ b/.agents/skills/openai-imagegen/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: openai-imagegen
+description: Use when generating or editing images with OpenAI gpt-image models (gpt-image-2, gpt-image-1.5) — creating images from text prompts, editing existing images, transparent-background assets like stickers or logos, product mockups, or any request to "generate an image" with OpenAI/gpt-image. Works against api.openai.com directly or any OpenAI-compatible proxy (e.g. CLIProxyAPI) via OPENAI_BASE_URL.
+---
+
+# OpenAI Image Generation (gpt-image)
+
+Generate and edit images with `gpt-image-2` and `gpt-image-1.5` via the OpenAI Images API — directly against `api.openai.com`, or through any OpenAI-compatible proxy (e.g. [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI), which translates these endpoints to the upstream Responses API).
+
+## Credentials & Endpoint
+
+| Env var | Meaning |
+|---------|---------|
+| `OPENAI_API_KEY` | Required. Your OpenAI key — or, when using a proxy, the proxy's API key. |
+| `OPENAI_BASE_URL` | Optional. Defaults to `https://api.openai.com/v1`. Set to your proxy's `/v1` base to route through it. |
+
+Before hunting for credentials, check whether the environment already provides an OpenAI-compatible proxy (a configured `OPENAI_BASE_URL`, or a local proxy config) — proxies often serve gpt-image models from an OAuth-backed upstream with no per-request OpenAI billing.
+
+Check which image models are actually served: `GET {base}/models` (through a proxy the list may differ from OpenAI's).
+
+## Model Choice
+
+| Model | Pick when | Constraints |
+|-------|-----------|-------------|
+| `gpt-image-2` (default) | Photorealism, max quality, high-fidelity edits | **No transparent background**; input fidelity fixed high |
+| `gpt-image-1.5` | Stickers/logos needing `background: transparent`; edits needing `input_fidelity` control | Slightly older |
+
+Rule: transparency requested → `gpt-image-1.5` + `output_format: png` (or webp). Otherwise `gpt-image-2`.
+
+## Quick Reference
+
+- **Generate:** `POST {base}/images/generations` (JSON)
+- **Edit/compose:** `POST {base}/images/edits` (multipart; `image` or `image[]`, optional `mask`)
+- **Sizes:** `1024x1024`, `1536x1024` (landscape), `1024x1536` (portrait), `auto`. No exact 16:9 — `1536x1024` is the closest.
+- **Params:** `quality` (`low|medium|high|auto`), `background`, `output_format` (`png|jpeg|webp`), `output_compression`, `moderation`
+- **Response:** `data[0].b64_json` (use `response_format: b64_json`)
+- **Generation takes 30–120s** — set generous HTTP timeouts (300s).
+- Images carry C2PA provenance metadata; PNG out by default.
+
+## Scripts
+
+```bash
+# Generate
+bun ~/.agents/skills/openai-imagegen/scripts/generate_image.ts \
+  --prompt "a minimalist robot mascot, flat design" \
+  --model gpt-image-2 --size 1536x1024 --quality high --output robot.png
+
+# Sticker with transparency (auto-guards model choice)
+bun ~/.agents/skills/openai-imagegen/scripts/generate_image.ts \
+  --prompt "kawaii red panda sticker, bold outlines" \
+  --model gpt-image-1.5 --background transparent --output panda.png
+
+# Edit / inpaint / compose from references
+bun ~/.agents/skills/openai-imagegen/scripts/edit_image.ts \
+  --prompt "add a sunset sky" --image scene.png --output sunset.png
+```
+
+Run either script with no args for full usage. Both fail with a clear message if `OPENAI_API_KEY` is missing.
+
+## Raw API Pattern
+
+```bash
+curl -sS -X POST "${OPENAI_BASE_URL:-https://api.openai.com/v1}/images/generations" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" -H "Content-Type: application/json" \
+  -d '{"model":"gpt-image-2","prompt":"a red fox","size":"1024x1024","quality":"high","response_format":"b64_json"}' \
+  | jq -r '.data[0].b64_json' | base64 -d > fox.png
+```
+
+## Streaming & Multi-Turn
+
+Partial-image streaming (`stream: true`, `partial_images: 1-3`) is SSE-only and unreliable through proxies (CLIProxyAPI translates Images calls to the Responses API internally) — **prefer non-streaming calls**. For iterative refinement, chain `/images/edits` calls feeding the previous output back as `--image`.
+
+## Common Mistakes
+
+- Hardcoding `api.openai.com` when the environment routes through a proxy → honor `OPENAI_BASE_URL`.
+- `gpt-image-1` / `dall-e-3` → stale; current models are `gpt-image-2` and `gpt-image-1.5`.
+- Transparent background on `gpt-image-2` → unsupported; switch to `gpt-image-1.5`.
+- Requesting `1920x1080` → invalid size; use `1536x1024`.
+- Default fetch timeouts → generations can exceed 60s; use 300s.
+- Trusting the requested size through a proxy → the Responses translation may return a different resolution than requested (observed: `1536x1024` request → `1254x1254` square). Verify with `file` and crop/retry if the aspect ratio matters.

--- a/.agents/skills/openai-imagegen/SKILL.md
+++ b/.agents/skills/openai-imagegen/SKILL.md
@@ -9,12 +9,14 @@ Generate and edit images with `gpt-image-2` and `gpt-image-1.5` via the OpenAI I
 
 ## Credentials & Endpoint
 
-| Env var | Meaning |
-|---------|---------|
-| `OPENAI_API_KEY` | Required. Your OpenAI key — or, when using a proxy, the proxy's API key. |
-| `OPENAI_BASE_URL` | Optional. Defaults to `https://api.openai.com/v1`. Set to your proxy's `/v1` base to route through it. |
+The scripts resolve auth in this order (first match wins):
 
-Before hunting for credentials, check whether the environment already provides an OpenAI-compatible proxy (a configured `OPENAI_BASE_URL`, or a local proxy config) — proxies often serve gpt-image models from an OAuth-backed upstream with no per-request OpenAI billing.
+| Priority | Env vars | Meaning |
+|----------|----------|---------|
+| 1 | `OPENAI_API_KEY` (+ optional `OPENAI_BASE_URL`) | Direct OpenAI, or any OpenAI-compatible proxy. Base defaults to `https://api.openai.com/v1`. |
+| 2 | `CLIPROXY_API_KEY` + `CLIPROXY_URL` or `CLIPROXY_DOMAIN` | CLIProxyAPI convention. Bare domains get `https://`; `/v1` is appended if missing. |
+
+Before hunting for credentials, check what the environment already provides: a project `.env` often carries `CLIPROXY_API_KEY`/`CLIPROXY_URL` (Bun auto-loads `./.env` from the CWD, so running the scripts from that project authenticates with zero setup) — proxies serve gpt-image models from an OAuth-backed upstream with no per-request OpenAI billing.
 
 Check which image models are actually served: `GET {base}/models` (through a proxy the list may differ from OpenAI's).
 
@@ -55,7 +57,7 @@ bun ~/.agents/skills/openai-imagegen/scripts/edit_image.ts \
   --prompt "add a sunset sky" --image scene.png --output sunset.png
 ```
 
-Run either script with no args for full usage. Both fail with a clear message if `OPENAI_API_KEY` is missing.
+Run either script with no args for full usage. Both fail with a clear message listing the accepted env vars when no credentials resolve.
 
 ## Raw API Pattern
 

--- a/.agents/skills/openai-imagegen/scripts/edit_image.ts
+++ b/.agents/skills/openai-imagegen/scripts/edit_image.ts
@@ -7,8 +7,9 @@
  *     [--mask mask.png] [--model gpt-image-1.5] [--input-fidelity low|high]
  *     [--size 1024x1024] [--quality high] [--output out.png]
  *
- * Auth: OPENAI_API_KEY env var; OPENAI_BASE_URL optional (defaults to
- * https://api.openai.com/v1 — set to your OpenAI-compatible proxy's /v1 base).
+ * Auth/endpoint (first match wins):
+ *   OPENAI_API_KEY + OPENAI_BASE_URL (optional, default https://api.openai.com/v1)
+ *   CLIPROXY_API_KEY + CLIPROXY_URL or CLIPROXY_DOMAIN — CLIProxyAPI; /v1 appended if missing
  * Endpoint: POST {base}/images/edits (multipart).
  * Note: --input-fidelity applies to gpt-image-1.5 only (gpt-image-2 is fixed high).
  */
@@ -29,16 +30,32 @@ if (!prompt || images.length === 0) {
   process.exit(1)
 }
 
-const apiKey = process.env.OPENAI_API_KEY
-if (!apiKey) {
-  console.error('OPENAI_API_KEY is not set. Use your OpenAI key, or your OpenAI-compatible proxy key with OPENAI_BASE_URL pointed at the proxy.')
+function resolveAuth(): {apiKey: string; baseUrl: string} {
+  const trimBase = (u: string) => u.replace(/\/$/, '')
+  if (process.env.OPENAI_API_KEY) {
+    return {
+      apiKey: process.env.OPENAI_API_KEY,
+      baseUrl: trimBase(process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1'),
+    }
+  }
+  if (process.env.CLIPROXY_API_KEY) {
+    const domain = process.env.CLIPROXY_DOMAIN
+    const raw = process.env.CLIPROXY_URL ?? (domain ? (domain.includes('://') ? domain : `https://${domain}`) : process.env.OPENAI_BASE_URL)
+    if (!raw) {
+      console.error('CLIPROXY_API_KEY is set but no endpoint — set CLIPROXY_URL or CLIPROXY_DOMAIN (e.g. your-cliproxy-host.example).')
+      process.exit(1)
+    }
+    const base = trimBase(raw)
+    return {apiKey: process.env.CLIPROXY_API_KEY, baseUrl: base.endsWith('/v1') ? base : `${base}/v1`}
+  }
+  console.error('No credentials. Set OPENAI_API_KEY (+ optional OPENAI_BASE_URL), or CLIPROXY_API_KEY + CLIPROXY_URL for CLIProxyAPI. Project .env files work if your runner loads them (e.g. Bun auto-loads ./.env).')
   process.exit(1)
 }
 
+const {apiKey, baseUrl} = resolveAuth()
+
 const model = arg('model', 'gpt-image-1.5')!
 const output = arg('output', `edited-${Date.now()}.png`)!
-const baseUrl = (process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1').replace(/\/$/, '')
-
 const form = new FormData()
 form.append('model', model)
 form.append('prompt', prompt)

--- a/.agents/skills/openai-imagegen/scripts/edit_image.ts
+++ b/.agents/skills/openai-imagegen/scripts/edit_image.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env bun
+/**
+ * Edit an image (or compose from references) with OpenAI gpt-image models.
+ *
+ * Usage:
+ *   bun edit_image.ts --prompt "add a sunset" --image input.png [--image ref2.png]
+ *     [--mask mask.png] [--model gpt-image-1.5] [--input-fidelity low|high]
+ *     [--size 1024x1024] [--quality high] [--output out.png]
+ *
+ * Auth: OPENAI_API_KEY env var; OPENAI_BASE_URL optional (defaults to
+ * https://api.openai.com/v1 — set to your OpenAI-compatible proxy's /v1 base).
+ * Endpoint: POST {base}/images/edits (multipart).
+ * Note: --input-fidelity applies to gpt-image-1.5 only (gpt-image-2 is fixed high).
+ */
+
+function args(name: string): string[] {
+  const out: string[] = []
+  for (let i = 0; i < process.argv.length; i++) {
+    if (process.argv[i] === `--${name}` && process.argv[i + 1]) out.push(process.argv[i + 1] as string)
+  }
+  return out
+}
+const arg = (name: string, fallback?: string) => args(name)[0] ?? fallback
+
+const prompt = arg('prompt')
+const images = args('image')
+if (!prompt || images.length === 0) {
+  console.error('Usage: bun edit_image.ts --prompt "..." --image input.png [--image ref.png] [--mask mask.png] [--model gpt-image-1.5] [--output out.png]')
+  process.exit(1)
+}
+
+const apiKey = process.env.OPENAI_API_KEY
+if (!apiKey) {
+  console.error('OPENAI_API_KEY is not set. Use your OpenAI key, or your OpenAI-compatible proxy key with OPENAI_BASE_URL pointed at the proxy.')
+  process.exit(1)
+}
+
+const model = arg('model', 'gpt-image-1.5')!
+const output = arg('output', `edited-${Date.now()}.png`)!
+const baseUrl = (process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1').replace(/\/$/, '')
+
+const form = new FormData()
+form.append('model', model)
+form.append('prompt', prompt)
+form.append('size', arg('size', '1024x1024')!)
+form.append('quality', arg('quality', 'high')!)
+for (const img of images) {
+  form.append(images.length > 1 ? 'image[]' : 'image', new Blob([await Bun.file(img).arrayBuffer()]), img.split('/').pop())
+}
+const mask = arg('mask')
+if (mask) form.append('mask', new Blob([await Bun.file(mask).arrayBuffer()]), 'mask.png')
+const fidelity = arg('input-fidelity')
+if (fidelity) form.append('input_fidelity', fidelity)
+
+const res = await fetch(`${baseUrl}/images/edits`, {
+  method: 'POST',
+  headers: {Authorization: `Bearer ${apiKey}`},
+  body: form,
+  signal: AbortSignal.timeout(300_000),
+})
+
+if (!res.ok) {
+  console.error(`HTTP ${res.status}: ${(await res.text()).slice(0, 500)}`)
+  process.exit(1)
+}
+
+const json = (await res.json()) as {data?: {b64_json?: string}[]}
+const b64 = json.data?.[0]?.b64_json
+if (!b64) {
+  console.error(`No image in response: ${JSON.stringify(json).slice(0, 300)}`)
+  process.exit(1)
+}
+
+await Bun.write(output, Buffer.from(b64, 'base64'))
+console.log(`Saved ${output} (${Math.round(Buffer.from(b64, 'base64').length / 1024)} KB, model=${model})`)

--- a/.agents/skills/openai-imagegen/scripts/generate_image.ts
+++ b/.agents/skills/openai-imagegen/scripts/generate_image.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env bun
+/**
+ * Generate an image with OpenAI gpt-image models.
+ *
+ * Usage:
+ *   bun generate_image.ts --prompt "a red fox" [--model gpt-image-2] [--size 1024x1024]
+ *     [--quality low|medium|high|auto] [--background transparent|opaque|auto]
+ *     [--output out.png] [--format png|jpeg|webp]
+ *
+ * Auth/endpoint:
+ *   OPENAI_API_KEY   — required (for OpenAI-compatible proxies, the proxy's key)
+ *   OPENAI_BASE_URL  — optional, defaults to https://api.openai.com/v1
+ *                      (set to your proxy's /v1 base to route through it)
+ */
+
+function arg(name: string, fallback?: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`)
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback
+}
+
+const prompt = arg('prompt')
+if (!prompt) {
+  console.error('Usage: bun generate_image.ts --prompt "..." [--model gpt-image-2] [--size 1024x1024] [--quality high] [--background auto] [--output out.png] [--format png]')
+  process.exit(1)
+}
+
+const apiKey = process.env.OPENAI_API_KEY
+if (!apiKey) {
+  console.error('OPENAI_API_KEY is not set. Use your OpenAI key, or your OpenAI-compatible proxy key with OPENAI_BASE_URL pointed at the proxy.')
+  process.exit(1)
+}
+
+const model = arg('model', 'gpt-image-2')!
+const background = arg('background', 'auto')!
+if (model === 'gpt-image-2' && background === 'transparent') {
+  console.error('gpt-image-2 does not support transparent backgrounds — use --model gpt-image-1.5')
+  process.exit(1)
+}
+
+const format = arg('format', 'png')!
+const output = arg('output', `image-${Date.now()}.${format}`)!
+const baseUrl = (process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1').replace(/\/$/, '')
+
+const body: Record<string, unknown> = {
+  model,
+  prompt,
+  size: arg('size', '1024x1024'),
+  quality: arg('quality', 'high'),
+  output_format: format,
+  response_format: 'b64_json',
+}
+if (background !== 'auto') body.background = background
+
+const res = await fetch(`${baseUrl}/images/generations`, {
+  method: 'POST',
+  headers: {Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json'},
+  body: JSON.stringify(body),
+  signal: AbortSignal.timeout(300_000),
+})
+
+if (!res.ok) {
+  console.error(`HTTP ${res.status}: ${(await res.text()).slice(0, 500)}`)
+  process.exit(1)
+}
+
+const json = (await res.json()) as {data?: {b64_json?: string}[]}
+const b64 = json.data?.[0]?.b64_json
+if (!b64) {
+  console.error(`No image in response: ${JSON.stringify(json).slice(0, 300)}`)
+  process.exit(1)
+}
+
+await Bun.write(output, Buffer.from(b64, 'base64'))
+console.log(`Saved ${output} (${Math.round(Buffer.from(b64, 'base64').length / 1024)} KB, model=${model})`)

--- a/.agents/skills/openai-imagegen/scripts/generate_image.ts
+++ b/.agents/skills/openai-imagegen/scripts/generate_image.ts
@@ -7,11 +7,32 @@
  *     [--quality low|medium|high|auto] [--background transparent|opaque|auto]
  *     [--output out.png] [--format png|jpeg|webp]
  *
- * Auth/endpoint:
- *   OPENAI_API_KEY   — required (for OpenAI-compatible proxies, the proxy's key)
- *   OPENAI_BASE_URL  — optional, defaults to https://api.openai.com/v1
- *                      (set to your proxy's /v1 base to route through it)
+ * Auth/endpoint (first match wins):
+ *   OPENAI_API_KEY + OPENAI_BASE_URL (optional, default https://api.openai.com/v1)
+ *   CLIPROXY_API_KEY + CLIPROXY_URL or CLIPROXY_DOMAIN — CLIProxyAPI; /v1 appended if missing
  */
+
+function resolveAuth(): {apiKey: string; baseUrl: string} {
+  const trimBase = (u: string) => u.replace(/\/$/, '')
+  if (process.env.OPENAI_API_KEY) {
+    return {
+      apiKey: process.env.OPENAI_API_KEY,
+      baseUrl: trimBase(process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1'),
+    }
+  }
+  if (process.env.CLIPROXY_API_KEY) {
+    const domain = process.env.CLIPROXY_DOMAIN
+    const raw = process.env.CLIPROXY_URL ?? (domain ? (domain.includes('://') ? domain : `https://${domain}`) : process.env.OPENAI_BASE_URL)
+    if (!raw) {
+      console.error('CLIPROXY_API_KEY is set but no endpoint — set CLIPROXY_URL or CLIPROXY_DOMAIN (e.g. your-cliproxy-host.example).')
+      process.exit(1)
+    }
+    const base = trimBase(raw)
+    return {apiKey: process.env.CLIPROXY_API_KEY, baseUrl: base.endsWith('/v1') ? base : `${base}/v1`}
+  }
+  console.error('No credentials. Set OPENAI_API_KEY (+ optional OPENAI_BASE_URL), or CLIPROXY_API_KEY + CLIPROXY_URL for CLIProxyAPI. Project .env files work if your runner loads them (e.g. Bun auto-loads ./.env).')
+  process.exit(1)
+}
 
 function arg(name: string, fallback?: string): string | undefined {
   const i = process.argv.indexOf(`--${name}`)
@@ -24,11 +45,7 @@ if (!prompt) {
   process.exit(1)
 }
 
-const apiKey = process.env.OPENAI_API_KEY
-if (!apiKey) {
-  console.error('OPENAI_API_KEY is not set. Use your OpenAI key, or your OpenAI-compatible proxy key with OPENAI_BASE_URL pointed at the proxy.')
-  process.exit(1)
-}
+const {apiKey, baseUrl} = resolveAuth()
 
 const model = arg('model', 'gpt-image-2')!
 const background = arg('background', 'auto')!
@@ -39,8 +56,6 @@ if (model === 'gpt-image-2' && background === 'transparent') {
 
 const format = arg('format', 'png')!
 const output = arg('output', `image-${Date.now()}.${format}`)!
-const baseUrl = (process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1').replace(/\/$/, '')
-
 const body: Record<string, unknown> = {
   model,
   prompt,


### PR DESCRIPTION
Portable OpenAI Images API skill: generate + edit scripts (Bun),
gpt-image-2/gpt-image-1.5 model-choice guidance, transparent-background
guard, proxy support via OPENAI_BASE_URL. Works against api.openai.com
or any OpenAI-compatible proxy (e.g. CLIProxyAPI).