### PR TITLE
chore(opencode): update model assignments and bump systematic plugin

### DIFF
--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -36,8 +36,8 @@
         "mcps": []
       },
       "fixer": {
-        "model": "openai/gpt-5.6-luna",
-        "variant": "xhigh",
+        "model": "anthropic/claude-sonnet-4-6",
+        "variant": "high",
         "skills": ["agent-browser", "impeccable", "systematic:*"],
         "mcps": []
       }
@@ -98,13 +98,13 @@
         "model": "openai/gpt-5.6-sol"
       },
       "librarian": {
-        "model": "openai/gpt-5.6-luna",
+        "model": "github-copilot/gpt-5.4-mini",
         "variant": "low",
         "skills": [],
         "mcps": ["websearch", "context7", "grep_app"]
       },
       "explorer": {
-        "model": "openai/gpt-5.6-luna",
+        "model": "github-copilot/gpt-5.4-mini",
         "variant": "low",
         "skills": [],
         "mcps": []
@@ -138,13 +138,13 @@
         "model": "openai/gpt-5.6-sol"
       },
       "librarian": {
-        "model": "openai/gpt-5.6-luna",
+        "model": "github-copilot/gpt-5.4-mini",
         "variant": "low",
         "skills": [],
         "mcps": ["websearch", "context7", "grep_app"]
       },
       "explorer": {
-        "model": "openai/gpt-5.6-luna",
+        "model": "github-copilot/gpt-5.4-mini",
         "variant": "low",
         "skills": [],
         "mcps": []

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -6,7 +6,7 @@
     "oh-my-opencode-slim@2.2.8",
     "@cortexkit/opencode-magic-context@0.33.0",
     "@cortexkit/aft-opencode@0.48.1",
-    "@fro.bot/systematic@3.3.0"
+    "@fro.bot/systematic@3.3.1"
   ],
   "mcp": {
     "context7": {

--- a/.config/opencode/systematic.jsonc
+++ b/.config/opencode/systematic.jsonc
@@ -25,9 +25,9 @@
       "model": "github-copilot/gemini-3.5-flash"
     },
     "systematic-implementer": {
-      "model": "openai/gpt-5.6-luna",
-      "variant": "xhigh",
-      "temperature": 0.1
+      "model": "anthropic/claude-sonnet-4-6",
+      "variant": "high",
+      "temperature": 0
     }
   }
 }


### PR DESCRIPTION
- switch fixer agent from openai/gpt-5.6-luna (xhigh) to anthropic/claude-sonnet-4-6 (high) in oh-my-opencode-slim.jsonc
- reassign librarian and explorer agents (both persona groups) from openai/gpt-5.6-luna to github-copilot/gpt-5.4-mini (low)
- switch systematic-implementer from openai/gpt-5.6-luna (xhigh) to anthropic/claude-sonnet-4-6 (high, temperature 0) in systematic.jsonc
- bump @fro.bot/systematic plugin from 3.3.0 to 3.3.1 in opencode.json