### PR TITLE
feat(opencode): add verification planning skill

### DIFF
--- a/.config/cortexkit/magic-context.jsonc
+++ b/.config/cortexkit/magic-context.jsonc
@@ -63,12 +63,12 @@
     "anthropic/claude-fable-5": "59m",
     "openai/gpt-5.5": "10m",
     "openai/gpt-5.5-fast": "10m",
-    "openai/gpt-5.6-sol": "10m",
-    "openai/gpt-5.6-sol-fast": "10m",
-    "openai/gpt-5.6-terra": "10m",
-    "openai/gpt-5.6-terra-fast": "10m",
-    "openai/gpt-5.6-luna": "10m",
-    "openai/gpt-5.6-luna-fast": "10m"
+    "openai/gpt-5.6-sol": "30m",
+    "openai/gpt-5.6-sol-fast": "30m",
+    "openai/gpt-5.6-terra": "30m",
+    "openai/gpt-5.6-terra-fast": "30m",
+    "openai/gpt-5.6-luna": "30m",
+    "openai/gpt-5.6-luna-fast": "30m"
   },
   "execute_threshold_percentage": {
     "default": 65,

--- a/.config/opencode/skills/deepwork/SKILL.md
+++ b/.config/opencode/skills/deepwork/SKILL.md
@@ -1,13 +1,18 @@
 ---
 name: deepwork
-description: Orchestrator-only workflow for heavy coding sessions, multi-phase implementation, and risky refactors. Use for complex work that needs planning, review gates, and persistent progress tracking.
+description: High-cost orchestrator workflow for large, high-risk, multi-phase coding efforts with meaningful dependencies and review gates. Do not activate for routine multi-file changes.
 ---
 
 # Deepwork
 
-Deepwork is an orchestrator workflow for heavy coding sessions. Use it when the
-work is broad, risky, multi-file, or likely to span several implementation
-phases. Do not use it for trivial edits, quick docs changes, or simple bug fixes.
+Deepwork is an orchestrator workflow for heavy coding sessions. Use it only
+when the work is clearly large or high-risk: multiple dependent phases,
+cross-cutting architectural change, unsafe-to-partially-ship migration, or
+sustained coordination across several specialist lanes.
+
+Do not infer Deepwork merely because a task touches multiple files. Do not use
+it for trivial edits, quick docs changes, simple bug fixes, or routine bounded
+features.
 
 ## Core Contract
 
@@ -16,6 +21,10 @@ not as the default implementation worker.
 
 Required behavior:
 
+- before planning, delegation, or creating a deepwork state file, inspect the
+  existing `.gitignore` and `.ignore`; add only missing entries, without
+  duplicates, so `.gitignore` contains `.slim/deepwork/` and `.ignore` contains
+  `!.slim/deepwork/` and `!.slim/deepwork/**`;
 - keep OpenCode todos aligned with the active deepwork phase;
 - create and maintain a local markdown progress file under `.slim/deepwork/`;
 - write valuable research findings into that file as confirmed research context
@@ -65,8 +74,8 @@ Create a task-specific file such as:
 .slim/deepwork/<short-task-slug>.md
 ```
 
-Keep `.slim/deepwork/` out of git, but make it readable to OpenCode. Ensure the
-project ignore files include:
+Before creating this file—and before planning or delegation—inspect the existing
+`.gitignore` and `.ignore`. Add only missing entries and do not add duplicates:
 
 ```gitignore
 # .gitignore
@@ -78,6 +87,8 @@ project ignore files include:
 !.slim/deepwork/
 !.slim/deepwork/**
 ```
+
+These rules keep deepwork state git-local while allowing OpenCode to read it.
 
 Do not follow a rigid template. Choose whatever markdown structure best fits the
 work. The file only needs to remain useful as persistent session state and should

--- a/.config/opencode/skills/verification-planning/SKILL.md
+++ b/.config/opencode/skills/verification-planning/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: verification-planning
+description: Verification planning for non-trivial coding work. Use before implementing a feature, bug fix, refactor, cross-system change, or high-confidence behavior change that needs a credible project-specific evidence path.
+---
+
+# Verification Planning
+
+## Build an evidence path
+
+Before changing a non-trivial system, build an **evidence path**: a
+project-specific route from the claim being made to evidence that can establish,
+limit, or refute it.
+
+The purpose is not to select a familiar technique. The purpose is to decide how
+this system can reveal the truth of this particular change.
+
+## 1. Frame the claim
+
+State the behavior that needs to become true and the conditions that could make
+a confident conclusion wrong.
+
+Consider what must change, what must remain true, where the behavior crosses a
+boundary, and which failure would matter most.
+
+**Complete when:** the claim, its meaningful uncertainty, and its important
+failure modes are concrete enough to investigate.
+
+## 2. Design the evidence path
+
+Derive possible evidence paths from the system itself: its controllable inputs,
+observable effects, state transitions, invariants, boundaries, artifacts, and
+ability to repeat or reverse a scenario.
+
+Generate alternatives before choosing. Prefer the path that produces a
+trustworthy conclusion with proportionate cost, safety, and effort.
+
+**Complete when:** there is a preferred path, its limitations are understood,
+and a weaker or stronger alternative is available if circumstances change.
+
+## 3. Create a verification affordance when needed
+
+When the existing system leaves the decisive truth too indirect or ambiguous,
+extend the evidence path with a **verification affordance**: the smallest
+capability that makes the relevant state controllable, observable, repeatable,
+and diagnosable for an agent.
+
+Ask what capability would let an agent establish the claim directly, repeat the
+scenario from a known state, and explain a failure without inference. Prefer an
+affordance that strengthens directness, determinism, agent-legibility,
+isolation, resetability, or future reuse.
+
+Treat the affordance as part of the evidence path, not an automatic product
+feature. Decide deliberately whether it is temporary or durable before building
+it.
+
+**Complete when:** the chosen path can establish the claim directly enough for
+its stakes, and any needed affordance has a defined lifecycle.
+
+## 4. Research when the path is unknown
+
+When the right evidence path depends on an unfamiliar dependency, framework,
+external service, or rapidly changing capability, ask `@librarian` for focused
+research before committing to an approach.
+
+Ask for official or project-specific facilities, constraints, and trade-offs
+that affect this exact verification problem. Use existing project evidence
+directly when it already resolves the choice.
+
+**Complete when:** the chosen path rests on known capabilities and real
+constraints rather than assumption.
+
+## 5. Make the path runnable
+
+Prepare only the support needed to follow the evidence path reliably. Keep the
+support narrow, repeatable, and safe to inspect.
+
+Decide whether that support has recurring value or exists only to resolve the
+current uncertainty. Retain durable value deliberately; remove temporary
+support once it has served its purpose.
+
+Ask before introducing dependencies, persistent diagnostic surfaces, or
+structural changes whose sole purpose is evidence gathering.
+
+**Complete when:** the path can be followed without guessing about setup,
+state, or interpretation.
+
+## 6. Close the evidence path
+
+After implementation, follow the planned path and interpret the resulting
+evidence against the original claim.
+
+Report whether the claim was established, limited, or refuted; distinguish
+known facts from remaining uncertainty.
+
+**Complete when:** a future reader can see what supports the conclusion and
+what remains outside its reach.
+
+## Scope
+
+Use this skill proportionately. Small mechanical changes can follow ordinary
+project checks directly. For release-specific validation, use
+`release-smoke-test`; for larger multi-phase work, let this skill establish the
+evidence path that later work follows.


### PR DESCRIPTION
- add new verification-planning skill for building project-specific evidence paths before non-trivial changes
- tighten deepwork skill activation criteria for high-risk, multi-phase efforts
- require deepwork ignore-file checks before planning/delegation and clarify .slim state handling
- increase magic-context cooldowns for GPT-5.6 model variants from 10m to 30m