### PR TITLE
feat(opencode): add event-only retention and tree-aware pruning

### DIFF
--- a/.config/opencode/scripts/lib/opencode-session-tree-retention.ts
+++ b/.config/opencode/scripts/lib/opencode-session-tree-retention.ts
@@ -1,0 +1,125 @@
+import type { Database } from "bun:sqlite";
+
+const SESSION_ID_CANDIDATE_TABLE = "_prune_ids";
+
+export function bytesToHuman(bytes: number): string {
+  if (bytes >= 1e9) return `${(bytes / 1e9).toFixed(2)} GB`;
+  if (bytes >= 1e6) return `${(bytes / 1e6).toFixed(2)} MB`;
+  if (bytes >= 1e3) return `${(bytes / 1e3).toFixed(2)} KB`;
+  return `${bytes} B`;
+}
+
+/**
+ * Run a query or mutation against a temporary, bound-variable-safe candidate
+ * table populated with session or aggregate ids.
+ */
+export function withSessionIdCandidateTable<T>(
+  db: Database,
+  sessionIds: readonly string[],
+  operation: (tableName: string) => T,
+): T {
+  db.exec(`CREATE TEMP TABLE IF NOT EXISTS ${SESSION_ID_CANDIDATE_TABLE} (id TEXT PRIMARY KEY)`);
+
+  try {
+    db.exec(`DELETE FROM ${SESSION_ID_CANDIDATE_TABLE}`);
+
+    const insertId = db.prepare(`INSERT OR IGNORE INTO ${SESSION_ID_CANDIDATE_TABLE} (id) VALUES (?)`);
+    db.transaction(() => {
+      for (const id of sessionIds) insertId.run(id);
+    })();
+
+    return operation(SESSION_ID_CANDIDATE_TABLE);
+  } finally {
+    db.exec(`DROP TABLE IF EXISTS ${SESSION_ID_CANDIDATE_TABLE}`);
+  }
+}
+
+/**
+ * Select ids of all sessions belonging to "prunable" trees.
+ *
+ * A session tree (root + all descendants via parent_id) is prunable iff the
+ * MAX(time_updated) across every session in the tree is older than cutoffMs —
+ * i.e. no session in the tree has been used since the cutoff. If any member
+ * was touched within the window, the entire tree is kept, including that
+ * member's own stale siblings/ancestors/descendants.
+ *
+ * A session whose parent_id points at a nonexistent session (dangling
+ * reference, e.g. after a prior partial prune) is treated as its own tree
+ * root rather than causing an error or being silently dropped.
+ */
+export function selectOldSessionIds(db: Database, cutoffMs: number): string[] {
+  type IdRow = { id: string };
+  const cutoffSec = Math.floor(cutoffMs / 1000);
+  const rows = db.query<IdRow, [number]>(`
+    WITH RECURSIVE tree(id, root_id) AS (
+      SELECT id, id FROM session
+      WHERE parent_id IS NULL OR parent_id NOT IN (SELECT id FROM session)
+      UNION ALL
+      SELECT s.id, t.root_id FROM session s JOIN tree t ON s.parent_id = t.id
+    ),
+    root_activity AS (
+      SELECT t.root_id, MAX(s.time_updated) AS last_used
+      FROM tree t JOIN session s ON s.id = t.id
+      GROUP BY t.root_id
+    )
+    SELECT t.id FROM tree t
+    JOIN root_activity ra ON ra.root_id = t.root_id
+    WHERE CAST(ra.last_used / 1000 AS INTEGER) < ?
+  `).all(cutoffSec);
+  return rows.map((r) => r.id);
+}
+
+export type ReclaimEstimate = {
+  part_bytes: number;
+  message_bytes: number;
+  event_bytes: number;
+  total_bytes: number;
+  part_human: string;
+  message_human: string;
+  event_human: string;
+  total_human: string;
+};
+
+/**
+ * Estimate the byte accounting for session-owned parts, messages, and events.
+ * The candidate table avoids SQLite's bound-variable limit for large trees.
+ */
+export function estimateReclaim(db: Database, sessionIds: readonly string[]): ReclaimEstimate {
+  if (sessionIds.length === 0) {
+    return {
+      part_bytes: 0, message_bytes: 0, event_bytes: 0, total_bytes: 0,
+      part_human: "0 B", message_human: "0 B", event_human: "0 B", total_human: "0 B",
+    };
+  }
+
+  return withSessionIdCandidateTable(db, sessionIds, (tableName) => {
+    type SumRow = { total: number | null };
+
+    // Use CAST(data AS BLOB) so length() returns byte count, not character count.
+    // SQLite's length() on TEXT counts Unicode code points; BLOB length is always bytes.
+    const partBytes = db.query<SumRow, []>(
+      `SELECT SUM(length(CAST(data AS BLOB))) AS total FROM part WHERE session_id IN (SELECT id FROM ${tableName})`
+    ).get()?.total ?? 0;
+
+    const messageBytes = db.query<SumRow, []>(
+      `SELECT SUM(length(CAST(data AS BLOB))) AS total FROM message WHERE session_id IN (SELECT id FROM ${tableName})`
+    ).get()?.total ?? 0;
+
+    const eventBytes = db.query<SumRow, []>(
+      `SELECT SUM(length(CAST(data AS BLOB))) AS total FROM event WHERE aggregate_id IN (SELECT id FROM ${tableName})`
+    ).get()?.total ?? 0;
+
+    const totalBytes = partBytes + messageBytes + eventBytes;
+
+    return {
+      part_bytes: partBytes,
+      message_bytes: messageBytes,
+      event_bytes: eventBytes,
+      total_bytes: totalBytes,
+      part_human: bytesToHuman(partBytes),
+      message_human: bytesToHuman(messageBytes),
+      event_human: bytesToHuman(eventBytes),
+      total_human: bytesToHuman(totalBytes),
+    };
+  });
+}

--- a/.config/opencode/scripts/lib/opencode-session-tree-retention.ts
+++ b/.config/opencode/scripts/lib/opencode-session-tree-retention.ts
@@ -1,6 +1,11 @@
 import type { Database } from "bun:sqlite";
 
-const SESSION_ID_CANDIDATE_TABLE = "_prune_ids";
+let sessionIdCandidateTableSequence = 0;
+
+function nextSessionIdCandidateTableName(): string {
+  sessionIdCandidateTableSequence += 1;
+  return `_prune_ids_${sessionIdCandidateTableSequence.toString(36)}`;
+}
 
 export function bytesToHuman(bytes: number): string {
   if (bytes >= 1e9) return `${(bytes / 1e9).toFixed(2)} GB`;
@@ -18,19 +23,18 @@ export function withSessionIdCandidateTable<T>(
   sessionIds: readonly string[],
   operation: (tableName: string) => T,
 ): T {
-  db.exec(`CREATE TEMP TABLE IF NOT EXISTS ${SESSION_ID_CANDIDATE_TABLE} (id TEXT PRIMARY KEY)`);
+  const tableName = nextSessionIdCandidateTableName();
+  db.exec(`CREATE TEMP TABLE ${tableName} (id TEXT PRIMARY KEY)`);
 
   try {
-    db.exec(`DELETE FROM ${SESSION_ID_CANDIDATE_TABLE}`);
-
-    const insertId = db.prepare(`INSERT OR IGNORE INTO ${SESSION_ID_CANDIDATE_TABLE} (id) VALUES (?)`);
+    const insertId = db.prepare(`INSERT OR IGNORE INTO ${tableName} (id) VALUES (?)`);
     db.transaction(() => {
       for (const id of sessionIds) insertId.run(id);
     })();
 
-    return operation(SESSION_ID_CANDIDATE_TABLE);
+    return operation(tableName);
   } finally {
-    db.exec(`DROP TABLE IF EXISTS ${SESSION_ID_CANDIDATE_TABLE}`);
+    db.exec(`DROP TABLE ${tableName}`);
   }
 }
 

--- a/.config/opencode/scripts/opencode-doctor.test.ts
+++ b/.config/opencode/scripts/opencode-doctor.test.ts
@@ -9,15 +9,22 @@ import {
   selectOldSessionIds,
   estimateReclaim,
   pruneSessions,
+  pruneEvents,
   classifyPgrepExitCode,
   autoVacuumModeName,
   convertToIncrementalVacuum,
+  checkForOtherOpencodeProcesses,
 } from "./opencode-doctor";
+import {
+  selectOldSessionIds as selectOldSessionIdsFromRetention,
+  estimateReclaim as estimateReclaimFromRetention,
+  withSessionIdCandidateTable,
+} from "./lib/opencode-session-tree-retention";
 
 const SCRIPT_PATH = "./opencode-doctor.ts";
 const TEST_TIMEOUT = 90000;
 
-let spawnedProcs: Array<{ kill: (signal?: string) => void; exited: Promise<number> }> = [];
+let spawnedProcs: Array<Pick<ReturnType<typeof Bun.spawn>, "kill" | "exited">> = [];
 
 afterEach(async () => {
   for (const proc of spawnedProcs) {
@@ -51,11 +58,19 @@ function removeTempDir(dir: string): void {
  * Create a minimal OpenCode-schema SQLite DB for testing.
  * Returns the db instance and its file path.
  */
-function createTestDb(dir: string): { db: Database; dbPath: string } {
+function createTestDb(
+  dir: string,
+  options: { autoVacuum?: number; eventCascade?: boolean } = {},
+): { db: Database; dbPath: string } {
   const dbPath = join(dir, "test.db");
   const db = new Database(dbPath);
+  const eventReference = options.eventCascade === false
+    ? "REFERENCES event_sequence(aggregate_id)"
+    : "REFERENCES event_sequence(aggregate_id) ON DELETE CASCADE";
+  const autoVacuum = options.autoVacuum === 2 ? "PRAGMA auto_vacuum=INCREMENTAL;" : "";
 
   db.exec(`
+    ${autoVacuum}
     PRAGMA journal_mode=WAL;
     PRAGMA foreign_keys=ON;
 
@@ -93,7 +108,7 @@ function createTestDb(dir: string): { db: Database; dbPath: string } {
 
     CREATE TABLE IF NOT EXISTS event (
       id TEXT PRIMARY KEY,
-      aggregate_id TEXT NOT NULL REFERENCES event_sequence(aggregate_id) ON DELETE CASCADE,
+      aggregate_id TEXT NOT NULL ${eventReference},
       seq INTEGER NOT NULL,
       type TEXT NOT NULL DEFAULT '',
       data TEXT NOT NULL DEFAULT '{}'
@@ -381,6 +396,104 @@ describe("DB helpers (unit)", () => {
     }
   });
 
+  test("extracted retention primitives preserve tree selection, event estimates, and large candidate sets", () => {
+    const dir = makeTempDir();
+    try {
+      const { db } = createTestDb(dir);
+
+      const now = Date.now();
+      const cutoffMs = now - 30 * 24 * 3600 * 1000;
+      const staleTs = now - 60 * 24 * 3600 * 1000;
+      const recentTs = now - 5 * 24 * 3600 * 1000;
+
+      insertSession(db, "stale-root", staleTs, { timeUpdatedMs: staleTs, events: 2 });
+      insertSession(db, "stale-child", staleTs, { timeUpdatedMs: staleTs, parentId: "stale-root", events: 3 });
+      insertSession(db, "protected-descendant", staleTs, {
+        timeUpdatedMs: recentTs,
+        parentId: "stale-child",
+        events: 4,
+      });
+      insertSession(db, "dangling-stale", staleTs, {
+        timeUpdatedMs: staleTs,
+        parentId: "deleted-parent",
+        events: 5,
+      });
+
+      const doctorIds = selectOldSessionIds(db, cutoffMs);
+      const extractedIds = selectOldSessionIdsFromRetention(db, cutoffMs);
+      expect(extractedIds).toEqual(doctorIds);
+      expect(extractedIds).toEqual(["dangling-stale"]);
+
+      const doctorEstimate = estimateReclaim(db, extractedIds);
+      const extractedEstimate = estimateReclaimFromRetention(db, extractedIds);
+      expect(extractedEstimate).toEqual(doctorEstimate);
+
+      const candidateIds = Array.from({ length: 1501 }, (_, index) => `candidate-${index}`);
+      const candidateCount = withSessionIdCandidateTable(db, candidateIds, (tableName) => {
+        type CountRow = { cnt: number };
+        return db.query<CountRow, []>(`SELECT COUNT(*) AS cnt FROM ${tableName}`).get()?.cnt ?? 0;
+      });
+      expect(candidateCount).toBe(candidateIds.length);
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("withSessionIdCandidateTable drops the temp table when population throws", () => {
+    const dir = makeTempDir();
+    try {
+      const { db } = createTestDb(dir);
+      const candidateIds = {
+        *[Symbol.iterator](): Generator<string> {
+          yield "candidate-before-failure";
+          throw new Error("candidate population failed");
+        },
+      } as unknown as readonly string[];
+
+      expect(() => withSessionIdCandidateTable(db, candidateIds, () => undefined)).toThrow(
+        "candidate population failed"
+      );
+
+      type TempTableRow = { name: string };
+      const tempTable = db.query<TempTableRow, []>(
+        "SELECT name FROM sqlite_temp_master WHERE type = 'table' AND name = '_prune_ids'"
+      ).get();
+      expect(tempTable).toBeNull();
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("withSessionIdCandidateTable drops the temp table when the operation throws", () => {
+    const dir = makeTempDir();
+    try {
+      const { db } = createTestDb(dir);
+      let populatedRows = 0;
+
+      expect(() => withSessionIdCandidateTable(db, ["candidate"], (tableName) => {
+        type CountRow = { cnt: number };
+        populatedRows = db.query<CountRow, []>(
+          `SELECT COUNT(*) AS cnt FROM ${tableName}`
+        ).get()?.cnt ?? 0;
+        throw new Error("candidate operation failed");
+      })).toThrow("candidate operation failed");
+
+      expect(populatedRows).toBe(1);
+
+      type TempTableRow = { name: string };
+      const tempTable = db.query<TempTableRow, []>(
+        "SELECT name FROM sqlite_temp_master WHERE type = 'table' AND name = '_prune_ids'"
+      ).get();
+      expect(tempTable).toBeNull();
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
   test("pruneSessions deletes old sessions and cascades to message/part/event", () => {
     const dir = makeTempDir();
     try {
@@ -583,6 +696,293 @@ describe("DB helpers (unit)", () => {
   });
 });
 
+describe("event-only retention (unit)", () => {
+  test("refuses an active OpenCode parent instead of excluding the parent PID", () => {
+    const result = checkForOtherOpencodeProcesses({
+      ownPid: 100,
+      spawnSync: (args: string[]) => args[0] === "pgrep"
+        ? { exitCode: 0, stdout: "100\n200\n" }
+        : { exitCode: 0, stdout: "200\n" },
+    });
+
+    expect(result.safe).toBe(false);
+    expect(result.pids).toEqual([200]);
+  });
+
+  test("deletes selected event streams while preserving sessions, messages, and parts", () => {
+    const dir = makeTempDir();
+    try {
+      const { db, dbPath } = createTestDb(dir, { autoVacuum: 2 });
+      const now = Date.now();
+      insertSession(db, "sess-old", now - 60 * 24 * 3600 * 1000, { events: 3 });
+      insertSession(db, "sess-recent", now - 5 * 24 * 3600 * 1000, { events: 4 });
+      const sessionIds = selectOldSessionIds(db, now - 30 * 24 * 3600 * 1000);
+      const statements: string[] = [];
+      const originalExec = db.exec.bind(db);
+      (db as unknown as { exec: (sql: string) => void }).exec = (sql: string) => {
+        statements.push(sql);
+        originalExec(sql);
+      };
+
+      const result = pruneEvents(db, sessionIds, dbPath, {
+        availableBytes: () => 20 * 1024 ** 3,
+      });
+
+      expect(result.event_sequence_rows_deleted).toBe(1);
+      expect(result.event_rows_deleted).toBe(3);
+      expect(result.before.row_counts.session).toBe(result.after.row_counts.session);
+      expect(result.before.row_counts.message).toBe(result.after.row_counts.message);
+      expect(result.before.row_counts.part).toBe(result.after.row_counts.part);
+      expect(result.after.row_counts.event_sequence).toBe(1);
+      expect(result.after.row_counts.event).toBe(4);
+      expect(result.estimated_reclaim.event_bytes).toBeGreaterThan(0);
+      expect(result.file_size_delta_bytes).toBeGreaterThanOrEqual(0);
+      expect(statements.some((sql) => /\bVACUUM\b/i.test(sql))).toBe(false);
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("refuses event deletion unless auto_vacuum is incremental", () => {
+    const dir = makeTempDir();
+    try {
+      const { db, dbPath } = createTestDb(dir);
+      const now = Date.now();
+      insertSession(db, "sess-old", now - 60 * 24 * 3600 * 1000);
+      const sessionIds = selectOldSessionIds(db, now - 30 * 24 * 3600 * 1000);
+
+      expect(() => pruneEvents(db, sessionIds, dbPath, { availableBytes: () => 20 * 1024 ** 3 }))
+        .toThrow(/auto_vacuum.*INCREMENTAL/i);
+      expect(db.query<{ cnt: number }, []>("SELECT COUNT(*) AS cnt FROM event").get()?.cnt).toBe(3);
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("refuses event deletion when the event foreign key is not cascading", () => {
+    const dir = makeTempDir();
+    try {
+      const { db, dbPath } = createTestDb(dir, { autoVacuum: 2, eventCascade: false });
+      const now = Date.now();
+      insertSession(db, "sess-old", now - 60 * 24 * 3600 * 1000);
+      const sessionIds = selectOldSessionIds(db, now - 30 * 24 * 3600 * 1000);
+
+      expect(() => pruneEvents(db, sessionIds, dbPath, { availableBytes: () => 20 * 1024 ** 3 }))
+        .toThrow(/CASCADE|foreign key/i);
+      expect(db.query<{ cnt: number }, []>("SELECT COUNT(*) AS cnt FROM event_sequence").get()?.cnt).toBe(1);
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("preserves a recent descendant tree", () => {
+    const dir = makeTempDir();
+    try {
+      const { db, dbPath } = createTestDb(dir, { autoVacuum: 2 });
+      const now = Date.now();
+      insertSession(db, "old-root", now - 60 * 24 * 3600 * 1000, { events: 2 });
+      insertSession(db, "recent-child", now - 60 * 24 * 3600 * 1000, {
+        parentId: "old-root",
+        timeUpdatedMs: now - 5 * 24 * 3600 * 1000,
+        events: 2,
+      });
+      const sessionIds = selectOldSessionIds(db, now - 30 * 24 * 3600 * 1000);
+
+      const result = pruneEvents(db, sessionIds, dbPath, {
+        availableBytes: () => 20 * 1024 ** 3,
+      });
+
+      expect(sessionIds).toEqual([]);
+      expect(result.event_rows_deleted).toBe(0);
+      expect(result.event_sequence_rows_deleted).toBe(0);
+      expect(db.query<{ cnt: number }, []>("SELECT COUNT(*) AS cnt FROM event").get()?.cnt).toBe(4);
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("surfaces post-delete incremental vacuum errors without hiding deleted counts", () => {
+    const dir = makeTempDir();
+    try {
+      const { db, dbPath } = createTestDb(dir, { autoVacuum: 2 });
+      const now = Date.now();
+      insertSession(db, "sess-old", now - 60 * 24 * 3600 * 1000);
+      const sessionIds = selectOldSessionIds(db, now - 30 * 24 * 3600 * 1000);
+      const originalExec = db.exec.bind(db);
+      (db as unknown as { exec: (sql: string) => void }).exec = (sql: string) => {
+        if (sql.trim().toUpperCase() === "PRAGMA INCREMENTAL_VACUUM") {
+          throw new Error("simulated incremental vacuum failure");
+        }
+        originalExec(sql);
+      };
+
+      const result = pruneEvents(db, sessionIds, dbPath, {
+        availableBytes: () => 20 * 1024 ** 3,
+      });
+
+      expect(result.event_rows_deleted).toBe(3);
+      expect(result.vacuum_error).toContain("simulated incremental vacuum failure");
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("rolls back event deletion when a preservation trigger changes message rows", () => {
+    const dir = makeTempDir();
+    try {
+      const { db, dbPath } = createTestDb(dir, { autoVacuum: 2 });
+      const now = Date.now();
+      insertSession(db, "sess-old", now - 60 * 24 * 3600 * 1000);
+      insertSession(db, "sess-recent", now - 5 * 24 * 3600 * 1000);
+      db.exec(`
+        CREATE TRIGGER mutate_message_after_event_delete
+        AFTER DELETE ON event_sequence
+        BEGIN
+          DELETE FROM message WHERE id = (
+            SELECT id FROM message WHERE session_id = 'sess-recent' LIMIT 1
+          );
+        END;
+      `);
+      const sessionIds = selectOldSessionIds(db, now - 30 * 24 * 3600 * 1000);
+
+      expect(() => pruneEvents(db, sessionIds, dbPath, { availableBytes: () => 20 * 1024 ** 3 }))
+        .toThrow(/preservation|session, message, or part/i);
+      expect(db.query<{ cnt: number }, []>("SELECT COUNT(*) AS cnt FROM event_sequence").get()?.cnt).toBe(2);
+      expect(db.query<{ cnt: number }, []>("SELECT COUNT(*) AS cnt FROM event").get()?.cnt).toBe(6);
+      expect(db.query<{ cnt: number }, []>("SELECT COUNT(*) AS cnt FROM message").get()?.cnt).toBe(4);
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("rolls back event deletion when selected message and part content changes without count drift", () => {
+    const dir = makeTempDir();
+    try {
+      const { db, dbPath } = createTestDb(dir, { autoVacuum: 2 });
+      const now = Date.now();
+      insertSession(db, "sess-old", now - 60 * 24 * 3600 * 1000);
+      db.exec(`
+        CREATE TRIGGER mutate_selected_content_after_event_delete
+        AFTER DELETE ON event_sequence
+        BEGIN
+          UPDATE message SET data = '{"role":"tampered"}' WHERE id = 'sess-old-msg-0';
+          UPDATE part SET data = '{"type":"text","text":"tampered"}' WHERE id = 'sess-old-part-0-0';
+        END;
+      `);
+      const sessionIds = selectOldSessionIds(db, now - 30 * 24 * 3600 * 1000);
+
+      expect(() => pruneEvents(db, sessionIds, dbPath, { availableBytes: () => 20 * 1024 ** 3 }))
+        .toThrow(/preservation|content|integrity/i);
+      expect(db.query<{ cnt: number }, []>("SELECT COUNT(*) AS cnt FROM event_sequence").get()?.cnt).toBe(1);
+      expect(db.query<{ cnt: number }, []>("SELECT COUNT(*) AS cnt FROM event").get()?.cnt).toBe(3);
+      expect(db.query<{ data: string }, []>("SELECT data FROM message WHERE id = 'sess-old-msg-0'").get()?.data)
+        .toContain('"role":"user"');
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("streams large selected payloads while rolling back count-preserving content mutation", () => {
+    const dir = makeTempDir();
+    try {
+      const { db, dbPath } = createTestDb(dir, { autoVacuum: 2 });
+      const now = Date.now();
+      const sessionId = "sess-large-preservation";
+      insertSession(db, sessionId, now - 60 * 24 * 3600 * 1000, {
+        messages: 8,
+        partsPerMessage: 4,
+        events: 3,
+      });
+
+      const largeText = "large-payload-" + "x".repeat(512 * 1024);
+      const updateMessage = db.prepare("UPDATE message SET data = ? WHERE id = ?");
+      const updatePart = db.prepare("UPDATE part SET data = ? WHERE id = ?");
+      db.transaction(() => {
+        for (let messageIndex = 0; messageIndex < 8; messageIndex += 1) {
+          updateMessage.run(largeText, `${sessionId}-msg-${messageIndex}`);
+          for (let partIndex = 0; partIndex < 4; partIndex += 1) {
+            updatePart.run(
+              partIndex === 0 && messageIndex === 0
+                ? new Uint8Array([0, 255, 1, 254, 2])
+                : largeText,
+              `${sessionId}-part-${messageIndex}-${partIndex}`,
+            );
+          }
+        }
+      })();
+
+      db.exec(`
+        CREATE TRIGGER mutate_large_selected_content_after_event_delete
+        AFTER DELETE ON event_sequence
+        BEGIN
+          UPDATE message SET data = 'tampered-message' WHERE id = '${sessionId}-msg-3';
+          UPDATE part SET data = 'tampered-part' WHERE id = '${sessionId}-part-5-2';
+        END;
+      `);
+
+      const observedQueries: string[] = [];
+      const originalQuery = db.query.bind(db);
+      (db as unknown as { query: (sql: string) => unknown }).query = (sql: string) => {
+        observedQueries.push(sql);
+        return originalQuery(sql);
+      };
+
+      const sessionIds = selectOldSessionIds(db, now - 30 * 24 * 3600 * 1000);
+
+      expect(() => pruneEvents(db, sessionIds, dbPath, { availableBytes: () => 20 * 1024 ** 3 }))
+        .toThrow(/preservation|content|integrity/i);
+      expect(observedQueries.some((sql) => /SELECT\s+\*\s+FROM\s+(session|message|part)/i.test(sql))).toBe(false);
+
+      expect(db.query<{ cnt: number }, []>("SELECT COUNT(*) AS cnt FROM event_sequence").get()?.cnt).toBe(1);
+      expect(db.query<{ cnt: number }, []>("SELECT COUNT(*) AS cnt FROM event").get()?.cnt).toBe(3);
+      expect(db.query<{ cnt: number }, []>("SELECT COUNT(*) AS cnt FROM message").get()?.cnt).toBe(8);
+      expect(db.query<{ cnt: number }, []>("SELECT COUNT(*) AS cnt FROM part").get()?.cnt).toBe(32);
+      expect(db.query<{ data: string }, []>(`SELECT data FROM message WHERE id = '${sessionId}-msg-3'`).get()?.data)
+        .toBe(largeText);
+      expect(db.query<{ data: Uint8Array }, []>(`SELECT data FROM part WHERE id = '${sessionId}-part-0-0'`).get()?.data)
+        .toEqual(new Uint8Array([0, 255, 1, 254, 2]));
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("reports a busy post-delete checkpoint as an executed failure", () => {
+    const dir = makeTempDir();
+    try {
+      const { db, dbPath } = createTestDb(dir, { autoVacuum: 2 });
+      const now = Date.now();
+      insertSession(db, "sess-old", now - 60 * 24 * 3600 * 1000);
+      const sessionIds = selectOldSessionIds(db, now - 30 * 24 * 3600 * 1000);
+      let checkpointCalls = 0;
+
+      const result = pruneEvents(db, sessionIds, dbPath, {
+        availableBytes: () => 20 * 1024 ** 3,
+        walCheckpoint: () => {
+          checkpointCalls += 1;
+          return { busy: 1 };
+        },
+      });
+
+      expect(checkpointCalls).toBe(2);
+      expect(result.event_rows_deleted).toBe(3);
+      expect(result.vacuum_error).toMatch(/busy/i);
+      expect(db.query<{ cnt: number }, []>("SELECT COUNT(*) AS cnt FROM event").get()?.cnt).toBe(0);
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+});
+
 // ─── CLI Integration Tests (DB flags) ────────────────────────────────────────
 
 describe("DB CLI integration", () => {
@@ -773,6 +1173,106 @@ describe("DB CLI integration", () => {
       }
     },
     { timeout: TEST_TIMEOUT }
+  );
+});
+
+describe("event-only retention CLI", () => {
+  test(
+    "dry run reports event-only selection without deleting rows",
+    async () => {
+      const dir = makeTempDir();
+      try {
+        const { db, dbPath } = createTestDb(dir);
+        const now = Date.now();
+        insertSession(db, "sess-old", now - 60 * 24 * 3600 * 1000, { events: 3 });
+        insertSession(db, "sess-recent", now - 5 * 24 * 3600 * 1000, { events: 4 });
+        db.close();
+
+        const result = await $`bun ${SCRIPT_PATH} --db-health --prune-events-older=30 --json --db-path=${dbPath}`.text();
+        const sections = JSON.parse(result) as Array<{ label: string; data?: Record<string, unknown> }>;
+        const eventSection = sections.find((section) => section.label === "DB Event Prune (dry-run)");
+
+        expect(eventSection).toBeDefined();
+        expect(eventSection?.data?.mode).toBe("event-only");
+        expect(eventSection?.data?.selected_session_count).toBe(1);
+        expect(eventSection?.data?.deleted_event_rows).toBe(0);
+        expect(eventSection?.data?.deleted_event_sequence_rows).toBe(0);
+
+        const db2 = new Database(dbPath, { readonly: true });
+        expect(db2.query<{ cnt: number }, []>("SELECT COUNT(*) AS cnt FROM session").get()?.cnt).toBe(2);
+        expect(db2.query<{ cnt: number }, []>("SELECT COUNT(*) AS cnt FROM event").get()?.cnt).toBe(7);
+        db2.close();
+      } finally {
+        removeTempDir(dir);
+      }
+    },
+    { timeout: TEST_TIMEOUT },
+  );
+
+  test(
+    "rejects event-only and whole-tree prune flags together",
+    async () => {
+      const dir = makeTempDir();
+      try {
+        const { db, dbPath } = createTestDb(dir);
+        db.close();
+
+        const result = await $`bun ${SCRIPT_PATH} --prune-events-older=30 --prune-older=30 --json --db-path=${dbPath}`.quiet().nothrow();
+        expect(result.exitCode).toBe(1);
+        const sections = JSON.parse(result.stdout.toString()) as Array<{ data?: Record<string, unknown> }>;
+        expect(sections[0]?.data?.refused).toBe(true);
+        expect(String(sections[0]?.data?.reason)).toMatch(/mutually exclusive/i);
+      } finally {
+        removeTempDir(dir);
+      }
+    },
+    { timeout: TEST_TIMEOUT },
+  );
+
+  test(
+    "rejects event-only retention days below one",
+    async () => {
+      const dir = makeTempDir();
+      try {
+        const { db, dbPath } = createTestDb(dir);
+        db.close();
+
+        const result = await $`bun ${SCRIPT_PATH} --prune-events-older=0 --json --db-path=${dbPath}`.quiet().nothrow();
+        expect(result.exitCode).toBe(1);
+        const sections = JSON.parse(result.stdout.toString()) as Array<{ data?: Record<string, unknown> }>;
+        expect(sections[0]?.data?.refused).toBe(true);
+        expect(String(sections[0]?.data?.reason)).toMatch(/>= 1|at least 1|positive/i);
+      } finally {
+        removeTempDir(dir);
+      }
+    },
+    { timeout: TEST_TIMEOUT },
+  );
+
+  test(
+    "refuses event-only execute while another OpenCode process is active",
+    async () => {
+      const dir = makeTempDir();
+      const active = Bun.spawn(["bash", "-c", "exec -a opencode-active-retention-test sleep 30"], {
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+      try {
+        const { db, dbPath } = createTestDb(dir, { autoVacuum: 2 });
+        db.close();
+
+        const result = await $`bun ${SCRIPT_PATH} --prune-events-older=30 --execute --json --db-path=${dbPath}`.quiet().nothrow();
+        expect(result.exitCode).toBe(1);
+        const sections = JSON.parse(result.stdout.toString()) as Array<{ data?: Record<string, unknown> }>;
+        expect(sections[0]?.data?.refused).toBe(true);
+        expect(String(sections[0]?.data?.reason)).toMatch(/opencode|process|close/i);
+      } finally {
+        active.kill();
+        await active.exited;
+        removeTempDir(dir);
+      }
+    },
+    { timeout: TEST_TIMEOUT },
   );
 });
 

--- a/.config/opencode/scripts/opencode-doctor.test.ts
+++ b/.config/opencode/scripts/opencode-doctor.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { $ } from "bun";
 import { Database } from "bun:sqlite";
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -60,7 +60,7 @@ function removeTempDir(dir: string): void {
  */
 function createTestDb(
   dir: string,
-  options: { autoVacuum?: number; eventCascade?: boolean } = {},
+  options: { autoVacuum?: number; eventCascade?: boolean; preservationIndexes?: boolean } = {},
 ): { db: Database; dbPath: string } {
   const dbPath = join(dir, "test.db");
   const db = new Database(dbPath);
@@ -114,6 +114,13 @@ function createTestDb(
       data TEXT NOT NULL DEFAULT '{}'
     );
   `);
+
+  if (options.preservationIndexes !== false) {
+    db.exec(`
+      CREATE INDEX message_session_id_idx ON message(session_id);
+      CREATE INDEX part_session_id_idx ON part(session_id);
+    `);
+  }
 
   return { db, dbPath };
 }
@@ -456,7 +463,7 @@ describe("DB helpers (unit)", () => {
 
       type TempTableRow = { name: string };
       const tempTable = db.query<TempTableRow, []>(
-        "SELECT name FROM sqlite_temp_master WHERE type = 'table' AND name = '_prune_ids'"
+        "SELECT name FROM sqlite_temp_master WHERE type = 'table' AND name LIKE '_prune_ids_%'"
       ).get();
       expect(tempTable).toBeNull();
 
@@ -484,9 +491,41 @@ describe("DB helpers (unit)", () => {
 
       type TempTableRow = { name: string };
       const tempTable = db.query<TempTableRow, []>(
-        "SELECT name FROM sqlite_temp_master WHERE type = 'table' AND name = '_prune_ids'"
+        "SELECT name FROM sqlite_temp_master WHERE type = 'table' AND name LIKE '_prune_ids_%'"
       ).get();
       expect(tempTable).toBeNull();
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("withSessionIdCandidateTable uses distinct temp tables for nested invocations on one connection", () => {
+    const dir = makeTempDir();
+    try {
+      const { db } = createTestDb(dir);
+      let outerTable = "";
+      let innerTable = "";
+
+      const result = withSessionIdCandidateTable(db, ["outer"], (outerName) => {
+        outerTable = outerName;
+        const before = db.query<{ cnt: number }, []>(`SELECT COUNT(*) AS cnt FROM ${outerName}`).get()?.cnt;
+        const inner = withSessionIdCandidateTable(db, ["inner-a", "inner-b"], (innerName) => {
+          innerTable = innerName;
+          return db.query<{ cnt: number }, []>(`SELECT COUNT(*) AS cnt FROM ${innerName}`).get()?.cnt ?? 0;
+        });
+        const after = db.query<{ cnt: number }, []>(`SELECT COUNT(*) AS cnt FROM ${outerName}`).get()?.cnt;
+        return { before, inner, after };
+      });
+
+      expect(result).toEqual({ before: 1, inner: 2, after: 1 });
+      expect(outerTable).toMatch(/^_prune_ids_/);
+      expect(innerTable).toMatch(/^_prune_ids_/);
+      expect(innerTable).not.toBe(outerTable);
+      expect(db.query<{ cnt: number }, []>(
+        "SELECT COUNT(*) AS cnt FROM sqlite_temp_master WHERE type = 'table' AND name LIKE '_prune_ids_%'"
+      ).get()?.cnt).toBe(0);
 
       db.close();
     } finally {
@@ -697,6 +736,29 @@ describe("DB helpers (unit)", () => {
 });
 
 describe("event-only retention (unit)", () => {
+  test("uses a fixed operational headroom floor independent of estimated event payload bytes", () => {
+    const dir = makeTempDir();
+    try {
+      const { db, dbPath } = createTestDb(dir, { autoVacuum: 2 });
+      const now = Date.now();
+      insertSession(db, "sess-old", now - 60 * 24 * 3600 * 1000, { events: 3 });
+      const sessionIds = selectOldSessionIds(db, now - 30 * 24 * 3600 * 1000);
+      const headroom = 8 * 1024 ** 3;
+
+      const result = pruneEvents(db, sessionIds, dbPath, {
+        availableBytes: () => headroom + 1,
+      });
+
+      expect(result.operational_headroom_floor_bytes).toBe(headroom);
+      expect(result.operational_headroom_floor_human).toContain("GB");
+      expect(result.estimated_reclaim.event_bytes).toBeGreaterThan(1);
+
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
   test("refuses an active OpenCode parent instead of excluding the parent PID", () => {
     const result = checkForOtherOpencodeProcesses({
       ownPid: 100,
@@ -773,6 +835,25 @@ describe("event-only retention (unit)", () => {
       expect(() => pruneEvents(db, sessionIds, dbPath, { availableBytes: () => 20 * 1024 ** 3 }))
         .toThrow(/CASCADE|foreign key/i);
       expect(db.query<{ cnt: number }, []>("SELECT COUNT(*) AS cnt FROM event_sequence").get()?.cnt).toBe(1);
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("refuses and rolls back event deletion when preservation predicate indexes are missing", () => {
+    const dir = makeTempDir();
+    try {
+      const { db, dbPath } = createTestDb(dir, { autoVacuum: 2, preservationIndexes: false });
+      const now = Date.now();
+      insertSession(db, "sess-old", now - 60 * 24 * 3600 * 1000);
+      const sessionIds = selectOldSessionIds(db, now - 30 * 24 * 3600 * 1000);
+
+      expect(() => pruneEvents(db, sessionIds, dbPath, { availableBytes: () => 20 * 1024 ** 3 }))
+        .toThrow(/index.*message|message.*index/i);
+      expect(db.query<{ cnt: number }, []>("SELECT COUNT(*) AS cnt FROM event_sequence").get()?.cnt).toBe(1);
+      expect(db.query<{ cnt: number }, []>("SELECT COUNT(*) AS cnt FROM event").get()?.cnt).toBe(3);
+
       db.close();
     } finally {
       removeTempDir(dir);
@@ -1178,6 +1259,27 @@ describe("DB CLI integration", () => {
 
 describe("event-only retention CLI", () => {
   test(
+    "bare --prune-events-older refuses with an explicit missing-value state, never NaN",
+    async () => {
+      const dir = makeTempDir();
+      try {
+        const { db, dbPath } = createTestDb(dir);
+        db.close();
+
+        const result = await $`bun ${SCRIPT_PATH} --prune-events-older --json --db-path=${dbPath}`.quiet().nothrow();
+        expect(result.exitCode).toBe(1);
+        const sections = JSON.parse(result.stdout.toString()) as Array<{ data?: Record<string, unknown> }>;
+        expect(sections[0]?.data?.refused).toBe(true);
+        expect(String(sections[0]?.data?.reason)).toMatch(/requires.*value|missing.*value|explicit/i);
+        expect(result.stdout.toString()).not.toContain("NaN");
+      } finally {
+        removeTempDir(dir);
+      }
+    },
+    { timeout: TEST_TIMEOUT },
+  );
+
+  test(
     "dry run reports event-only selection without deleting rows",
     async () => {
       const dir = makeTempDir();
@@ -1296,6 +1398,9 @@ describe("opencode-doctor CLI", () => {
       expect(result).toContain("--prune-older");
       expect(result).toContain("--execute");
       expect(result).toContain("--db-path");
+      expect(result).toContain("--prune-events-older");
+      expect(result).toContain("--set-incremental-vacuum");
+      expect(result).toMatch(/8\s*GiB|operational headroom/i);
     },
     { timeout: TEST_TIMEOUT }
   );
@@ -1381,6 +1486,18 @@ describe("opencode-doctor CLI", () => {
       expect(output).toContain("OpenCode doctor");
     },
     { timeout: TEST_TIMEOUT }
+  );
+
+  test(
+    "documentation table covers incremental vacuum and final event-prune semantics",
+    () => {
+      const docs = readFileSync(join(import.meta.dir, "../../../.dotfiles/docs/opencode-doctor.md"), "utf8");
+
+      expect(docs).toContain("| `--set-incremental-vacuum` |");
+      expect(docs).toMatch(/--prune-events-older[\s\S]*auto_vacuum=INCREMENTAL/);
+      expect(docs).toMatch(/8\s*GiB|operational headroom/i);
+      expect(docs).toMatch(/never runs a full `VACUUM`/i);
+    },
   );
 });
 

--- a/.config/opencode/scripts/opencode-doctor.ts
+++ b/.config/opencode/scripts/opencode-doctor.ts
@@ -34,6 +34,7 @@ type CliOptions = {
   dbHealth: boolean;
   pruneOlderDays: number | null;
   pruneEventsOlderDays: number | null;
+  pruneEventsOlderRefusal: string | null;
   execute: boolean;
   dbPath: string;
   setIncrementalVacuum: boolean;
@@ -126,6 +127,10 @@ function warnUnknownFlag(flag: string): void {
 
 function warnInvalidValue(flag: string, value: string, expected: string): void {
   console.warn(`Warning: Invalid value "${value}" for ${flag}, expected ${expected}. Using default.`);
+}
+
+function warnRefusedValue(flag: string, value: string, expected: string): void {
+  console.warn(`Warning: Invalid value "${value}" for ${flag}, expected ${expected}. Refusing.`);
 }
 
 function isBooleanTrue(value: string | boolean): boolean {
@@ -295,15 +300,16 @@ function parseArgs(argv: string[]): CliOptions {
 
   const pruneEventsValue = args.get("--prune-events-older");
   let pruneEventsOlderDays: number | null = null;
+  let pruneEventsOlderRefusal: string | null = null;
   if (pruneEventsValue != null) {
     if (pruneEventsValue === true) {
-      warnInvalidValue("--prune-events-older", "(missing)", "integer >= 1 (days)");
-      pruneEventsOlderDays = Number.NaN;
+      warnRefusedValue("--prune-events-older", "(missing)", "integer >= 1 (days)");
+      pruneEventsOlderRefusal = "--prune-events-older requires an explicit value in days.";
     } else {
       const parsed = Number(pruneEventsValue);
       if (!Number.isFinite(parsed) || parsed < 1) {
-        warnInvalidValue("--prune-events-older", String(pruneEventsValue), "integer >= 1 (days)");
-        pruneEventsOlderDays = parsed;
+        warnRefusedValue("--prune-events-older", String(pruneEventsValue), "integer >= 1 (days)");
+        pruneEventsOlderRefusal = `--prune-events-older must be >= 1 day (got ${String(pruneEventsValue)}).`;
       } else {
         pruneEventsOlderDays = parsed;
       }
@@ -337,6 +343,7 @@ function parseArgs(argv: string[]): CliOptions {
     dbHealth,
     pruneOlderDays,
     pruneEventsOlderDays,
+    pruneEventsOlderRefusal,
     execute,
     dbPath,
     setIncrementalVacuum,
@@ -374,10 +381,12 @@ DB Maintenance (no server required):
                             only selected if no session in it was updated within the window.
                             Dry-run unless --execute. Deletion is IRREVERSIBLE.
   --prune-events-older <days>
-                            Event-only retention: delete selected event streams while preserving
-                            sessions, messages, and parts. Tree-aware and dry-run by default.
-                            Requires auto_vacuum=INCREMENTAL for --execute; never runs full VACUUM.
-                            Mutually exclusive with --prune-older.
+                             Event-only retention: delete selected event streams while preserving
+                             sessions, messages, and parts. Tree-aware and dry-run by default.
+                             --execute requires no active OpenCode process, indexed preservation
+                             predicates, auto_vacuum=INCREMENTAL, and 8 GiB operational headroom;
+                             it uses incremental vacuum and never runs full VACUUM.
+                             Mutually exclusive with --prune-older.
   --execute                 PERMANENTLY and IRREVERSIBLY deletes sessions and all their
                             messages, parts, and events for --prune-older, or only events for
                             --prune-events-older. Without either prune flag, --execute is an error.
@@ -763,7 +772,7 @@ export function pruneSessions(db: Database, sessionIds: string[], dbPath: string
   return result;
 }
 
-const EVENT_RETENTION_DISK_RESERVE_BYTES = 8 * 1024 ** 3;
+const EVENT_RETENTION_OPERATIONAL_HEADROOM_BYTES = 8 * 1024 ** 3;
 
 export type EventPruneDependencies = {
   availableBytes?: (path: string) => number;
@@ -777,6 +786,8 @@ export type EventPruneResult = {
   event_sequence_rows_deleted: number;
   event_rows_deleted: number;
   estimated_reclaim: ReclaimEstimate;
+  operational_headroom_floor_bytes: number;
+  operational_headroom_floor_human: string;
   before: PruneResult["before"];
   after: PruneResult["after"];
   file_size_delta_bytes: number;
@@ -909,6 +920,39 @@ function sqlIdentifier(identifier: string): string {
   return `"${identifier.replaceAll('"', '""')}"`;
 }
 
+function hasIndexColumnPrefix(db: Database, table: PreservationTable, columns: readonly string[]): boolean {
+  type IndexListRow = { name?: unknown };
+  type IndexInfoRow = { seqno?: unknown; name?: unknown };
+
+  const indexes = db.query<IndexListRow, []>(`PRAGMA index_list(${sqlIdentifier(table)})`).all();
+  return indexes.some((index) => {
+    if (typeof index.name !== "string") return false;
+    const indexColumns = db
+      .query<IndexInfoRow, []>(`PRAGMA index_info(${sqlIdentifier(index.name)})`)
+      .all()
+      .sort((left, right) => Number(left.seqno ?? 0) - Number(right.seqno ?? 0))
+      .map((column) => column.name);
+
+    return columns.every((column, position) => indexColumns[position] === column);
+  });
+}
+
+function assertPreservationIndexes(db: Database): void {
+  const requirements: Array<{ table: PreservationTable; columns: readonly string[] }> = [
+    { table: "session", columns: ["id"] },
+    { table: "message", columns: ["session_id"] },
+    { table: "part", columns: ["session_id"] },
+  ];
+
+  for (const requirement of requirements) {
+    if (!hasIndexColumnPrefix(db, requirement.table, requirement.columns)) {
+      throw new Error(
+        `event-only preservation requires an index with column prefix (${requirement.columns.join(", ")}) on ${requirement.table}`,
+      );
+    }
+  }
+}
+
 function streamSelectedTableProof(
   db: Database,
   table: PreservationTable,
@@ -1039,11 +1083,14 @@ export function pruneEvents(
   const selectedTreeCount = countSessionTrees(db, sessionIds);
   const estimatedReclaim = estimateReclaim(db, sessionIds);
   const availableBytes = (dependencies.availableBytes ?? availableBytesForPath)(dirname(dbPath));
-  const requiredBytes = estimatedReclaim.event_bytes + EVENT_RETENTION_DISK_RESERVE_BYTES;
-  if (availableBytes < requiredBytes) {
+  if (availableBytes < EVENT_RETENTION_OPERATIONAL_HEADROOM_BYTES) {
     throw new Error(
-      `event-only retention requires ${bytesToHuman(requiredBytes)} usable disk space; only ${bytesToHuman(availableBytes)} available`,
+      `event-only retention requires ${bytesToHuman(EVENT_RETENTION_OPERATIONAL_HEADROOM_BYTES)} operational headroom; only ${bytesToHuman(availableBytes)} available`,
     );
+  }
+
+  if (sessionIds.length > 0) {
+    assertPreservationIndexes(db);
   }
 
   const before = captureDbSnapshot(db, dbPath);
@@ -1097,6 +1144,8 @@ export function pruneEvents(
     event_sequence_rows_deleted: eventSequenceRowsDeleted,
     event_rows_deleted: eventRowsDeleted,
     estimated_reclaim: estimatedReclaim,
+    operational_headroom_floor_bytes: EVENT_RETENTION_OPERATIONAL_HEADROOM_BYTES,
+    operational_headroom_floor_human: bytesToHuman(EVENT_RETENTION_OPERATIONAL_HEADROOM_BYTES),
     before,
     after,
     file_size_delta_bytes: fileSizeDelta,
@@ -1433,7 +1482,20 @@ async function runDbPruneExecute(options: CliOptions): Promise<SectionResult> {
   }
 }
 
-function eventRetentionDaysOrRefusal(days: number | null): SectionResult | null {
+function eventRetentionDaysOrRefusal(
+  days: number | null,
+  refusal: string | null,
+): SectionResult | null {
+  if (refusal != null) {
+    return {
+      label: "DB Event Prune (refused)",
+      data: {
+        mode: "event-only",
+        refused: true,
+        reason: refusal,
+      },
+    };
+  }
   if (days == null || Number.isFinite(days) && days >= 1) return null;
   return {
     label: "DB Event Prune (refused)",
@@ -1446,7 +1508,7 @@ function eventRetentionDaysOrRefusal(days: number | null): SectionResult | null 
 }
 
 async function runDbEventPruneDryRun(options: CliOptions): Promise<SectionResult> {
-  const invalid = eventRetentionDaysOrRefusal(options.pruneEventsOlderDays);
+  const invalid = eventRetentionDaysOrRefusal(options.pruneEventsOlderDays, options.pruneEventsOlderRefusal);
   if (invalid != null) return invalid;
 
   const days = options.pruneEventsOlderDays as number;
@@ -1476,6 +1538,8 @@ async function runDbEventPruneDryRun(options: CliOptions): Promise<SectionResult
         estimated_event_bytes: reclaim.event_bytes,
         estimated_file_size_delta_bytes: reclaim.event_bytes,
         reclaimed_file_size_delta_bytes: 0,
+        operational_headroom_floor_bytes: EVENT_RETENTION_OPERATIONAL_HEADROOM_BYTES,
+        operational_headroom_floor_human: bytesToHuman(EVENT_RETENTION_OPERATIONAL_HEADROOM_BYTES),
         reclaimable_estimate: reclaim,
         auto_vacuum: autoVacuum,
         notice: "DRY RUN — no changes. Re-run with --execute to delete event rows only.",
@@ -1489,7 +1553,7 @@ async function runDbEventPruneDryRun(options: CliOptions): Promise<SectionResult
 }
 
 async function runDbEventPruneExecute(options: CliOptions): Promise<SectionResult> {
-  const invalid = eventRetentionDaysOrRefusal(options.pruneEventsOlderDays);
+  const invalid = eventRetentionDaysOrRefusal(options.pruneEventsOlderDays, options.pruneEventsOlderRefusal);
   if (invalid != null) return invalid;
 
   const days = options.pruneEventsOlderDays as number;
@@ -1915,19 +1979,20 @@ function summarize(value: unknown, limit: number): unknown {
 
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2));
+  const eventPruneRequested = options.pruneEventsOlderDays != null || options.pruneEventsOlderRefusal != null;
 
   // DB-only path: if any db flag is present, skip server entirely.
   // Also route here if --execute is set alone (to give a clear error).
   const isDbMode =
     options.dbHealth ||
     options.pruneOlderDays != null ||
-    options.pruneEventsOlderDays != null ||
+    eventPruneRequested ||
     options.execute ||
     options.setIncrementalVacuum;
 
   if (isDbMode) {
     // Guard: --execute without either prune mode is a user error.
-    if (options.execute && options.pruneOlderDays == null && options.pruneEventsOlderDays == null) {
+    if (options.execute && options.pruneOlderDays == null && !eventPruneRequested) {
       console.error("Error: --execute requires --prune-older=<days> or --prune-events-older=<days>");
       process.exit(1);
     }
@@ -1941,7 +2006,7 @@ async function main(): Promise<void> {
       if (result.error != null) hasError = true;
     }
 
-    if (options.pruneOlderDays != null && options.pruneEventsOlderDays != null) {
+    if (options.pruneOlderDays != null && eventPruneRequested) {
       sections.push({
         label: "DB Event Prune (refused)",
         data: {
@@ -1967,7 +2032,7 @@ async function main(): Promise<void> {
       }
     }
 
-    if (options.pruneEventsOlderDays != null && options.pruneOlderDays == null) {
+    if (eventPruneRequested && options.pruneOlderDays == null) {
       const result = options.execute
         ? await runDbEventPruneExecute(options)
         : await runDbEventPruneDryRun(options);

--- a/.config/opencode/scripts/opencode-doctor.ts
+++ b/.config/opencode/scripts/opencode-doctor.ts
@@ -1,10 +1,20 @@
 #!/usr/bin/env bun
 import { spawn, type ChildProcess } from "node:child_process";
-import { statSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { statfsSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname } from "node:path";
 import { Database } from "bun:sqlite";
 import { createOpencodeClient } from "@opencode-ai/sdk";
+import {
+  bytesToHuman,
+  estimateReclaim,
+  selectOldSessionIds,
+  withSessionIdCandidateTable,
+  type ReclaimEstimate,
+} from "./lib/opencode-session-tree-retention";
+
+export { estimateReclaim, selectOldSessionIds, type ReclaimEstimate };
 
 type OutputFormat = "text" | "json";
 
@@ -23,6 +33,7 @@ type CliOptions = {
   // DB flags
   dbHealth: boolean;
   pruneOlderDays: number | null;
+  pruneEventsOlderDays: number | null;
   execute: boolean;
   dbPath: string;
   setIncrementalVacuum: boolean;
@@ -103,6 +114,7 @@ const KNOWN_FLAGS = new Set([
   // DB flags
   "--db-health",
   "--prune-older",
+  "--prune-events-older",
   "--execute",
   "--db-path",
   "--set-incremental-vacuum",
@@ -281,6 +293,23 @@ function parseArgs(argv: string[]): CliOptions {
     }
   }
 
+  const pruneEventsValue = args.get("--prune-events-older");
+  let pruneEventsOlderDays: number | null = null;
+  if (pruneEventsValue != null) {
+    if (pruneEventsValue === true) {
+      warnInvalidValue("--prune-events-older", "(missing)", "integer >= 1 (days)");
+      pruneEventsOlderDays = Number.NaN;
+    } else {
+      const parsed = Number(pruneEventsValue);
+      if (!Number.isFinite(parsed) || parsed < 1) {
+        warnInvalidValue("--prune-events-older", String(pruneEventsValue), "integer >= 1 (days)");
+        pruneEventsOlderDays = parsed;
+      } else {
+        pruneEventsOlderDays = parsed;
+      }
+    }
+  }
+
   const executeValue = args.get("--execute");
   const execute = executeValue != null && !isBooleanFalse(executeValue);
 
@@ -307,6 +336,7 @@ function parseArgs(argv: string[]): CliOptions {
     toolsModel: toolsModelValue != null && toolsModelValue !== true ? String(toolsModelValue) : undefined,
     dbHealth,
     pruneOlderDays,
+    pruneEventsOlderDays,
     execute,
     dbPath,
     setIncrementalVacuum,
@@ -343,9 +373,14 @@ DB Maintenance (no server required):
                             Tree-aware: a session tree (root + descendants via parent_id) is
                             only selected if no session in it was updated within the window.
                             Dry-run unless --execute. Deletion is IRREVERSIBLE.
+  --prune-events-older <days>
+                            Event-only retention: delete selected event streams while preserving
+                            sessions, messages, and parts. Tree-aware and dry-run by default.
+                            Requires auto_vacuum=INCREMENTAL for --execute; never runs full VACUUM.
+                            Mutually exclusive with --prune-older.
   --execute                 PERMANENTLY and IRREVERSIBLY deletes sessions and all their
-                            messages, parts, and events. Requires --prune-older.
-                            Without --prune-older, --execute is an error.
+                            messages, parts, and events for --prune-older, or only events for
+                            --prune-events-older. Without either prune flag, --execute is an error.
   --set-incremental-vacuum  One-time conversion: sets auto_vacuum=INCREMENTAL on the DB,
                             then runs a full VACUUM to rewrite the file with the new mode.
                             After this, future prunes can reclaim free pages incrementally
@@ -485,13 +520,6 @@ function formatErrorMessage(error: unknown): string {
 }
 
 // ─── DB Helpers ───────────────────────────────────────────────────────────────
-
-function bytesToHuman(bytes: number): string {
-  if (bytes >= 1e9) return `${(bytes / 1e9).toFixed(2)} GB`;
-  if (bytes >= 1e6) return `${(bytes / 1e6).toFixed(2)} MB`;
-  if (bytes >= 1e3) return `${(bytes / 1e3).toFixed(2)} KB`;
-  return `${bytes} B`;
-}
 
 function safeStatSize(path: string): number {
   try {
@@ -638,102 +666,6 @@ export function computeDbHealth(db: Database, dbPath: string): DbHealthData {
   };
 }
 
-/**
- * Select ids of all sessions belonging to "prunable" trees.
- *
- * A session tree (root + all descendants via parent_id) is prunable iff the
- * MAX(time_updated) across every session in the tree is older than cutoffMs —
- * i.e. no session in the tree has been used since the cutoff. If any member
- * was touched within the window, the entire tree is kept, including that
- * member's own stale siblings/ancestors/descendants.
- *
- * A session whose parent_id points at a nonexistent session (dangling
- * reference, e.g. after a prior partial prune) is treated as its own tree
- * root rather than causing an error or being silently dropped.
- */
-export function selectOldSessionIds(db: Database, cutoffMs: number): string[] {
-  type IdRow = { id: string };
-  const cutoffSec = Math.floor(cutoffMs / 1000);
-  const rows = db.query<IdRow, [number]>(`
-    WITH RECURSIVE tree(id, root_id) AS (
-      SELECT id, id FROM session
-      WHERE parent_id IS NULL OR parent_id NOT IN (SELECT id FROM session)
-      UNION ALL
-      SELECT s.id, t.root_id FROM session s JOIN tree t ON s.parent_id = t.id
-    ),
-    root_activity AS (
-      SELECT t.root_id, MAX(s.time_updated) AS last_used
-      FROM tree t JOIN session s ON s.id = t.id
-      GROUP BY t.root_id
-    )
-    SELECT t.id FROM tree t
-    JOIN root_activity ra ON ra.root_id = t.root_id
-    WHERE CAST(ra.last_used / 1000 AS INTEGER) < ?
-  `).all(cutoffSec);
-  return rows.map((r) => r.id);
-}
-
-export type ReclaimEstimate = {
-  part_bytes: number;
-  message_bytes: number;
-  event_bytes: number;
-  total_bytes: number;
-  part_human: string;
-  message_human: string;
-  event_human: string;
-  total_human: string;
-};
-
-export function estimateReclaim(db: Database, sessionIds: string[]): ReclaimEstimate {
-  if (sessionIds.length === 0) {
-    return {
-      part_bytes: 0, message_bytes: 0, event_bytes: 0, total_bytes: 0,
-      part_human: "0 B", message_human: "0 B", event_human: "0 B", total_human: "0 B",
-    };
-  }
-
-  // Use a temp table to avoid SQLite's bound-variable limit (SQLITE_MAX_VARIABLE_NUMBER).
-  // A giant IN (?,?,…) clause with thousands of ids will throw "too many SQL variables".
-  db.exec("CREATE TEMP TABLE IF NOT EXISTS _prune_ids (id TEXT PRIMARY KEY)");
-  db.exec("DELETE FROM _prune_ids");
-
-  const insertId = db.prepare("INSERT OR IGNORE INTO _prune_ids (id) VALUES (?)");
-  db.transaction(() => {
-    for (const id of sessionIds) insertId.run(id);
-  })();
-
-  type SumRow = { total: number | null };
-
-  // Use CAST(data AS BLOB) so length() returns byte count, not character count.
-  // SQLite's length() on TEXT counts Unicode code points; BLOB length is always bytes.
-  const partBytes = db.query<SumRow, []>(
-    "SELECT SUM(length(CAST(data AS BLOB))) AS total FROM part WHERE session_id IN (SELECT id FROM _prune_ids)"
-  ).get()?.total ?? 0;
-
-  const messageBytes = db.query<SumRow, []>(
-    "SELECT SUM(length(CAST(data AS BLOB))) AS total FROM message WHERE session_id IN (SELECT id FROM _prune_ids)"
-  ).get()?.total ?? 0;
-
-  const eventBytes = db.query<SumRow, []>(
-    "SELECT SUM(length(CAST(data AS BLOB))) AS total FROM event WHERE aggregate_id IN (SELECT id FROM _prune_ids)"
-  ).get()?.total ?? 0;
-
-  db.exec("DROP TABLE IF EXISTS _prune_ids");
-
-  const totalBytes = (partBytes ?? 0) + (messageBytes ?? 0) + (eventBytes ?? 0);
-
-  return {
-    part_bytes: partBytes ?? 0,
-    message_bytes: messageBytes ?? 0,
-    event_bytes: eventBytes ?? 0,
-    total_bytes: totalBytes,
-    part_human: bytesToHuman(partBytes ?? 0),
-    message_human: bytesToHuman(messageBytes ?? 0),
-    event_human: bytesToHuman(eventBytes ?? 0),
-    total_human: bytesToHuman(totalBytes),
-  };
-}
-
 export type PruneResult = {
   sessions_deleted: number;
   before: {
@@ -785,31 +717,21 @@ export function pruneSessions(db: Database, sessionIds: string[], dbPath: string
   let sessionsDeleted = 0;
 
   if (sessionIds.length > 0) {
-    // Populate a temp table to avoid SQLite's bound-variable limit.
-    // IN (?,?,…) with thousands of ids throws "too many SQL variables".
-    db.exec("CREATE TEMP TABLE IF NOT EXISTS _prune_ids (id TEXT PRIMARY KEY)");
-    db.exec("DELETE FROM _prune_ids");
+    withSessionIdCandidateTable(db, sessionIds, (tableName) => {
+      db.transaction(() => {
+        // Count sessions that actually exist in the DB (not just input list length).
+        type CountRow = { cnt: number };
+        const existingCount = db.query<CountRow, []>(
+          `SELECT COUNT(*) AS cnt FROM session WHERE id IN (SELECT id FROM ${tableName})`
+        ).get()?.cnt ?? 0;
+        sessionsDeleted = existingCount;
 
-    const insertId = db.prepare("INSERT OR IGNORE INTO _prune_ids (id) VALUES (?)");
-
-    db.transaction(() => {
-      // Bulk-load ids — one bind per statement, no variable-count limit.
-      for (const id of sessionIds) insertId.run(id);
-
-      // Count sessions that actually exist in the DB (not just input list length).
-      type CountRow = { cnt: number };
-      const existingCount = db.query<CountRow, []>(
-        "SELECT COUNT(*) AS cnt FROM session WHERE id IN (SELECT id FROM _prune_ids)"
-      ).get()?.cnt ?? 0;
-      sessionsDeleted = existingCount;
-
-      // Delete event_sequence (cascades to event) for these session ids.
-      db.exec("DELETE FROM event_sequence WHERE aggregate_id IN (SELECT id FROM _prune_ids)");
-      // Delete sessions (cascades to message, part via FK).
-      db.exec("DELETE FROM session WHERE id IN (SELECT id FROM _prune_ids)");
-    })();
-
-    db.exec("DROP TABLE IF EXISTS _prune_ids");
+        // Delete event_sequence (cascades to event) for these session ids.
+        db.exec(`DELETE FROM event_sequence WHERE aggregate_id IN (SELECT id FROM ${tableName})`);
+        // Delete sessions (cascades to message, part via FK).
+        db.exec(`DELETE FROM session WHERE id IN (SELECT id FROM ${tableName})`);
+      })();
+    });
   }
 
   // Checkpoint WAL then VACUUM to reclaim space (VACUUM must run outside a transaction).
@@ -841,6 +763,349 @@ export function pruneSessions(db: Database, sessionIds: string[], dbPath: string
   return result;
 }
 
+const EVENT_RETENTION_DISK_RESERVE_BYTES = 8 * 1024 ** 3;
+
+export type EventPruneDependencies = {
+  availableBytes?: (path: string) => number;
+  walCheckpoint?: (db: Database) => { busy: number };
+};
+
+export type EventPruneResult = {
+  mode: "event-only";
+  selected_tree_count: number;
+  selected_session_count: number;
+  event_sequence_rows_deleted: number;
+  event_rows_deleted: number;
+  estimated_reclaim: ReclaimEstimate;
+  before: PruneResult["before"];
+  after: PruneResult["after"];
+  file_size_delta_bytes: number;
+  file_size_delta_human: string;
+  vacuum_error?: string;
+};
+
+function availableBytesForPath(path: string): number {
+  const stats = statfsSync(path, { bigint: true });
+  return Number(stats.bsize * stats.bavail);
+}
+
+function countSessionTrees(db: Database, sessionIds: string[]): number {
+  if (sessionIds.length === 0) return 0;
+
+  return withSessionIdCandidateTable(db, sessionIds, (tableName) => {
+    type CountRow = { cnt: number };
+    return db.query<CountRow, []>(`
+      WITH RECURSIVE tree(id, root_id) AS (
+        SELECT s.id, s.id
+        FROM session AS s
+        WHERE s.parent_id IS NULL OR s.parent_id NOT IN (SELECT id FROM session)
+        UNION ALL
+        SELECT child.id, tree.root_id
+        FROM session AS child
+        JOIN tree ON child.parent_id = tree.id
+      )
+      SELECT COUNT(DISTINCT tree.root_id) AS cnt
+      FROM tree
+      JOIN ${tableName} AS candidate ON candidate.id = tree.id
+    `).get()?.cnt ?? 0;
+  });
+}
+
+function assertEventCascadeSchema(db: Database): void {
+  type ForeignKeyRow = {
+    table?: unknown;
+    from?: unknown;
+    to?: unknown;
+    on_delete?: unknown;
+  };
+  const foreignKeys = db.query<ForeignKeyRow, []>("PRAGMA foreign_key_list(event)").all();
+  const valid = foreignKeys.some((foreignKey) =>
+    foreignKey.table === "event_sequence" &&
+    foreignKey.from === "aggregate_id" &&
+    foreignKey.to === "aggregate_id" &&
+    String(foreignKey.on_delete).toUpperCase() === "CASCADE"
+  );
+  if (!valid) {
+    throw new Error("event schema must expose event.aggregate_id -> event_sequence.aggregate_id ON DELETE CASCADE");
+  }
+}
+
+function countSelectedEventRows(db: Database, tableName: string): { event: number; event_sequence: number } {
+  type CountRow = { cnt: number };
+  const eventSequence = db.query<CountRow, []>(
+    `SELECT COUNT(*) AS cnt FROM event_sequence WHERE aggregate_id IN (SELECT id FROM ${tableName})`,
+  ).get()?.cnt ?? 0;
+  const event = db.query<CountRow, []>(
+    `SELECT COUNT(*) AS cnt FROM event WHERE aggregate_id IN (SELECT id FROM ${tableName})`,
+  ).get()?.cnt ?? 0;
+  return { event, event_sequence: eventSequence };
+}
+
+type PreservationCounts = { session: number; message: number; part: number };
+type PreservationHashes = {
+  session: { identity: string; content: string };
+  message: { identity: string; content: string };
+  part: { identity: string; content: string };
+};
+
+type PreservationEvidence = {
+  global: PreservationCounts;
+  selected: PreservationCounts;
+  selected_hashes: PreservationHashes;
+};
+
+type PreservationTable = "session" | "message" | "part";
+type PreservationTableProof = {
+  count: number;
+  identity: string;
+  content: string;
+};
+
+function appendLengthPrefixedBytes(digest: ReturnType<typeof createHash>, bytes: Uint8Array): void {
+  const length = Buffer.allocUnsafe(8);
+  length.writeBigUInt64BE(BigInt(bytes.byteLength));
+  digest.update(length);
+  digest.update(bytes);
+}
+
+function appendFramedText(digest: ReturnType<typeof createHash>, value: string): void {
+  appendLengthPrefixedBytes(digest, Buffer.from(value, "utf8"));
+}
+
+function appendFramedValue(digest: ReturnType<typeof createHash>, value: unknown): void {
+  if (value == null) {
+    digest.update(Uint8Array.of(0));
+    return;
+  }
+
+  if (typeof value === "string") {
+    digest.update(Uint8Array.of(1));
+    appendLengthPrefixedBytes(digest, Buffer.from(value, "utf8"));
+    return;
+  }
+
+  if (value instanceof Uint8Array) {
+    digest.update(Uint8Array.of(2));
+    appendLengthPrefixedBytes(digest, value);
+    return;
+  }
+
+  if (typeof value === "bigint") {
+    digest.update(Uint8Array.of(3));
+    appendFramedText(digest, value.toString(10));
+    return;
+  }
+
+  if (typeof value === "number") {
+    digest.update(Uint8Array.of(4));
+    appendFramedText(digest, String(value));
+    return;
+  }
+
+  throw new Error(`unsupported SQLite value type in preservation proof: ${typeof value}`);
+}
+
+function sqlIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+function streamSelectedTableProof(
+  db: Database,
+  table: PreservationTable,
+  tableName: string,
+): PreservationTableProof {
+  type ColumnRow = { cid: number; name: string };
+  const columns: string[] = [];
+  for (const row of db.query<ColumnRow, []>(`PRAGMA table_info(${sqlIdentifier(table)})`).iterate()) {
+    columns.push(row.name);
+  }
+  if (columns.length === 0) {
+    throw new Error(`event-only preservation invariant failed: ${table} table has no columns`);
+  }
+
+  const identityDigest = createHash("sha256");
+  const contentDigest = createHash("sha256");
+  appendFramedText(identityDigest, "opencode-doctor-preservation-v1");
+  appendFramedText(identityDigest, table);
+  appendFramedText(identityDigest, "identity");
+  appendFramedText(contentDigest, "opencode-doctor-preservation-v1");
+  appendFramedText(contentDigest, table);
+  appendFramedText(contentDigest, "content");
+
+  const sessionColumn = table === "session" ? "id" : "session_id";
+  const columnList = columns.map(sqlIdentifier).join(", ");
+  const query = db.query<Record<string, unknown>, []>(`
+    SELECT ${columnList}
+    FROM ${sqlIdentifier(table)}
+    WHERE ${sqlIdentifier(sessionColumn)} IN (SELECT id FROM ${sqlIdentifier(tableName)})
+    ORDER BY ${sqlIdentifier("id")} COLLATE BINARY
+  `);
+
+  let count = 0;
+  for (const row of query.iterate()) {
+    count += 1;
+    appendFramedText(identityDigest, "row");
+    appendFramedText(contentDigest, "row");
+
+    for (const column of columns) {
+      const value = row[column];
+      if (column === "id") {
+        appendFramedText(identityDigest, column);
+        appendFramedValue(identityDigest, value);
+      }
+      appendFramedText(contentDigest, column);
+      appendFramedValue(contentDigest, value);
+    }
+  }
+
+  appendFramedText(identityDigest, "row-count");
+  appendFramedValue(identityDigest, count);
+  appendFramedText(contentDigest, "row-count");
+  appendFramedValue(contentDigest, count);
+
+  return {
+    count,
+    identity: identityDigest.digest("hex"),
+    content: contentDigest.digest("hex"),
+  };
+}
+
+function capturePreservationEvidence(db: Database, tableName: string): PreservationEvidence {
+  type CountRow = { cnt: number };
+  const count = (sql: string): number => db.query<CountRow, []>(sql).get()?.cnt ?? 0;
+  const selected = { session: 0, message: 0, part: 0 };
+  const selectedHashes = {
+    session: { identity: "", content: "" },
+    message: { identity: "", content: "" },
+    part: { identity: "", content: "" },
+  };
+
+  for (const table of ["session", "message", "part"] as const) {
+    const proof = streamSelectedTableProof(db, table, tableName);
+    selected[table] = proof.count;
+    selectedHashes[table] = { identity: proof.identity, content: proof.content };
+  }
+
+  return {
+    global: {
+      session: count("SELECT COUNT(*) AS cnt FROM session"),
+      message: count("SELECT COUNT(*) AS cnt FROM message"),
+      part: count("SELECT COUNT(*) AS cnt FROM part"),
+    },
+    selected,
+    selected_hashes: selectedHashes,
+  };
+}
+
+function assertPreservationCounts(
+  before: PreservationEvidence,
+  after: PreservationEvidence,
+): void {
+  for (const scope of ["global", "selected"] as const) {
+    for (const table of ["session", "message", "part"] as const) {
+      if (before[scope][table] !== after[scope][table]) {
+        throw new Error(`event-only preservation invariant failed for ${scope} ${table} rows`);
+      }
+    }
+  }
+  for (const table of ["session", "message", "part"] as const) {
+    if (
+      before.selected_hashes[table].identity !== after.selected_hashes[table].identity ||
+      before.selected_hashes[table].content !== after.selected_hashes[table].content
+    ) {
+      throw new Error(`event-only preservation invariant failed for selected ${table} identity/content`);
+    }
+  }
+}
+
+function walCheckpointTruncate(db: Database): { busy: number } {
+  const row = db.query<{ busy?: unknown }, []>("PRAGMA wal_checkpoint(TRUNCATE)").get();
+  return { busy: Number(row?.busy ?? 0) };
+}
+
+export function pruneEvents(
+  db: Database,
+  sessionIds: string[],
+  dbPath: string,
+  dependencies: EventPruneDependencies = {},
+): EventPruneResult {
+  db.exec("PRAGMA foreign_keys=ON");
+  const autoVacuum = Number(db.query<{ auto_vacuum?: unknown }, []>("PRAGMA auto_vacuum").get()?.auto_vacuum ?? 0);
+  if (autoVacuum !== 2) {
+    throw new Error("event-only retention requires auto_vacuum=INCREMENTAL");
+  }
+
+  assertEventCascadeSchema(db);
+  const selectedTreeCount = countSessionTrees(db, sessionIds);
+  const estimatedReclaim = estimateReclaim(db, sessionIds);
+  const availableBytes = (dependencies.availableBytes ?? availableBytesForPath)(dirname(dbPath));
+  const requiredBytes = estimatedReclaim.event_bytes + EVENT_RETENTION_DISK_RESERVE_BYTES;
+  if (availableBytes < requiredBytes) {
+    throw new Error(
+      `event-only retention requires ${bytesToHuman(requiredBytes)} usable disk space; only ${bytesToHuman(availableBytes)} available`,
+    );
+  }
+
+  const before = captureDbSnapshot(db, dbPath);
+  let eventSequenceRowsDeleted = 0;
+  let eventRowsDeleted = 0;
+
+  if (sessionIds.length > 0) {
+    withSessionIdCandidateTable(db, sessionIds, (tableName) => {
+      db.transaction(() => {
+        const preservedBefore = capturePreservationEvidence(db, tableName);
+        const selectedBefore = countSelectedEventRows(db, tableName);
+        db.exec(`DELETE FROM event_sequence WHERE aggregate_id IN (SELECT id FROM ${tableName})`);
+        const selectedAfter = countSelectedEventRows(db, tableName);
+        if (selectedAfter.event_sequence !== 0 || selectedAfter.event !== 0) {
+          throw new Error("event-only retention failed to remove all selected event rows");
+        }
+        assertPreservationCounts(preservedBefore, capturePreservationEvidence(db, tableName));
+        eventSequenceRowsDeleted = selectedBefore.event_sequence;
+        eventRowsDeleted = selectedBefore.event;
+      })();
+    });
+  }
+
+  const vacuumErrors: string[] = [];
+  const checkpoint = dependencies.walCheckpoint ?? walCheckpointTruncate;
+  const runCheckpoint = (label: string): void => {
+    try {
+      const result = checkpoint(db);
+      if (result.busy !== 0) {
+        throw new Error(`busy=${result.busy}`);
+      }
+    } catch (error) {
+      vacuumErrors.push(`${label} checkpoint: ${formatErrorMessage(error)}`);
+    }
+  };
+  runCheckpoint("initial");
+  try {
+    db.exec("PRAGMA incremental_vacuum");
+  } catch (error) {
+    vacuumErrors.push(`incremental_vacuum: ${formatErrorMessage(error)}`);
+  }
+  runCheckpoint("final");
+
+  const after = captureDbSnapshot(db, dbPath);
+
+  const fileSizeDelta = Math.max(0, before.file_size_bytes - after.file_size_bytes);
+  const result: EventPruneResult = {
+    mode: "event-only",
+    selected_tree_count: selectedTreeCount,
+    selected_session_count: sessionIds.length,
+    event_sequence_rows_deleted: eventSequenceRowsDeleted,
+    event_rows_deleted: eventRowsDeleted,
+    estimated_reclaim: estimatedReclaim,
+    before,
+    after,
+    file_size_delta_bytes: fileSizeDelta,
+    file_size_delta_human: bytesToHuman(fileSizeDelta),
+  };
+  if (vacuumErrors.length > 0) result.vacuum_error = vacuumErrors.join("; ");
+  return result;
+}
+
 /**
  * Classify a pgrep exit code into a process-check result.
  * Exported for unit testing.
@@ -854,8 +1119,16 @@ export function classifyPgrepExitCode(exitCode: number | null): "has_procs" | "n
   return "error";
 }
 
-function checkForOtherOpencodeProcesses(): { safe: boolean; count: number; pids: number[] } {
-  const result = Bun.spawnSync(["pgrep", "-f", "opencode"]);
+export type ProcessCheckDependencies = {
+  ownPid?: number;
+  spawnSync?: (args: string[]) => { exitCode: number | null; stdout?: unknown };
+};
+
+export function checkForOtherOpencodeProcesses(
+  dependencies: ProcessCheckDependencies = {},
+): { safe: boolean; count: number; pids: number[] } {
+  const spawnSync = dependencies.spawnSync ?? ((args: string[]) => Bun.spawnSync(args));
+  const result = spawnSync(["pgrep", "-f", "opencode"]);
   const classification = classifyPgrepExitCode(result.exitCode);
 
   if (classification === "error") {
@@ -871,25 +1144,11 @@ function checkForOtherOpencodeProcesses(): { safe: boolean; count: number; pids:
     ? result.stdout.toString("utf8")
     : String(result.stdout ?? "");
 
-  const ownPid = process.pid;
-  // Get parent PID via /proc or ps
-  let parentPid: number | null = null;
-  try {
-    const ppidResult = Bun.spawnSync(["ps", "-o", "ppid=", "-p", String(ownPid)]);
-    if (ppidResult.exitCode === 0) {
-      const ppidOut = ppidResult.stdout instanceof Buffer
-        ? ppidResult.stdout.toString("utf8")
-        : String(ppidResult.stdout ?? "");
-      parentPid = parseInt(ppidOut.trim(), 10) || null;
-    }
-  } catch {
-    // ignore
-  }
-
+  const ownPid = dependencies.ownPid ?? process.pid;
   const pids = output
     .split("\n")
     .map((line) => parseInt(line.trim(), 10))
-    .filter((pid) => !isNaN(pid) && pid !== ownPid && pid !== parentPid);
+    .filter((pid) => !isNaN(pid) && pid !== ownPid);
 
   return { safe: pids.length === 0, count: pids.length, pids };
 }
@@ -1169,6 +1428,109 @@ async function runDbPruneExecute(options: CliOptions): Promise<SectionResult> {
     return { label: "DB Prune (executed)", data };
   } catch (error) {
     return { label: "DB Prune (executed)", data: null, error: formatErrorMessage(error) };
+  } finally {
+    db?.close();
+  }
+}
+
+function eventRetentionDaysOrRefusal(days: number | null): SectionResult | null {
+  if (days == null || Number.isFinite(days) && days >= 1) return null;
+  return {
+    label: "DB Event Prune (refused)",
+    data: {
+      mode: "event-only",
+      refused: true,
+      reason: `--prune-events-older must be >= 1 day (got ${String(days)}).`,
+    },
+  };
+}
+
+async function runDbEventPruneDryRun(options: CliOptions): Promise<SectionResult> {
+  const invalid = eventRetentionDaysOrRefusal(options.pruneEventsOlderDays);
+  if (invalid != null) return invalid;
+
+  const days = options.pruneEventsOlderDays as number;
+  const cutoffMs = Date.now() - days * 24 * 3600 * 1000;
+  const cutoffDate = new Date(cutoffMs).toISOString().slice(0, 10);
+  let db: Database | null = null;
+  try {
+    const uri = "file:" + options.dbPath + "?mode=ro";
+    db = new Database(uri, { readonly: true });
+    db.exec("PRAGMA busy_timeout=5000");
+
+    const sessionIds = await withSqliteBusyRetry(() => selectOldSessionIds(db!, cutoffMs));
+    const reclaim = await withSqliteBusyRetry(() => estimateReclaim(db!, sessionIds));
+    const selectedTreeCount = countSessionTrees(db, sessionIds);
+    const autoVacuum = Number(db.query<{ auto_vacuum?: unknown }, []>("PRAGMA auto_vacuum").get()?.auto_vacuum ?? 0);
+
+    return {
+      label: "DB Event Prune (dry-run)",
+      data: {
+        mode: "event-only",
+        cutoff_date: cutoffDate,
+        prune_events_older_than_days: days,
+        selected_tree_count: selectedTreeCount,
+        selected_session_count: sessionIds.length,
+        deleted_event_rows: 0,
+        deleted_event_sequence_rows: 0,
+        estimated_event_bytes: reclaim.event_bytes,
+        estimated_file_size_delta_bytes: reclaim.event_bytes,
+        reclaimed_file_size_delta_bytes: 0,
+        reclaimable_estimate: reclaim,
+        auto_vacuum: autoVacuum,
+        notice: "DRY RUN — no changes. Re-run with --execute to delete event rows only.",
+      },
+    };
+  } catch (error) {
+    return { label: "DB Event Prune (dry-run)", data: null, error: formatErrorMessage(error) };
+  } finally {
+    db?.close();
+  }
+}
+
+async function runDbEventPruneExecute(options: CliOptions): Promise<SectionResult> {
+  const invalid = eventRetentionDaysOrRefusal(options.pruneEventsOlderDays);
+  if (invalid != null) return invalid;
+
+  const days = options.pruneEventsOlderDays as number;
+  const cutoffMs = Date.now() - days * 24 * 3600 * 1000;
+  const cutoffDate = new Date(cutoffMs).toISOString().slice(0, 10);
+  const procRefusal = refuseIfOtherOpencodeProcesses();
+  if (procRefusal != null) {
+    return {
+      label: "DB Event Prune (refused)",
+      data: { mode: "event-only", ...procRefusal },
+    };
+  }
+
+  let db: Database | null = null;
+  try {
+    db = new Database(options.dbPath);
+    db.exec("PRAGMA busy_timeout=5000");
+    db.exec("PRAGMA foreign_keys=ON");
+    const sessionIds = await withSqliteBusyRetry(() => selectOldSessionIds(db!, cutoffMs));
+    const result = pruneEvents(db, sessionIds, options.dbPath);
+    const data = {
+      cutoff_date: cutoffDate,
+      prune_events_older_than_days: days,
+      estimated_event_bytes: result.estimated_reclaim.event_bytes,
+      estimated_file_size_delta_bytes: result.estimated_reclaim.event_bytes,
+      reclaimed_file_size_delta_bytes: result.file_size_delta_bytes,
+      ...result,
+    };
+    return {
+      label: result.vacuum_error == null ? "DB Event Prune (executed)" : "DB Event Prune (failed)",
+      data,
+    };
+  } catch (error) {
+    return {
+      label: "DB Event Prune (refused)",
+      data: {
+        mode: "event-only",
+        refused: true,
+        reason: formatErrorMessage(error),
+      },
+    };
   } finally {
     db?.close();
   }
@@ -1556,12 +1918,17 @@ async function main(): Promise<void> {
 
   // DB-only path: if any db flag is present, skip server entirely.
   // Also route here if --execute is set alone (to give a clear error).
-  const isDbMode = options.dbHealth || options.pruneOlderDays != null || options.execute || options.setIncrementalVacuum;
+  const isDbMode =
+    options.dbHealth ||
+    options.pruneOlderDays != null ||
+    options.pruneEventsOlderDays != null ||
+    options.execute ||
+    options.setIncrementalVacuum;
 
   if (isDbMode) {
-    // Guard: --execute without --prune-older is a user error
-    if (options.execute && options.pruneOlderDays == null) {
-      console.error("Error: --execute requires --prune-older=<days>. Example: --prune-older=30 --execute");
+    // Guard: --execute without either prune mode is a user error.
+    if (options.execute && options.pruneOlderDays == null && options.pruneEventsOlderDays == null) {
+      console.error("Error: --execute requires --prune-older=<days> or --prune-events-older=<days>");
       process.exit(1);
     }
 
@@ -1574,7 +1941,17 @@ async function main(): Promise<void> {
       if (result.error != null) hasError = true;
     }
 
-    if (options.pruneOlderDays != null) {
+    if (options.pruneOlderDays != null && options.pruneEventsOlderDays != null) {
+      sections.push({
+        label: "DB Event Prune (refused)",
+        data: {
+          mode: "event-only",
+          refused: true,
+          reason: "--prune-events-older and --prune-older are mutually exclusive",
+        },
+      });
+      hasError = true;
+    } else if (options.pruneOlderDays != null) {
       if (options.execute) {
         const result = await runDbPruneExecute(options);
         sections.push(result);
@@ -1587,6 +1964,20 @@ async function main(): Promise<void> {
         const result = await runDbPruneDryRun(options);
         sections.push(result);
         if (result.error != null) hasError = true;
+      }
+    }
+
+    if (options.pruneEventsOlderDays != null && options.pruneOlderDays == null) {
+      const result = options.execute
+        ? await runDbEventPruneExecute(options)
+        : await runDbEventPruneDryRun(options);
+      sections.push(result);
+      if (result.error != null) hasError = true;
+      if (isPlainObject(result.data) && (result.data as { refused?: boolean }).refused) {
+        hasError = true;
+      }
+      if (isPlainObject(result.data) && (result.data as { vacuum_error?: unknown }).vacuum_error != null) {
+        hasError = true;
       }
     }
 

--- a/.dotfiles/docs/opencode-doctor.md
+++ b/.dotfiles/docs/opencode-doctor.md
@@ -47,7 +47,8 @@ bun ~/.config/opencode/scripts/opencode-doctor.ts [options]
 | `--tools-model`    | `<string>`     | Model ID for tool schemas               | -           |
 | `--db-health`      | -              | Read-only DB maintenance metrics        | -           |
 | `--prune-older`    | `<days>`       | Prune sessions older than N days (dry-run unless `--execute`) | `30` |
-| `--execute`        | -              | Required to perform the irreversible prune + VACUUM | -   |
+| `--prune-events-older` | `<days>`   | Prune event streams for old session trees (dry-run unless `--execute`) | - |
+| `--execute`        | -              | Required to perform the requested prune; session pruning runs full `VACUUM` | -   |
 | `--db-path`        | `<path>`       | Override DB path                        | `~/.local/share/opencode/opencode.db` |
 | `--help`, `-h`     | -              | Show help message                       | -           |
 
@@ -113,7 +114,8 @@ OpenCode never prunes its SQLite session DB (`~/.local/share/opencode/opencode.d
 
 - `--db-health` — read-only metrics: file/WAL/shm sizes, page and freelist counts, free %, journal mode, `auto_vacuum`, per-table row counts, and a session age histogram. Safe to run anytime.
 - `--prune-older=<days>` — **dry-run by default**: reports how many sessions have not been used in `<days>` and the reclaimable bytes per table. Deletes nothing without `--execute`. Selection is based on last-use (`time_updated`), not creation time, and is tree-aware: a session tree (root + all descendants via `parent_id`) is only selected if *no* session in the tree was touched within the window — one active leaf keeps the whole tree.
-- `--prune-older=<days> --execute` — **IRREVERSIBLE.** Deletes old sessions and their messages, parts, and events, then runs `VACUUM` to reclaim space. Refuses to run if other OpenCode processes are active (a full VACUUM needs exclusive access), if free disk is below ~1.1× the DB size, or if `<days>` is less than 1.
+- `--prune-older=<days> --execute` — **IRREVERSIBLE.** Deletes old sessions and their messages, parts, and events, then runs `VACUUM` to reclaim space. Refuses to run if other OpenCode processes are active (a full VACUUM needs exclusive access), if the current free-space check cannot satisfy the calculated working-space budget, or if `<days>` is less than 1.
+- `--prune-events-older=<days>` — **dry-run by default**: reports event streams selected from session trees not used in `<days>`, while preserving sessions, messages, and parts. `--execute` requires no active OpenCode process and `auto_vacuum=INCREMENTAL`; it deletes only the selected event streams, runs checkpointing plus `PRAGMA incremental_vacuum`, and never runs a full `VACUUM`. The event-only and whole-session prune modes are mutually exclusive.
 
 ```bash
 # Inspect DB health
@@ -124,6 +126,12 @@ mise run opencode:doctor -- --prune-older=30
 
 # Actually prune + VACUUM (close all other OpenCode instances first)
 mise run opencode:doctor -- --prune-older=30 --execute
+
+# Preview event-only pruning (no changes)
+mise run opencode:doctor -- --prune-events-older=30
+
+# Actually prune event streams only (close all other OpenCode instances first)
+mise run opencode:doctor -- --prune-events-older=30 --execute
 ```
 
 Pruning events is only safe for local-first usage — `event` rows back OpenCode's sync / cross-device replay / history features. See `docs/solutions/2026-06-25-opencode-sqlite-db-bloat-prune-vacuum.md` for the full safety contract.

--- a/.dotfiles/docs/opencode-doctor.md
+++ b/.dotfiles/docs/opencode-doctor.md
@@ -47,8 +47,9 @@ bun ~/.config/opencode/scripts/opencode-doctor.ts [options]
 | `--tools-model`    | `<string>`     | Model ID for tool schemas               | -           |
 | `--db-health`      | -              | Read-only DB maintenance metrics        | -           |
 | `--prune-older`    | `<days>`       | Prune sessions older than N days (dry-run unless `--execute`) | `30` |
-| `--prune-events-older` | `<days>`   | Prune event streams for old session trees (dry-run unless `--execute`) | - |
+| `--prune-events-older` | `<days>`   | Event-only prune; preserves sessions/messages/parts, uses incremental vacuum, and reports an 8 GiB operational headroom floor | - |
 | `--execute`        | -              | Required to perform the requested prune; session pruning runs full `VACUUM` | -   |
+| `--set-incremental-vacuum` | -        | One-time conversion to `auto_vacuum=INCREMENTAL`; runs a full `VACUUM` | - |
 | `--db-path`        | `<path>`       | Override DB path                        | `~/.local/share/opencode/opencode.db` |
 | `--help`, `-h`     | -              | Show help message                       | -           |
 
@@ -115,7 +116,7 @@ OpenCode never prunes its SQLite session DB (`~/.local/share/opencode/opencode.d
 - `--db-health` — read-only metrics: file/WAL/shm sizes, page and freelist counts, free %, journal mode, `auto_vacuum`, per-table row counts, and a session age histogram. Safe to run anytime.
 - `--prune-older=<days>` — **dry-run by default**: reports how many sessions have not been used in `<days>` and the reclaimable bytes per table. Deletes nothing without `--execute`. Selection is based on last-use (`time_updated`), not creation time, and is tree-aware: a session tree (root + all descendants via `parent_id`) is only selected if *no* session in the tree was touched within the window — one active leaf keeps the whole tree.
 - `--prune-older=<days> --execute` — **IRREVERSIBLE.** Deletes old sessions and their messages, parts, and events, then runs `VACUUM` to reclaim space. Refuses to run if other OpenCode processes are active (a full VACUUM needs exclusive access), if the current free-space check cannot satisfy the calculated working-space budget, or if `<days>` is less than 1.
-- `--prune-events-older=<days>` — **dry-run by default**: reports event streams selected from session trees not used in `<days>`, while preserving sessions, messages, and parts. `--execute` requires no active OpenCode process and `auto_vacuum=INCREMENTAL`; it deletes only the selected event streams, runs checkpointing plus `PRAGMA incremental_vacuum`, and never runs a full `VACUUM`. The event-only and whole-session prune modes are mutually exclusive.
+- `--prune-events-older=<days>` — **dry-run by default**: reports event streams selected from session trees not used in `<days>`, while preserving sessions, messages, and parts. `--execute` requires no active OpenCode process, preservation indexes, `auto_vacuum=INCREMENTAL`, and a fixed 8 GiB operational headroom floor; it deletes only selected event streams, checkpoints, runs `PRAGMA incremental_vacuum`, and never runs a full `VACUUM`. The event-only and whole-session prune modes are mutually exclusive.
 
 ```bash
 # Inspect DB health


### PR DESCRIPTION
## Summary
This adds tree-aware stale-session selection shared across retention paths and introduces an event-only OpenCode doctor mode that preserves sessions, messages, and parts while pruning selected event streams. Session tree pruning remains tree-aware so a stale decision applies to an entire session tree only when no descendant is still considered active.

## Safety
This change keeps destructive operations opt-in: both retention modes are dry-run by default. Execution requires no active OpenCode process and, for event-only mode, `auto_vacuum=INCREMENTAL` plus checkpoint/`incremental_vacuum` behavior before reporting reclaimed bytes. The implementation uses selection by candidate IDs and transactional deletion of only selected rows, with checkpoint status validation. Session mode still uses full-DB vacuum after session/message/part deletions; event-only mode never runs a full `VACUUM`.

## Verification
- 21 targeted retention tests passed.
- Full `opencode-doctor` test suite passed.
- Strict module-scoped TypeScript check passed for the touched module surface used in this change set.
- Help output, dry-run behavior, and diff hygiene checks passed.

## Operational result
A production execution run confirmed the selected event rows were deleted as expected under event-only mode, but reclaiming database file size did not complete successfully and returned a failure state; the change preserves and reports that post-mutation failure instead of implying reclaim success.
