### PR TITLE
fix(opencode): resolve doctor server binary via harness with fallback

### DIFF
--- a/.config/opencode/scripts/opencode-doctor.test.ts
+++ b/.config/opencode/scripts/opencode-doctor.test.ts
@@ -14,6 +14,7 @@ import {
   autoVacuumModeName,
   convertToIncrementalVacuum,
   checkForOtherOpencodeProcesses,
+  resolveOpencodeBin,
 } from "./opencode-doctor";
 import {
   selectOldSessionIds as selectOldSessionIdsFromRetention,
@@ -1617,6 +1618,45 @@ describe("error handling", () => {
     },
     { timeout: TEST_TIMEOUT }
   );
+});
+
+// ─── Server Binary Resolution Tests ───────────────────────────────────────────
+
+describe("resolveOpencodeBin", () => {
+  test("explicit OPENCODE_BIN wins verbatim, without probing", () => {
+    const bin = resolveOpencodeBin({
+      env: { OPENCODE_BIN: "/custom/opencode" },
+      resolveBin: () => {
+        throw new Error("resolveBin should not be called when OPENCODE_BIN is set");
+      },
+    });
+    expect(bin).toBe("/custom/opencode");
+  });
+
+  test("harness preferred over opencode when both resolvable", () => {
+    const bin = resolveOpencodeBin({
+      env: {},
+      resolveBin: (name) => (name === "harness" ? "/bin/harness" : "/bin/opencode"),
+    });
+    expect(bin).toBe("harness");
+  });
+
+  test("opencode used when harness absent", () => {
+    const bin = resolveOpencodeBin({
+      env: {},
+      resolveBin: (name) => (name === "opencode" ? "/bin/opencode" : null),
+    });
+    expect(bin).toBe("opencode");
+  });
+
+  test("throws clear error naming both candidates when neither exists", () => {
+    expect(() =>
+      resolveOpencodeBin({
+        env: {},
+        resolveBin: () => null,
+      })
+    ).toThrow(/harness.*opencode|opencode.*harness/i);
+  });
 });
 
 // ─── DB Guard Tests ───────────────────────────────────────────────────────────

--- a/.config/opencode/scripts/opencode-doctor.ts
+++ b/.config/opencode/scripts/opencode-doctor.ts
@@ -1638,16 +1638,51 @@ async function runSetIncrementalVacuum(options: CliOptions): Promise<SectionResu
 
 // ─── Server / Section Collection ─────────────────────────────────────────────
 
+export type ServerSpawnDependencies = {
+  resolveBin?: (name: string) => string | null;
+  env?: Record<string, string | undefined>;
+};
+
+/**
+ * Resolve the binary used to spawn the OpenCode server.
+ *
+ * Precedence:
+ *   1. OPENCODE_BIN, if set — explicit override always wins, used verbatim.
+ *   2. `harness` — the Fro Bot pass-through wrapper around the patched OpenCode
+ *      binary (this machine's runtime). Preferred when present.
+ *   3. `opencode` — the stock binary. Used only when `harness` is absent.
+ *   4. Otherwise throw, naming both candidates.
+ *
+ * "Resolvable" is a PATH lookup (Bun.which). We deliberately do NOT probe
+ * runnability here: a dead shim (e.g. a stale npm:opencode-ai install) may
+ * resolve but fail at spawn, and that error surfaces with a clear message
+ * rather than paying a slow probe on the hot path.
+ */
+export function resolveOpencodeBin(
+  dependencies: ServerSpawnDependencies = {},
+): string {
+  const resolveBin = dependencies.resolveBin ?? ((name: string) => Bun.which(name));
+  const env = dependencies.env ?? process.env;
+  const explicit = env.OPENCODE_BIN;
+  if (explicit) {
+    return explicit;
+  }
+  for (const candidate of ["harness", "opencode"]) {
+    if (resolveBin(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    `Could not resolve an OpenCode binary: tried "harness" and "opencode", neither is on PATH. Set OPENCODE_BIN to an explicit binary to override.`,
+  );
+}
+
 async function spawnOpencodeServer(
   hostname: string,
   port: number,
   timeoutMs = 10000
 ): Promise<{ proc: ChildProcess; url: string }> {
-  // The `opencode` shim is broken on this machine (stale unpinned npm:opencode-ai
-  // owns it and always fails). The `harness` CLI is a pass-through wrapper around
-  // the same patched OpenCode binary and IS on PATH. Keep it overridable via
-  // OPENCODE_BIN so the path isn't hardcoded.
-  const bin = process.env.OPENCODE_BIN ?? "harness";
+  const bin = resolveOpencodeBin();
   const proc = spawn(bin, ["serve", `--hostname=${hostname}`, `--port=${port}`], {
     env: process.env,
     stdio: ["ignore", "pipe", "pipe"],

--- a/.config/opencode/scripts/opencode-doctor.ts
+++ b/.config/opencode/scripts/opencode-doctor.ts
@@ -1643,7 +1643,12 @@ async function spawnOpencodeServer(
   port: number,
   timeoutMs = 10000
 ): Promise<{ proc: ChildProcess; url: string }> {
-  const proc = spawn("opencode", ["serve", `--hostname=${hostname}`, `--port=${port}`], {
+  // The `opencode` shim is broken on this machine (stale unpinned npm:opencode-ai
+  // owns it and always fails). The `harness` CLI is a pass-through wrapper around
+  // the same patched OpenCode binary and IS on PATH. Keep it overridable via
+  // OPENCODE_BIN so the path isn't hardcoded.
+  const bin = process.env.OPENCODE_BIN ?? "harness";
+  const proc = spawn(bin, ["serve", `--hostname=${hostname}`, `--port=${port}`], {
     env: process.env,
     stdio: ["ignore", "pipe", "pipe"],
     detached: true,


### PR DESCRIPTION
`mise run opencode:doctor` has been failing outright:

```
Failed to start opencode server: Server exited with code 1.
Output: mise ERROR No version is set for shim: opencode
```

The doctor spawns a server with a bare `spawn("opencode", ["serve", ...])`. That shim is dead on this machine: mise pins `npm:@fro.bot/harness` (which installs a `harness` bin, not an `opencode` one), while a stale unpinned `npm:opencode-ai` install owns the `opencode` shim. With no version set for it, every invocation fails.

`harness` is a pass-through wrapper around the same patched binary — it reserves only `info`, `patches`, `doctor` and `integrate`, and forwards everything else — so `harness serve` is equivalent to `opencode serve`.

Rather than hardcoding either name, the server spawn now resolves its binary in order:

1. `OPENCODE_BIN`, if set — explicit override, used verbatim with no probing
2. `harness`
3. `opencode`, so a normal installation still works
4. otherwise fail with an error naming both candidates tried

This keeps a plain `opencode` install working while preferring the harness where it is present.

Process-matching logic is untouched; only the binary invocation changed. Covered by unit tests for each branch of the resolution order, and confirmed end to end — `mise run opencode:doctor -- --only agents` starts a server and reports resolved agents again.
