### PR TITLE
chore(opencode): bump aft-opencode and clean systematic config profiles

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -4,7 +4,7 @@
     "@cortexkit/opencode-anthropic-auth@1.15.1",
     "oh-my-opencode-slim@2.2.3",
     "@cortexkit/opencode-magic-context@0.32.1",
-    "@cortexkit/aft-opencode@0.47.0",
+    "@cortexkit/aft-opencode@0.47.1",
     "@fro.bot/systematic@3.0.3"
   ],
   "mcp": {

--- a/.config/opencode/systematic.jsonc
+++ b/.config/opencode/systematic.jsonc
@@ -4,9 +4,6 @@
     "design": {
       "model": "github-copilot/gemini-3.1-pro-preview"
     },
-    "docs": {
-      "model": "opencode-go/kimi-k2.7-code"
-    },
     "document-review": {
       "model": "github-copilot/gpt-5.4-mini",
       "variant": "low"


### PR DESCRIPTION
- Bump @cortexkit/aft-opencode from 0.47.0 to 0.47.1 in opencode.json
- Remove deprecated "docs" assistant profile from systematic.jsonc