### PR TITLE
chore(deps): update @cortexkit/opencode-anthropic-auth to v1.19.1

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
-    "@cortexkit/opencode-anthropic-auth@1.19.0",
+    "@cortexkit/opencode-anthropic-auth@1.19.1",
     "@cortexkit/opencode-openai-auth@0.5.2",
     "oh-my-opencode-slim@2.2.11",
     "@cortexkit/opencode-magic-context@0.38.0",


### PR DESCRIPTION
Bumps `@cortexkit/opencode-anthropic-auth` from 1.19.0 to 1.19.1.

All five upstream changes are fixes on paths this setup actually exercises:

- Deterministic Opus 4.8 recovery stays available when Anthropic's server-side safety fallback still ends in a refusal, and source-model prewarms can no longer be routed back to the fallback model.
- Completed tool calls survive a served fallback that later refuses, so non-idempotent tools aren't replayed.
- Sticky-balanced routing returns explicit auth or quota responses when no eligible account exists, instead of falling through to an excluded main account.
- Stale token-bound `invalid_grant` state clears immediately after the main account is re-authenticated, while transient and rate-limit backoffs are retained.
- TUI preference live updates keep working when Bun can't create a directory watcher (`EBADF`), via an independent polling fallback.

The tool-call preservation fix matters most here given how much work runs through background specialists — a fallback refusal replaying a non-idempotent tool is the kind of failure that's expensive to notice after the fact.

No config or schema changes; version string only.
