### PR TITLE
chore(opencode): switch opus model to claude-opus-5

### DIFF
--- a/.config/cortexkit/magic-context.jsonc
+++ b/.config/cortexkit/magic-context.jsonc
@@ -60,6 +60,7 @@
     "anthropic/claude-opus-4-6": "59m",
     "anthropic/claude-opus-4-7": "59m",
     "anthropic/claude-opus-4-8": "59m",
+    "anthropic/claude-opus-5": "59m",
     "anthropic/claude-fable-5": "59m",
     "openai/gpt-5.5": "10m",
     "openai/gpt-5.5-fast": "10m",

--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -10,7 +10,7 @@
         "mcps": ["*", "!context7"]
       },
       "oracle": {
-        "model": "anthropic/claude-opus-4-8",
+        "model": "anthropic/claude-opus-5",
         "variant": "high",
         "skills": ["ce:brainstorm", "simplify"],
         "mcps": []
@@ -86,7 +86,7 @@
     },
     "mixed": {
       "orchestrator": {
-        "model": "anthropic/claude-opus-4-8",
+        "model": "anthropic/claude-opus-5",
         "variant": "high",
         "skills": ["*"],
         "mcps": ["*", "!context7"]
@@ -183,7 +183,7 @@
     "presets": {
       "default": {
         "alpha": {
-          "model": "anthropic/claude-opus-4-8",
+          "model": "anthropic/claude-opus-5",
           "variant": "high"
         },
         "beta": {


### PR DESCRIPTION
- add anthropic/claude-opus-5 timeout entry in magic-context model timeout map
- update oh-my-opencode-slim model selections from claude-opus-4-8 to claude-opus-5
- apply model upgrade across oracle, mixed orchestrator, and default alpha preset