### PR TITLE
fix(opencode-doctor): prune by tree-aware last-use, not creation date

### DIFF
--- a/.config/opencode/scripts/opencode-doctor.test.ts
+++ b/.config/opencode/scripts/opencode-doctor.test.ts
@@ -111,15 +111,23 @@ function insertSession(
   db: Database,
   id: string,
   timeCreatedMs: number,
-  opts: { messages?: number; partsPerMessage?: number; events?: number } = {}
+  opts: {
+    messages?: number;
+    partsPerMessage?: number;
+    events?: number;
+    timeUpdatedMs?: number;
+    parentId?: string | null;
+  } = {}
 ): void {
   const messages = opts.messages ?? 2;
   const partsPerMessage = opts.partsPerMessage ?? 2;
   const events = opts.events ?? 3;
+  const timeUpdatedMs = opts.timeUpdatedMs ?? timeCreatedMs;
+  const parentId = opts.parentId ?? null;
 
-  db.query("INSERT INTO session (id, time_created, time_updated) VALUES (?, ?, ?)").run(
-    id, timeCreatedMs, timeCreatedMs
-  );
+  db.query(
+    "INSERT INTO session (id, parent_id, time_created, time_updated) VALUES (?, ?, ?, ?)"
+  ).run(id, parentId, timeCreatedMs, timeUpdatedMs);
 
   for (let m = 0; m < messages; m++) {
     const msgId = `${id}-msg-${m}`;
@@ -182,7 +190,7 @@ describe("DB helpers (unit)", () => {
     }
   });
 
-  test("selectOldSessionIds returns only sessions older than cutoff", () => {
+  test("selectOldSessionIds returns only sessions not used since cutoff", () => {
     const dir = makeTempDir();
     try {
       const { db } = createTestDb(dir);
@@ -202,6 +210,129 @@ describe("DB helpers (unit)", () => {
       expect(ids).toContain("sess-old2");
       expect(ids).not.toContain("sess-recent");
       expect(ids).not.toContain("sess-border");
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("selectOldSessionIds keeps a root created long ago but updated recently (regression: last-use, not creation)", () => {
+    const dir = makeTempDir();
+    try {
+      const { db } = createTestDb(dir);
+
+      const now = Date.now();
+      const cutoffMs = now - 30 * 24 * 3600 * 1000;
+
+      insertSession(db, "sess-still-active", now - 60 * 24 * 3600 * 1000, {
+        timeUpdatedMs: now - 5 * 24 * 3600 * 1000,
+      });
+
+      const ids = selectOldSessionIds(db, cutoffMs);
+
+      expect(ids).not.toContain("sess-still-active");
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("selectOldSessionIds prunes an entire tree when every member is stale", () => {
+    const dir = makeTempDir();
+    try {
+      const { db } = createTestDb(dir);
+
+      const now = Date.now();
+      const cutoffMs = now - 30 * 24 * 3600 * 1000;
+      const staleTs = now - 60 * 24 * 3600 * 1000;
+
+      insertSession(db, "root", staleTs, { timeUpdatedMs: staleTs });
+      insertSession(db, "child", staleTs, { timeUpdatedMs: staleTs, parentId: "root" });
+      insertSession(db, "grandchild", staleTs, { timeUpdatedMs: staleTs, parentId: "child" });
+
+      const ids = selectOldSessionIds(db, cutoffMs);
+
+      expect(ids).toContain("root");
+      expect(ids).toContain("child");
+      expect(ids).toContain("grandchild");
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("selectOldSessionIds keeps the whole tree when a grandchild was updated recently", () => {
+    const dir = makeTempDir();
+    try {
+      const { db } = createTestDb(dir);
+
+      const now = Date.now();
+      const cutoffMs = now - 30 * 24 * 3600 * 1000;
+      const staleTs = now - 60 * 24 * 3600 * 1000;
+      const recentTs = now - 5 * 24 * 3600 * 1000;
+
+      insertSession(db, "root", staleTs, { timeUpdatedMs: staleTs });
+      insertSession(db, "child", staleTs, { timeUpdatedMs: staleTs, parentId: "root" });
+      insertSession(db, "grandchild", staleTs, { timeUpdatedMs: recentTs, parentId: "child" });
+
+      const ids = selectOldSessionIds(db, cutoffMs);
+
+      expect(ids).not.toContain("root");
+      expect(ids).not.toContain("child");
+      expect(ids).not.toContain("grandchild");
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("selectOldSessionIds keeps a stale child when the root is active (tree kept whole)", () => {
+    const dir = makeTempDir();
+    try {
+      const { db } = createTestDb(dir);
+
+      const now = Date.now();
+      const cutoffMs = now - 30 * 24 * 3600 * 1000;
+      const staleTs = now - 60 * 24 * 3600 * 1000;
+      const recentTs = now - 5 * 24 * 3600 * 1000;
+
+      insertSession(db, "root", staleTs, { timeUpdatedMs: recentTs });
+      insertSession(db, "child", staleTs, { timeUpdatedMs: staleTs, parentId: "root" });
+
+      const ids = selectOldSessionIds(db, cutoffMs);
+
+      expect(ids).not.toContain("root");
+      expect(ids).not.toContain("child");
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("selectOldSessionIds treats an orphan (dangling parent_id) as its own tree root", () => {
+    const dir = makeTempDir();
+    try {
+      const { db } = createTestDb(dir);
+
+      const now = Date.now();
+      const cutoffMs = now - 30 * 24 * 3600 * 1000;
+      const staleTs = now - 60 * 24 * 3600 * 1000;
+      const recentTs = now - 5 * 24 * 3600 * 1000;
+
+      // orphan-stale references a parent that doesn't exist and is itself stale — prune
+      insertSession(db, "orphan-stale", staleTs, { timeUpdatedMs: staleTs, parentId: "deleted-parent" });
+      // orphan-active references a parent that doesn't exist but was updated recently — keep
+      insertSession(db, "orphan-active", staleTs, { timeUpdatedMs: recentTs, parentId: "deleted-parent-2" });
+
+      const ids = selectOldSessionIds(db, cutoffMs);
+
+      expect(ids).toContain("orphan-stale");
+      expect(ids).not.toContain("orphan-active");
 
       db.close();
     } finally {

--- a/.config/opencode/scripts/opencode-doctor.ts
+++ b/.config/opencode/scripts/opencode-doctor.ts
@@ -339,7 +339,9 @@ Options:
 
 DB Maintenance (no server required):
   --db-health               Read-only DB metrics (size, pragmas, row counts, age histogram)
-  --prune-older[=<days>]    Select sessions older than N days (default: 30, minimum: 1).
+  --prune-older[=<days>]    Select sessions not used in the last N days (default: 30, minimum: 1).
+                            Tree-aware: a session tree (root + descendants via parent_id) is
+                            only selected if no session in it was updated within the window.
                             Dry-run unless --execute. Deletion is IRREVERSIBLE.
   --execute                 PERMANENTLY and IRREVERSIBLY deletes sessions and all their
                             messages, parts, and events. Requires --prune-older.
@@ -636,12 +638,38 @@ export function computeDbHealth(db: Database, dbPath: string): DbHealthData {
   };
 }
 
+/**
+ * Select ids of all sessions belonging to "prunable" trees.
+ *
+ * A session tree (root + all descendants via parent_id) is prunable iff the
+ * MAX(time_updated) across every session in the tree is older than cutoffMs —
+ * i.e. no session in the tree has been used since the cutoff. If any member
+ * was touched within the window, the entire tree is kept, including that
+ * member's own stale siblings/ancestors/descendants.
+ *
+ * A session whose parent_id points at a nonexistent session (dangling
+ * reference, e.g. after a prior partial prune) is treated as its own tree
+ * root rather than causing an error or being silently dropped.
+ */
 export function selectOldSessionIds(db: Database, cutoffMs: number): string[] {
   type IdRow = { id: string };
   const cutoffSec = Math.floor(cutoffMs / 1000);
-  const rows = db.query<IdRow, [number]>(
-    "SELECT id FROM session WHERE CAST(time_created / 1000 AS INTEGER) < ?"
-  ).all(cutoffSec);
+  const rows = db.query<IdRow, [number]>(`
+    WITH RECURSIVE tree(id, root_id) AS (
+      SELECT id, id FROM session
+      WHERE parent_id IS NULL OR parent_id NOT IN (SELECT id FROM session)
+      UNION ALL
+      SELECT s.id, t.root_id FROM session s JOIN tree t ON s.parent_id = t.id
+    ),
+    root_activity AS (
+      SELECT t.root_id, MAX(s.time_updated) AS last_used
+      FROM tree t JOIN session s ON s.id = t.id
+      GROUP BY t.root_id
+    )
+    SELECT t.id FROM tree t
+    JOIN root_activity ra ON ra.root_id = t.root_id
+    WHERE CAST(ra.last_used / 1000 AS INTEGER) < ?
+  `).all(cutoffSec);
   return rows.map((r) => r.id);
 }
 

--- a/.dotfiles/docs/opencode-doctor.md
+++ b/.dotfiles/docs/opencode-doctor.md
@@ -112,7 +112,7 @@ bun ~/.config/opencode/scripts/opencode-doctor.ts --port 5000
 OpenCode never prunes its SQLite session DB (`~/.local/share/opencode/opencode.db`), so it grows unbounded. These flags operate directly on the SQLite file and do **not** spawn the OpenCode server.
 
 - `--db-health` — read-only metrics: file/WAL/shm sizes, page and freelist counts, free %, journal mode, `auto_vacuum`, per-table row counts, and a session age histogram. Safe to run anytime.
-- `--prune-older=<days>` — **dry-run by default**: reports how many sessions are older than `<days>` and the reclaimable bytes per table. Deletes nothing without `--execute`.
+- `--prune-older=<days>` — **dry-run by default**: reports how many sessions have not been used in `<days>` and the reclaimable bytes per table. Deletes nothing without `--execute`. Selection is based on last-use (`time_updated`), not creation time, and is tree-aware: a session tree (root + all descendants via `parent_id`) is only selected if *no* session in the tree was touched within the window — one active leaf keeps the whole tree.
 - `--prune-older=<days> --execute` — **IRREVERSIBLE.** Deletes old sessions and their messages, parts, and events, then runs `VACUUM` to reclaim space. Refuses to run if other OpenCode processes are active (a full VACUUM needs exclusive access), if free disk is below ~1.1× the DB size, or if `<days>` is less than 1.
 
 ```bash


### PR DESCRIPTION
## Problem

`--prune-older` selected sessions by `time_created`, so long-lived sessions still in daily use were deleted once they aged past the window. This caused real data loss: active project sessions created more than 30 days ago were pruned.

## Fix

Selection is now tree-aware and last-use-based. Sessions group into trees via `parent_id` (recursive CTE, safe for orphaned children), and a tree is prunable only when `MAX(time_updated)` across every member is older than the cutoff. If anything in a tree was touched within the window, the whole tree is kept.

## Verification

- 6 new tests: the regression case (old-but-active root kept), whole-tree-stale pruned, any-member-active keeps the tree, active-root/stale-child kept whole, orphan stale/active handling. Full suite green.
- Read-only check against the production DB (8,033 sessions): old semantics selected 3,738 sessions including 10 active trees; new semantics selects 3,728 and protects those 10, with zero stale sessions escaping.

Also updates `--help` and docs/opencode-doctor.md wording to describe last-use semantics.