### PR TITLE
feat(opencode): add mixed-go preset and activate it

### DIFF
--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -206,7 +206,7 @@
       },
       "fast-generic": {
         "model": "opencode-go/deepseek-v4-flash",
-        "variant": "high"
+        "variant": "low"
       }
     }
   },

--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/oh-my-opencode-slim@2.2.11/oh-my-opencode-slim.schema.json",
-  "preset": "openai",
+  "preset": "mixed-go",
   "presets": {
     "openai": {
       "orchestrator": {
@@ -163,6 +163,51 @@
         "skills": ["agent-browser", "impeccable", "systematic:*"],
         "mcps": []
       }
+    },
+    "mixed-go": {
+      "orchestrator": {
+        "model": "anthropic/claude-opus-5",
+        "variant": "high",
+        "skills": ["*"],
+        "mcps": ["*", "!context7"]
+      },
+      "oracle": {
+        "model": "opencode-go/qwen3.7-max",
+        "variant": "max",
+        "skills": ["ce:brainstorm", "simplify"],
+        "mcps": []
+      },
+      "council": {
+        "model": "opencode-go/deepseek-v4-pro",
+        "variant": "high"
+      },
+      "librarian": {
+        "model": "github-copilot/gpt-5.4-mini",
+        "variant": "low",
+        "skills": [],
+        "mcps": ["context7", "gh_grep"]
+      },
+      "explorer": {
+        "model": "github-copilot/gpt-5.4-mini",
+        "variant": "low",
+        "skills": [],
+        "mcps": []
+      },
+      "designer": {
+        "model": "github-copilot/gemini-3.5-flash",
+        "skills": ["agent-browser", "impeccable", "systematic:*"],
+        "mcps": []
+      },
+      "fixer": {
+        "model": "opencode-go/deepseek-v4-flash",
+        "variant": "high",
+        "skills": ["agent-browser", "impeccable", "systematic:*"],
+        "mcps": []
+      },
+      "fast-generic": {
+        "model": "opencode-go/deepseek-v4-flash",
+        "variant": "high"
+      }
     }
   },
   "autoUpdate": false,
@@ -192,7 +237,7 @@
           "variant": "high"
         },
         "gamma": {
-          "model": "openai/gpt-5.6-sol",
+          "model": "opencode-go/deepseek-v4-pro",
           "variant": "high"
         }
       }

--- a/.config/opencode/skills/oh-my-opencode-slim/SKILL.md
+++ b/.config/opencode/skills/oh-my-opencode-slim/SKILL.md
@@ -110,6 +110,24 @@ Important schema boundary:
 - Unknown keys under top-level `agents` are custom agents. Custom agents may use
   `prompt` and `orchestratorPrompt` directly in config.
 
+Preset scope and merge semantics:
+
+- Preset agent blocks **merge into** the top-level `agents` config; they do not
+  replace it. A preset may therefore list a custom agent with only `model` and
+  `variant` to re-route it per preset while its global `prompt` and
+  `orchestratorPrompt` survive untouched.
+- Only agents already present in the resolved config receive preset overrides.
+  A preset entry for an agent that is defined nowhere else is ignored.
+- Preset agent names are unconstrained strings, so custom agents are valid preset
+  keys alongside the built-ins.
+- The active preset is the root `preset` key, overridable per machine with the
+  `OH_MY_OPENCODE_SLIM_PRESET` environment variable. Prefer the environment
+  variable for machine-specific routing so the config file stays portable.
+- Council seats are **not** preset-scoped. `council.presets.<name>.<seat>` lives
+  at the config root with no binding to the active agent preset, so an agent
+  preset cannot override a seat model. Changing a seat changes it for every
+  preset.
+
 ## Config Shapes
 
 ### Tune a built-in agent model/skills/MCPs


### PR DESCRIPTION
Adds a `mixed-go` OMO Slim preset for environments where OpenAI models aren't available, and makes it the active preset.

The preset keeps the providers that still work in those environments and swaps only the OpenAI slots:

| agent | model |
| --- | --- |
| orchestrator | `anthropic/claude-opus-5` |
| oracle | `opencode-go/qwen3.7-max` |
| council | `opencode-go/deepseek-v4-pro` |
| librarian | `github-copilot/gpt-5.4-mini` |
| explorer | `github-copilot/gpt-5.4-mini` |
| designer | `github-copilot/gemini-3.5-flash` |
| fixer | `opencode-go/deepseek-v4-flash` |
| fast-generic | `opencode-go/deepseek-v4-flash` |

Model choices reuse the assignments already proven in the existing `opencode-go` preset rather than introducing new ones. The orchestrator stays on Anthropic so the prompt-cache behaviour tuned in #2337 is unaffected.

Two details worth noting:

- `fast-generic` is defined globally under `agents`, outside any preset, so it would otherwise keep pointing at an OpenAI model. Preset blocks merge into the global agent config, so listing it here with only `model` and `variant` overrides the model while preserving its prompt.
- Council seats are configured at the root under `council.presets` with no binding to the active agent preset, so a preset cannot override them. The default gamma seat is repointed to an OpenCode Go model directly; alpha and beta already use Anthropic and Copilot.

Validated against the pinned 2.2.11 schema.
