### PR TITLE
chore(opencode): protect workflow guards without debug output

### DIFF
--- a/.config/opencode/systematic.jsonc
+++ b/.config/opencode/systematic.jsonc
@@ -28,5 +28,9 @@
       "model": "anthropic/claude-sonnet-5",
       "variant": "medium"
     }
+  },
+  "workflow_guard": {
+    "mode": "protected",
+    "debug": false
   }
 }


### PR DESCRIPTION
## Summary
This change hardens OpenCode delegated workflow execution by requiring the workflow guard to run in protected mode and by disabling guard debug output by default.

### Changes
- Set `workflow_guard.mode` to `protected`.
- Set `workflow_guard.debug` to `false`.

### Verification
- AFT diagnostics/readiness checks are clean for this change set.
- `mise run opencode:doctor -- --only health` passed.
- `git diff --check` is clean for the scoped change.
- `prettier` baseline and current both fail consistently, indicating no additional formatting regression from the intended one-line semantic change.
