### PR TITLE
chore(opencode): tune verification workflow

### DIFF
--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -37,7 +37,7 @@
       },
       "fixer": {
         "model": "openai/gpt-5.6-luna",
-        "variant": "xhigh",
+        "variant": "max",
         "skills": ["agent-browser", "impeccable", "systematic:*"],
         "mcps": []
       }
@@ -119,7 +119,7 @@
       },
       "fixer": {
         "model": "openai/gpt-5.6-luna",
-        "variant": "xhigh",
+        "variant": "max",
         "skills": ["agent-browser", "impeccable", "systematic:*"],
         "mcps": []
       }
@@ -159,7 +159,7 @@
       },
       "fixer": {
         "model": "openai/gpt-5.6-luna",
-        "variant": "xhigh",
+        "variant": "max",
         "skills": ["agent-browser", "impeccable", "systematic:*"],
         "mcps": []
       }

--- a/.config/opencode/skills/verification-planning/SKILL.md
+++ b/.config/opencode/skills/verification-planning/SKILL.md
@@ -37,6 +37,15 @@ trustworthy conclusion with proportionate cost, safety, and effort.
 **Complete when:** there is a preferred path, its limitations are understood,
 and a weaker or stronger alternative is available if circumstances change.
 
+## Set a verification budget
+
+At the final state, state the distinct claims, assign one owner to establish or
+refute each, and choose the minimum non-duplicative evidence that covers the
+claims and important boundaries. Reuse evidence only while its relevant code,
+inputs, environment, and state remain valid. Required repository and release
+checks still apply; broaden or repeat verification only when a stated condition
+justifies it.
+
 ## 3. Create a verification affordance when needed
 
 When the existing system leaves the decisive truth too indirect or ambiguous,

--- a/.config/opencode/skills/worktrees/SKILL.md
+++ b/.config/opencode/skills/worktrees/SKILL.md
@@ -135,7 +135,9 @@ keeps them readable to OpenCode.
 
 ### Phase 3: Integration & Validation
 Before merging or integrating the worktree branch:
-1. Run lint, build, formatting, and unit tests inside the worktree directory.
+1. Apply a proportionate final-state verification plan to the changed behavior
+   and its important boundaries. Run checks required by repository or release
+   instructions.
 2. Generate and display a clear diff comparing the worktree branch to the
    integration base branch.
 3. Ask the user for confirmation to integrate.

--- a/.config/opencode/systematic.jsonc
+++ b/.config/opencode/systematic.jsonc
@@ -26,7 +26,7 @@
     },
     "systematic-implementer": {
       "model": "openai/gpt-5.6-luna",
-      "variant": "xhigh"
+      "variant": "max"
     }
   },
   "workflow_guard": {


### PR DESCRIPTION
- switch OpenCode fixer and implementer model variants from xhigh to max
- add a verification-budget section to the planning skill to assign evidence ownership and keep checks proportionate
- update worktree validation guidance to prefer final-state verification and required repo/release checks over blanket lint/build/test runs