### PR TITLE
chore(opencode): align configs with 1.1.2

### DIFF
--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/oh-my-opencode-slim@latest/oh-my-opencode-slim.schema.json",
+  "$schema": "https://unpkg.com/oh-my-opencode-slim@1.1.2/oh-my-opencode-slim.schema.json",
   "preset": "openai",
   "presets": {
     "openai": {
@@ -19,13 +19,13 @@
         "model": "openai/gpt-5.6-sol"
       },
       "librarian": {
-        "model": "openai/gpt-5.6-luna",
+        "model": "github-copilot/gpt-5.4-mini",
         "variant": "low",
         "skills": [],
         "mcps": ["websearch", "context7", "grep_app"]
       },
       "explorer": {
-        "model": "openai/gpt-5.6-luna",
+        "model": "github-copilot/gpt-5.4-mini",
         "variant": "low",
         "skills": [],
         "mcps": []
@@ -173,9 +173,10 @@
       "mcps": []
     }
   },
-  "backgroundJobs": {
-    "continueOnIdle": false
-  },
+  // Only valid in oh-my-opencode-slim v2
+  // "backgroundJobs": {
+  //   "continueOnIdle": false
+  // },
   "council": {
     "presets": {
       "default": {

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -3,7 +3,7 @@
   "plugin": [
     "@cortexkit/opencode-anthropic-auth@1.18.0",
     "@cortexkit/opencode-openai-auth@0.4.3",
-    "oh-my-opencode-slim@2.2.8",
+    "oh-my-opencode-slim@1.1.2",
     "@cortexkit/opencode-magic-context@0.33.0",
     "@cortexkit/aft-opencode@0.48.1",
     "@fro.bot/systematic@3.3.1"

--- a/.config/opencode/systematic.jsonc
+++ b/.config/opencode/systematic.jsonc
@@ -26,8 +26,7 @@
     },
     "systematic-implementer": {
       "model": "anthropic/claude-sonnet-4-6",
-      "variant": "high",
-      "temperature": 0
+      "variant": "high"
     }
   }
 }


### PR DESCRIPTION
- pin oh-my-opencode-slim to 1.1.2 in the main OpenCode config
- update librarian and explorer presets to use github-copilot/gpt-5.4-mini
- remove the unsupported backgroundJobs block and legacy temperature setting for compatibility