### PR TITLE
chore(opencode): update plugins and mixed model

### DIFF
--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -119,8 +119,8 @@
     },
     "mixed": {
       "orchestrator": {
-        "model": "anthropic/claude-opus-4-8",
-        "variant": "xhigh",
+        "model": "anthropic/claude-fable-5",
+        "variant": "high",
         "skills": ["*"],
         "mcps": ["*", "!context7"]
       },

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -2,9 +2,9 @@
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
     "@cortexkit/opencode-anthropic-auth@1.15.1",
-    "oh-my-opencode-slim@2.2.2",
+    "oh-my-opencode-slim@2.2.3",
     "@cortexkit/opencode-magic-context@0.32.1",
-    "@cortexkit/aft-opencode@0.46.0",
+    "@cortexkit/aft-opencode@0.47.0",
     "@fro.bot/systematic@2.33.3"
   ],
   "mcp": {


### PR DESCRIPTION
- bump oh-my-opencode-slim from 2.2.2 to 2.2.3
- bump @cortexkit/aft-opencode from 0.46.0 to 0.47.0
- switch mixed orchestrator model from anthropic/claude-opus-4-8 to anthropic/claude-fable-5
- lower mixed orchestrator variant from xhigh to high