### PR TITLE
fix(opencode): correct OMO preset model routing

### DIFF
--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -40,6 +40,10 @@
         "variant": "high",
         "skills": ["agent-browser", "impeccable", "systematic:*"],
         "mcps": []
+      },
+      "fast-generic": {
+        "model": "openai/gpt-5.3-codex-spark",
+        "variant": "low"
       }
     },
     "opencode-go": {
@@ -82,6 +86,10 @@
         "variant": "high",
         "skills": ["agent-browser", "impeccable", "systematic:*"],
         "mcps": []
+      },
+      "fast-generic": {
+        "model": "opencode-go/deepseek-v4-flash",
+        "variant": "low"
       }
     },
     "mixed": {
@@ -122,6 +130,10 @@
         "variant": "high",
         "skills": ["agent-browser", "impeccable", "systematic:*"],
         "mcps": []
+      },
+      "fast-generic": {
+        "model": "openai/gpt-5.3-codex-spark",
+        "variant": "low"
       }
     },
     "mixed-fable": {
@@ -162,6 +174,10 @@
         "variant": "high",
         "skills": ["agent-browser", "impeccable", "systematic:*"],
         "mcps": []
+      },
+      "fast-generic": {
+        "model": "openai/gpt-5.3-codex-spark",
+        "variant": "low"
       }
     },
     "mixed-go": {
@@ -213,8 +229,6 @@
   "autoUpdate": false,
   "agents": {
     "fast-generic": {
-      "model": "openai/gpt-5.3-codex-spark",
-      "variant": "low",
       "prompt": "You are a fast generic execution agent for routine mechanical command work. Run requested shell commands, inspect results, and report concise outcomes. Prefer small single-purpose commands. Separate state changes from readback, use temporary files for multiline bodies instead of nested shell quoting, and verify supported CLI fields or endpoints before querying. Stop immediately when scoped status or diff shows there is nothing to do. Keep commit/PR creation, monitoring/merge, and local cleanup as separate steps. For git commits, inspect git status, git diff, and recent log first; stage only intended files; avoid secrets; preserve repository commit-message style; never amend, rebase, reset --hard, clean, push, force-push, delete branches, or perform destructive history operations unless the user explicitly requested that exact operation. Do not edit code or make architecture/design decisions.",
       "orchestratorPrompt": "Delegate to @fast-generic for routine mechanical command work: git status/diff/log reconnaissance, normal commit preparation, creating commits, and no-edit command validation such as lint, typecheck, static verification, tests, builds, or package-manager equivalents. Scope each delegation to one phase: commit/PR creation, monitoring/merge, or local cleanup. Ask it to inspect diffs before committing, stage only intended files, avoid secrets, preserve repository commit-message style, and report final commit hashes or push results. Do not use it for code edits, design work, architecture, debugging strategy, docs research, or destructive git history operations such as amend, rebase, reset --hard, clean, force-push, or deleting branches unless the user explicitly requested that exact operation.",
       "skills": [],

--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -215,7 +215,7 @@
         "mcps": []
       },
       "fixer": {
-        "model": "opencode-go/deepseek-v4-flash",
+        "model": "opencode-go/gpt-5.6-luna",
         "variant": "high",
         "skills": ["agent-browser", "impeccable", "systematic:*"],
         "mcps": []


### PR DESCRIPTION
Two related fixes to OMO Slim model routing, both in `oh-my-opencode-slim.jsonc`.

## `fast-generic` ignored its per-preset model

OMO merges presets with `deepMerge(preset, config.agents)` — the global `agents` block is the *override*, not the base. Because `agents.fast-generic` set `model` and `variant` globally, the per-preset values could never take effect.

The visible consequence: `mixed-go` declared `opencode-go/deepseek-v4-flash` for `fast-generic`, but the agent kept resolving to `openai/gpt-5.3-codex-spark`. The preset that exists specifically to avoid OpenAI was still routing an agent to OpenAI.

Fix is to move `model` and `variant` out of the global block and declare them in each of the five presets, leaving `prompt`, `orchestratorPrompt`, `skills` and `mcps` global where they genuinely are shared.

Verified against a running server rather than by reading config: `fast-generic` now resolves to `opencode-go/deepseek-v4-flash` under `mixed-go` with its prompt intact, and no agent resolves to an `openai/*` model.

## `mixed-go` fixer model

Switches the `mixed-go` fixer from `deepseek-v4-flash` to `gpt-5.6-luna`. `deepseek-v4-flash` was underperforming on multi-step work and looping.
