### PR TITLE
docs(opencode): refresh event retention learning

### DIFF
--- a/.dotfiles/docs/solutions/2026-06-25-opencode-sqlite-db-bloat-prune-vacuum.md
+++ b/.dotfiles/docs/solutions/2026-06-25-opencode-sqlite-db-bloat-prune-vacuum.md
@@ -1,14 +1,17 @@
 ---
-title: OpenCode SQLite DB bloat — prune old sessions then VACUUM
+title: OpenCode SQLite event bloat and bounded retention
 date: 2026-06-25
-category: docs/solutions/performance-issues/
-module: opencode
-problem_type: performance_issue
+last_updated: 2026-07-30
+category: docs/solutions/database-issues/
+module: opencode-doctor
+problem_type: database_issue
 component: tooling
 symptoms:
-  - OpenCode SQLite DB (~/.local/share/opencode/opencode.db) grew to ~13 GB
-  - perceived slowness running multiple concurrent OpenCode instances
-  - VACUUM alone reclaimed nothing (freelist_count=0, auto_vacuum=NONE)
+  - OpenCode SQLite storage grew into tens of GiB, with the event table dominating overflow pages
+  - VACUUM reclaimed nothing while the database contained no free pages
+  - session-tree pruning alone did not materially reduce recent event storage
+  - the first event-only production run exhausted memory before issuing DELETE
+  - a later run deleted event rows but returned failure before physical file-size reclaim
 root_cause: missing_tooling
 resolution_type: tooling_addition
 severity: high
@@ -18,126 +21,215 @@ related_components:
 tags:
   - opencode
   - sqlite
-  - vacuum
+  - event-retention
   - db-bloat
-  - prune
+  - incremental-vacuum
   - bun-sqlite
-  - maintenance
+  - bounded-memory
 ---
 
-# OpenCode SQLite DB bloat — prune old sessions then VACUUM
+# OpenCode SQLite event bloat and bounded retention
 
 ## Problem
 
-OpenCode's session DB at `~/.local/share/opencode/opencode.db` grew to ~13 GB
-over ~6 months, raising performance concern with multiple concurrent OpenCode
-instances. OpenCode has no built-in retention/prune path, so the DB grows
-unbounded.
+OpenCode stores sessions, messages, parts, and an event-sourcing log in a local
+SQLite database. It has no built-in retention policy, so the database grows
+without bound. Inspection with `dbstat` showed that `event` overflow pages—not
+stale session metadata—were the dominant storage consumer.
+
+The maintenance path therefore needed two distinct modes:
+
+- delete entire stale session trees when transcript removal is acceptable;
+- delete only stale event streams while preserving sessions, messages, and
+  parts.
+
+Logical deletion and physical disk reclamation are separate outcomes. The
+event-only deletion path is implemented and safety-gated, but the observed
+production run did not return database file space to the filesystem.
 
 ## Symptoms
 
-- DB at ~13 GB; perf concern with multiple running OpenCode processes.
-- `PRAGMA freelist_count` = 0 and `PRAGMA auto_vacuum` = NONE → `VACUUM` reclaims
-  nothing because there are no free pages; all 13 GB is live data.
-- `dbstat` breakdown: `event` ~6.7 GB, `part` ~4.9 GB, `message` ~0.7 GB.
+- The database grew into tens of GiB, with `event` dominating `part`, `message`,
+  and `session` storage.
+- `PRAGMA freelist_count = 0` meant a VACUUM-first attempt had no free pages to
+  reclaim; the stored rows were live data, not fragmentation.
+- Tree-aware session pruning reclaimed far less than expected because recent
+  session trees still retained large event histories.
+- The first event-only execution exhausted Bun's heap before deletion.
+- After the memory fix, an execution deleted selected event rows but returned a
+  failed result before file-size reclaim; the reported reclaimed delta remained
+  zero.
 
 ## What Didn't Work
 
-- **VACUUM-first premise (wrong).** The initial assumption was that VACUUM would
-  shrink the file. With `freelist_count = 0` it reclaims ~0 bytes — the bloat is
-  live data, not fragmentation. The WAL was also healthy (~2–4 MB), so
-  `wal_checkpoint(TRUNCATE)` was marginal too.
-- **Age-bucket queries without an integer cast.** `time_created` is epoch
-  **milliseconds**; comparing `time_created/1000` against `strftime('%s', ...)`
-  without `CAST(... AS INTEGER)` triggers SQLite's numeric-vs-text comparison and
-  silently buckets every row into one group.
-- **Giant `IN (?,?,...)` clauses.** With thousands of session ids this hits
-  `SQLITE_MAX_VARIABLE_NUMBER` (~32766 in Bun's build, 999 in older builds).
-- **`length(data)` for byte sizes.** Counts characters, not bytes, for non-ASCII.
-- **Treating a `pgrep` failure as "safe".** A non-0/non-1 exit (e.g. pgrep
-  unavailable) means "can't verify" and must be treated as unsafe, not safe.
+- **VACUUM before retention.** VACUUM compacts free pages; it does not create
+  free pages from live data.
+- **Session pruning as the only retention mechanism.** It removes transcripts
+  along with events and does not address event growth for retained sessions.
+- **A clone-only compatibility probe.** It added implementation overhead without
+  advancing the operator's storage-reclamation task, so it was removed.
+- **Materializing preservation evidence.** `SELECT * ... .all()` loaded every
+  selected session, message, and part payload into JavaScript. Canonical arrays,
+  sorting, and `JSON.stringify` then duplicated that data several times and
+  exhausted memory before the first `DELETE`.
+- **Client-side session graph construction.** Loading all session relationships
+  into a `Map` increased memory pressure unnecessarily.
+- **Giant variable-bound `IN` clauses.** Large candidate sets can exceed
+  SQLite's variable limit; temporary tables are safer and easier to reuse.
+- **Assuming incremental vacuum guarantees shrinkage.** Successful row deletion
+  does not prove checkpointing, file truncation, APFS allocation release, or
+  increased host free space.
 
 ## Solution
 
-Pruning old sessions creates free pages; VACUUM then compacts the file.
-Implemented as a DB-maintenance mode in
-`~/.config/opencode/scripts/opencode-doctor.ts`, run via
-`mise run opencode:doctor -- <flags>`:
+The supported implementation lives in:
 
-- `--db-health` — read-only metrics (sizes, page/freelist counts, free %,
-  journal mode, auto_vacuum, per-table row counts, session age histogram).
-- `--prune-older=<days>` (default 30) — **dry-run by default**: reports sessions
-  to delete and reclaimable bytes per table. Deletes nothing.
-- `--prune-older=<days> --execute` — **IRREVERSIBLE**: prune + checkpoint + VACUUM.
+- `.config/opencode/scripts/lib/opencode-session-tree-retention.ts`
+- `.config/opencode/scripts/opencode-doctor.ts`
+- `.config/opencode/scripts/opencode-doctor.test.ts`
 
-Cascade order (verified against OpenCode's own delete in `core/event.ts`):
+### Select complete trees by last use
+
+Session retention groups roots and descendants through `parent_id`, then uses
+the maximum `time_updated` across each tree. One recently touched descendant
+protects the entire tree.
 
 ```sql
--- session -> message, part cascade via FK ON DELETE CASCADE.
--- event keys off aggregate_id = session.id with NO session FK, so delete it
--- explicitly via event_sequence (which cascades to event).
-DELETE FROM event_sequence WHERE aggregate_id IN (SELECT id FROM _prune_ids);
-DELETE FROM session        WHERE id           IN (SELECT id FROM _prune_ids);
--- then, OUTSIDE the transaction:
-PRAGMA wal_checkpoint(TRUNCATE);
-VACUUM;
+WITH RECURSIVE tree(id, root_id) AS (
+  SELECT id, id
+  FROM session
+  WHERE parent_id IS NULL
+     OR parent_id NOT IN (SELECT id FROM session)
+
+  UNION ALL
+
+  SELECT child.id, tree.root_id
+  FROM session AS child
+  JOIN tree ON child.parent_id = tree.id
+),
+root_activity AS (
+  SELECT tree.root_id, MAX(session.time_updated) AS last_used
+  FROM tree
+  JOIN session ON session.id = tree.id
+  GROUP BY tree.root_id
+)
+SELECT tree.id
+FROM tree
+JOIN root_activity USING (root_id)
+WHERE CAST(last_used / 1000 AS INTEGER) < ?;
 ```
 
-Safety gates on `--execute`:
+Timestamps are epoch milliseconds. Cast the divided value to an integer before
+comparing it with an epoch-second cutoff.
 
-- Refuse if other `opencode` processes run (full VACUUM needs exclusive access;
-  `classifyPgrepExitCode`: 0=has procs, 1=none, other=error→unsafe).
-- Refuse if free disk < DB size × 1.1 (VACUUM needs a full-size temp copy; this
-  machine has hit ENOSPC).
-- Refuse `--prune-older < 1` (prevents `--prune-older=0` deleting everything).
-- If VACUUM fails after the DELETE commits, still report `sessions_deleted` +
-  a `vacuum_error` field — never hide that data was deleted.
+### Store candidate IDs in unique temporary tables
 
-Measured: pruning sessions older than 30 days = 7,048 sessions, ~5.9 GB
-reclaimable (13 GB → ~7.5 GB).
+Each operation creates an internally generated temporary table such as
+`_prune_ids_7`. The helper passes the safe identifier to its callback and drops
+the table in `finally`. Unique names allow nested or concurrent operations on
+the same connection without sharing mutable candidate state.
+Loading candidate IDs into that `TEXT PRIMARY KEY` table also avoids SQLite
+variable-count limits.
+
+### Keep preservation proof bounded
+
+Event-only deletion must prove that selected sessions, messages, and parts are
+unchanged. Hash rows in deterministic order with SQLite iteration instead of
+loading payloads into arrays:
+
+```ts
+for (const row of query.iterate()) {
+  appendFramedText(digest, "row");
+  for (const column of columns) {
+    appendFramedValue(digest, row[column]);
+  }
+}
+```
+
+Length-prefixed framing distinguishes `null`, text, blobs, and field
+boundaries. The proof records row counts plus SHA-256 identity/content hashes
+before and after deletion, inside the same transaction. Any mismatch rolls the
+transaction back. Schema checks require indexes supporting the selected-row
+predicates before the expensive proof begins.
+
+Count session trees with SQL rather than building a full client-side graph.
+
+### Separate whole-session and event-only maintenance
+
+`opencode-doctor` exposes two dry-run-first modes:
+
+- `--prune-older=<days>` selects stale trees and, with `--execute`, deletes
+  sessions, messages, parts, and events before a full VACUUM.
+- `--prune-events-older=<days>` selects the same stale trees but, with
+  `--execute`, deletes only `event_sequence` rows; the foreign-key cascade
+  removes matching `event` rows while preserving transcript tables.
+
+The event-only path requires:
+
+- explicit `--execute`;
+- no active OpenCode process holding the database;
+- `auto_vacuum=INCREMENTAL`;
+- the expected `event.aggregate_id -> event_sequence.aggregate_id` foreign key
+  with `ON DELETE CASCADE`;
+- preservation-supporting indexes;
+- a fixed operational free-space floor;
+- transactional transcript preservation checks;
+- successful, non-busy WAL checkpoints.
+
+It runs `PRAGMA incremental_vacuum`, never a full VACUUM. Invalid CLI state is
+represented explicitly rather than with a `NaN` sentinel.
+
+### Report mutation and reclaim separately
+
+If deletion commits but checkpointing or incremental vacuum fails, report the
+deleted row counts and a failed operation. Do not label the run refused, imply
+that no mutation occurred, or claim disk space was reclaimed.
+
+The observed production run after the bounded-memory fix deleted event streams
+but reported zero database file-size reduction. Physical reclamation therefore
+remains an operational follow-up, not a verified outcome of the implementation.
 
 ## Why This Works
 
-The real bloat is the event-sourcing log (`event`, 6.7 GB — payloads duplicate
-message data) plus large `part` payloads (tool outputs / file contents), and
-OpenCode never prunes (feature requests `anomalyco/opencode#22110`, `#31526`,
-`#16101`). Deleting old sessions removes the underlying rows; VACUUM then has
-free pages to reclaim.
+Tree-wide last-use selection protects active descendants. Deleting parent
+`event_sequence` rows uses the declared cascade to remove child `event` rows
+without touching transcripts. Ordered SQL iteration keeps memory proportional
+to one row, while deterministic content hashes detect count-preserving trigger
+mutations. Unique temporary tables avoid variable limits and nested-call
+collisions.
 
-Pruning events is safe **only for local-first usage** (verified against OpenCode
-v1.17.11 source): session display reads `message` + `part`, not `event`
-(`session.ts`, `message-v2.ts`); `event` is read for sync / cross-device replay /
-`/sync/history` (`sync.ts`, `control-plane/workspace.ts`, `core/event.ts`).
-Deleting events breaks those features for pruned sessions — fine if you never use
-sync/share/replay.
-
-## Reducing future full VACUUMs
-
-`opencode-doctor --set-incremental-vacuum` converts the DB from
-`auto_vacuum=NONE` to `INCREMENTAL` (one-time: `PRAGMA auto_vacuum=INCREMENTAL`
-then a full `VACUUM` to rewrite the file). After conversion, future deletes free
-pages that `PRAGMA incremental_vacuum` can reclaim without a full exclusive
-VACUUM. Same safety gates as prune (other-process check, free disk ≥ DB×1.1).
-Note: converting an existing DB still needs one full VACUUM, and `confirmed` is
-only true when that VACUUM completes — a failed conversion leaves the mode flag
-set but the file un-rewritten, so re-running always re-attempts the full VACUUM.
+Together, the process, schema, index, preservation, and checkpoint gates prove
+selection, deletion, and transcript preservation. They do not prove that
+SQLite or the filesystem returned physical storage; measure that independently.
 
 ## Prevention
 
-- Default to dry-run; require explicit `--execute` for deletion.
-- Gate destructive ops: refuse when safety can't be verified (pgrep error),
-  when free disk is insufficient, or when the window is `< 1` day.
-- Never hide deletion if VACUUM fails (surface `vacuum_error`).
-- Reusable SQLite rules:
-  - Epoch-ms comparisons: `CAST(time_created / 1000 AS INTEGER) < cutoffSec`.
-  - Bulk id sets: a `TEMP TABLE` join, not a giant `IN (?,?,...)`.
-  - Accurate byte sizes: `length(CAST(data AS BLOB))`, not `length(data)`.
-  - `dbstat` is a full virtual-table scan — slow (minutes) on a multi-GB DB.
+- Keep destructive database maintenance dry-run by default.
+- Treat these as separate assertions:
+  1. the intended rows were selected;
+  2. the intended rows were deleted;
+  3. protected rows were unchanged;
+  4. SQLite file size decreased;
+  5. host free space increased.
+- Never use `.all()` or `JSON.stringify` over unbounded database payloads in a
+  safety proof; stream ordered rows into a digest.
+- Use SQL aggregates for counts and byte estimates instead of materializing
+  rows in JavaScript.
+- Use temporary candidate tables rather than giant variable-bound lists.
+- Test large payloads, candidate sets above common SQLite variable limits,
+  missing indexes, trigger-based count-preserving mutation, checkpoint-busy
+  results, active-process refusal, and incremental-vacuum requirements.
+- Preserve honest post-mutation failure reporting. A failed reclaim phase does
+  not undo a committed delete.
+- For physical reclamation, record database size and filesystem free space
+  before and after; do not infer success from row counts or freelist changes.
 
 ## Related Issues
 
-- `docs/solutions/2026-05-22-bun-sqlite-readonly-wal-pattern.md` — sibling doc on
-  read-only Bun access to the same `opencode.db` (moderate overlap: same file,
-  different operation).
-- Upstream: `anomalyco/opencode#22110`, `#31526`, `#16101` (DB
-  maintenance / prune / storage growth feature requests).
+- `docs/solutions/2026-05-22-bun-sqlite-readonly-wal-pattern.md` — read-only Bun
+  access to the same WAL-mode database.
+- `docs/opencode-doctor.md` — current CLI and safety contract.
+- Issue #1924 — database growth and retention follow-up.
+- PR #2057 — tree-aware last-use pruning.
+- PR #2165 — event-only retention, bounded preservation proof, and review
+  hardening.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ git status  # now works on dotfiles
 | Git settings | `.config/git/config` | GPG signing on, rebase defaults, autoStash |
 | Mise tool versions | `.config/mise/config.toml` | Node, Python, Rust, etc. — `nvm` is disabled |
 | Mise tasks | `.config/mise/tasks/` | File-based shebang scripts; subdirs map to `:` (e.g. `mise/tools/install` -> `mise:tools:install`); auto-discovered, no `task_config.includes` needed |
-| Project docs | `.dotfiles/docs/` | `brainstorms/` (requirements), `plans/` (implementation plans), `runbooks/` (operational procedures), `solutions/` (compound knowledge captures) |
+| Project docs | `.dotfiles/docs/` | `brainstorms/` (requirements), `plans/` (implementation plans), `runbooks/` (operational procedures), `solutions/` entries searchable by YAML frontmatter (`module`, `tags`, `problem_type`) when implementing or debugging documented areas |
 | OpenCode scripts | `.config/opencode/scripts/` | Bun + TypeScript utilities. `opencode-doctor.ts` (config diagnostic), `ollama-distill.ts` (local session distillation pipeline) |
 | Brewfile | `Brewfile` | macOS apps + casks + mas + 140+ vscode extensions |
 | Claude Code agents/rules | `.claude/agents/`, `.claude/rules/` | Custom agent + rule definitions |


### PR DESCRIPTION
## Summary
- Refresh the OpenCode SQLite bloat learning around event-table growth patterns and tree-aware/event-only retention behavior.
- Document the bounded streaming preservation proof and the explicit separation between logical deletion and physical file reclamation.
- Update solution discoverability by making entries in `AGENTS.md` reference YAML frontmatter fields (`module`, `tags`, `problem_type`).

## Verification
- Parsed and validated solution frontmatter, including required metadata fields.
- Cross-checked documentation claims against the current `opencode-doctor` implementation, related tests, and SQLite behavior before committing.
- Ran `git diff --check`; no whitespace or formatting issues were detected.
