### PR TITLE
fix(opencode): pin OMO Slim to last known good release

### DIFF
--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/oh-my-opencode-slim@latest/oh-my-opencode-slim.schema.json",
+  "$schema": "https://unpkg.com/oh-my-opencode-slim@2.2.11/oh-my-opencode-slim.schema.json",
   "preset": "openai",
   "presets": {
     "openai": {

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -3,7 +3,7 @@
   "plugin": [
     "@cortexkit/opencode-anthropic-auth@1.19.0",
     "@cortexkit/opencode-openai-auth@0.5.2",
-    "oh-my-opencode-slim@2.2.14",
+    "oh-my-opencode-slim@2.2.11",
     "@cortexkit/opencode-magic-context@0.36.1",
     "@cortexkit/aft-opencode@0.50.1",
     "opencode-copilot-delegate@0.12.1",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,6 +21,16 @@
       ],
       datasourceTemplate: 'npm',
       versioningTemplate: 'semver'
+    },
+    {
+      customType: 'regex',
+      description: 'Update pinned npm schema versions in OpenCode config files.',
+      managerFilePatterns: ['/(^|/)\\.config/opencode/oh-my-opencode-slim\\.jsonc$/'],
+      matchStrings: [
+        'https://unpkg\\.com/(?<depName>oh-my-opencode-slim)@(?<currentValue>\\d+\\.\\d+\\.\\d+(?:[-+][a-z0-9.-]+)?)/oh-my-opencode-slim\\.schema\\.json'
+      ],
+      datasourceTemplate: 'npm',
+      versioningTemplate: 'semver'
     }
   ],
   ignorePresets: ['mergeConfidence:age-confidence-badges', 'mergeConfidence:all-badges'],
@@ -89,6 +99,11 @@
       description: 'Hold @cortexkit/aft-opencode at 0.32.0; v0.33.0 has regressions.',
       matchPackageNames: ['@cortexkit/aft-opencode'],
       allowedVersions: '0.32.0'
+    },
+    {
+      description: 'Hold oh-my-opencode-slim at 2.2.11.',
+      matchPackageNames: ['oh-my-opencode-slim'],
+      allowedVersions: '2.2.11'
     }
   ],
   prCreation: 'immediate',


### PR DESCRIPTION
## What this changes
This updates OMO Slim to the last-known-good v2.2.11 to avoid the stale Background Job Board regression seen in 2.2.14. It pins both the plugin and the bundled schema URL to the same release and adds Renovate safeguards so the pin remains stable.

## Why
- Prevent accidental upgrade churn from a known-bad release
- Keep schema resolution aligned with the pinned plugin
- Ensure Renovate can update the schema pin intentionally and refuses drift from 2.2.11 without an explicit allow-list change

## Validation
- Parsed updated OpenCode config and schema JSON/JSONC via existing local tooling
- Validated regex extraction for `depName`, `currentValue`, and datasource from the Renovate custom manager surface
- Ran scoped `git diff --check` on all touched files
- Renovate config validator is not available in this environment, so validation there was not run
