### PR TITLE
fix(opencode): guard destructive DB operations with lsof

### DIFF
--- a/.config/opencode/scripts/opencode-doctor.test.ts
+++ b/.config/opencode/scripts/opencode-doctor.test.ts
@@ -10,10 +10,10 @@ import {
   estimateReclaim,
   pruneSessions,
   pruneEvents,
-  classifyPgrepExitCode,
   autoVacuumModeName,
   convertToIncrementalVacuum,
   checkForOtherOpencodeProcesses,
+  refuseIfOtherOpencodeProcesses,
   resolveOpencodeBin,
 } from "./opencode-doctor";
 import {
@@ -760,18 +760,6 @@ describe("event-only retention (unit)", () => {
     }
   });
 
-  test("refuses an active OpenCode parent instead of excluding the parent PID", () => {
-    const result = checkForOtherOpencodeProcesses({
-      ownPid: 100,
-      spawnSync: (args: string[]) => args[0] === "pgrep"
-        ? { exitCode: 0, stdout: "100\n200\n" }
-        : { exitCode: 0, stdout: "200\n" },
-    });
-
-    expect(result.safe).toBe(false);
-    expect(result.pids).toEqual([200]);
-  });
-
   test("deletes selected event streams while preserving sessions, messages, and parts", () => {
     const dir = makeTempDir();
     try {
@@ -1352,31 +1340,6 @@ describe("event-only retention CLI", () => {
     { timeout: TEST_TIMEOUT },
   );
 
-  test(
-    "refuses event-only execute while another OpenCode process is active",
-    async () => {
-      const dir = makeTempDir();
-      const active = Bun.spawn(["bash", "-c", "exec -a opencode-active-retention-test sleep 30"], {
-        stdout: "ignore",
-        stderr: "ignore",
-      });
-      try {
-        const { db, dbPath } = createTestDb(dir, { autoVacuum: 2 });
-        db.close();
-
-        const result = await $`bun ${SCRIPT_PATH} --prune-events-older=30 --execute --json --db-path=${dbPath}`.quiet().nothrow();
-        expect(result.exitCode).toBe(1);
-        const sections = JSON.parse(result.stdout.toString()) as Array<{ data?: Record<string, unknown> }>;
-        expect(sections[0]?.data?.refused).toBe(true);
-        expect(String(sections[0]?.data?.reason)).toMatch(/opencode|process|close/i);
-      } finally {
-        active.kill();
-        await active.exited;
-        removeTempDir(dir);
-      }
-    },
-    { timeout: TEST_TIMEOUT },
-  );
 });
 
 // ─── Existing CLI Tests ───────────────────────────────────────────────────────
@@ -1662,26 +1625,127 @@ describe("resolveOpencodeBin", () => {
 // ─── DB Guard Tests ───────────────────────────────────────────────────────────
 
 describe("DB guards (unit)", () => {
-  // ── classifyPgrepExitCode ──────────────────────────────────────────────────
+  const dbPath = "/tmp/opencode.db";
+  const walPath = `${dbPath}-wal`;
 
-  test("classifyPgrepExitCode: exit 0 → has_procs", () => {
-    expect(classifyPgrepExitCode(0)).toBe("has_procs");
+  test("holder on the main database refuses and names the holder", () => {
+    const refusal = refuseIfOtherOpencodeProcesses(dbPath, {
+      ownPid: 100,
+      spawnSync: (args) => args[3] === dbPath
+        ? { exitCode: 0, stdout: "p200\ncmagic-context-dashboard\nf12\n" }
+        : { exitCode: 1, stdout: "" },
+    });
+
+    expect(refusal).toEqual({
+      refused: true,
+      reason: expect.stringContaining("magic-context-dashboard (PID 200)"),
+      instruction: "Close all OpenCode instances and re-run.",
+    });
   });
 
-  test("classifyPgrepExitCode: exit 1 → no_procs (safe)", () => {
-    expect(classifyPgrepExitCode(1)).toBe("no_procs");
+  test("holder found only on the WAL refuses", () => {
+    const result = checkForOtherOpencodeProcesses(dbPath, {
+      ownPid: 100,
+      spawnSync: (args) => args[3] === dbPath
+        ? { exitCode: 1, stdout: "" }
+        : args[3] === walPath
+          ? { exitCode: 0, stdout: "p200\ncopencode\nf12\n" }
+          : { exitCode: 1, stdout: "" },
+    });
+
+    expect(result.safe).toBe(false);
+    expect(result.count).toBe(1);
+    expect(result.pids).toEqual([200]);
   });
 
-  test("classifyPgrepExitCode: exit 127 (command not found) → error (unsafe)", () => {
-    expect(classifyPgrepExitCode(127)).toBe("error");
+  test("deduplicates a PID across file descriptors and database paths", () => {
+    const result = checkForOtherOpencodeProcesses(dbPath, {
+      ownPid: 100,
+      spawnSync: (args) => args[3] === dbPath
+        ? { exitCode: 0, stdout: "p200\ncopencode\nf12\nf24\n" }
+        : args[3] === walPath
+          ? { exitCode: 0, stdout: "p200\ncopencode\nf37\n" }
+          : { exitCode: 1, stdout: "" },
+    });
+
+    expect(result.safe).toBe(false);
+    expect(result.count).toBe(1);
+    expect(result.pids).toEqual([200]);
   });
 
-  test("classifyPgrepExitCode: exit 2 → error (unsafe)", () => {
-    expect(classifyPgrepExitCode(2)).toBe("error");
+  test("does not filter holders by command name", () => {
+    const result = checkForOtherOpencodeProcesses(dbPath, {
+      ownPid: 100,
+      spawnSync: (args) => args[3] === dbPath
+        ? { exitCode: 0, stdout: "p200\ncmagic-context-dashboard\nf12\n" }
+        : { exitCode: 1, stdout: "" },
+    });
+
+    expect(result.safe).toBe(false);
+    expect(result.holders).toEqual([{ pid: 200, command: "magic-context-dashboard" }]);
   });
 
-  test("classifyPgrepExitCode: null exit code → error (unsafe)", () => {
-    expect(classifyPgrepExitCode(null)).toBe("error");
+  test("own PID as the sole holder is safe", () => {
+    const result = checkForOtherOpencodeProcesses(dbPath, {
+      ownPid: 100,
+      spawnSync: (args) => args[3] === dbPath
+        ? { exitCode: 0, stdout: "p100\ncopencode\nf12\n" }
+        : { exitCode: 1, stdout: "" },
+    });
+
+    expect(result).toMatchObject({ safe: true, count: 0, pids: [] });
+  });
+
+  test("no holders on any database path is safe", () => {
+    const result = checkForOtherOpencodeProcesses(dbPath, {
+      ownPid: 100,
+      spawnSync: () => ({ exitCode: 1, stdout: "" }),
+    });
+
+    expect(result).toMatchObject({ safe: true, count: 0, pids: [] });
+  });
+
+  test("non-0/1 lsof exit code refuses closed", () => {
+    const refusal = refuseIfOtherOpencodeProcesses(dbPath, {
+      ownPid: 100,
+      spawnSync: () => ({ exitCode: 2, stdout: "" }),
+    });
+
+    expect(refusal).toEqual({
+      refused: true,
+      reason: expect.stringContaining("lsof"),
+      instruction: "Close all OpenCode instances and re-run.",
+    });
+  });
+
+  test("lsof spawn failure refuses closed", () => {
+    const refusal = refuseIfOtherOpencodeProcesses(dbPath, {
+      ownPid: 100,
+      spawnSync: () => {
+        throw new Error("spawn failed");
+      },
+    });
+
+    expect(refusal).toEqual({
+      refused: true,
+      reason: expect.stringContaining("spawn failed"),
+      instruction: "Close all OpenCode instances and re-run.",
+    });
+  });
+
+  test("unparseable lsof output refuses closed", () => {
+    const refusal = refuseIfOtherOpencodeProcesses(dbPath, {
+      ownPid: 100,
+      spawnSync: (args) => args[3] === dbPath
+        ? { exitCode: 0, stdout: "not-lsof-output\n" }
+        : { exitCode: 1, stdout: "" },
+    });
+
+    expect(refusal).toEqual({
+      refused: true,
+      reason: expect.stringContaining("lsof"),
+      instruction: "Close all OpenCode instances and re-run.",
+    });
   });
 
   // ── prune-older floor ──────────────────────────────────────────────────────

--- a/.config/opencode/scripts/opencode-doctor.ts
+++ b/.config/opencode/scripts/opencode-doctor.ts
@@ -1155,65 +1155,148 @@ export function pruneEvents(
   return result;
 }
 
-/**
- * Classify a pgrep exit code into a process-check result.
- * Exported for unit testing.
- *   0  → pgrep found matches (processes exist)
- *   1  → pgrep found no matches (safe)
- *   other → pgrep itself failed / unavailable (treat as UNSAFE)
- */
-export function classifyPgrepExitCode(exitCode: number | null): "has_procs" | "no_procs" | "error" {
-  if (exitCode === 0) return "has_procs";
-  if (exitCode === 1) return "no_procs";
-  return "error";
-}
+type ProcessHolder = {
+  pid: number;
+  command: string;
+};
 
 export type ProcessCheckDependencies = {
   ownPid?: number;
   spawnSync?: (args: string[]) => { exitCode: number | null; stdout?: unknown };
 };
 
+type ProcessCheckResult = {
+  safe: boolean;
+  count: number;
+  pids: number[];
+  holders: ProcessHolder[];
+  error?: string;
+};
+
+function outputToString(output: unknown): string | null {
+  if (typeof output === "string") return output;
+  if (output instanceof Uint8Array) return new TextDecoder().decode(output);
+  return null;
+}
+
+function parseLsofOutput(output: unknown): ProcessHolder[] | null {
+  const text = outputToString(output);
+  if (text == null || text.trim() === "") return null;
+
+  const holders = new Map<number, ProcessHolder>();
+  let currentPid: number | null = null;
+  let currentCommand: string | null = null;
+
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+    if (line === "") continue;
+
+    const field = line[0];
+    const value = line.slice(1);
+    if (field === "p") {
+      if (!/^\d+$/.test(value)) return null;
+      const pid = Number(value);
+      if (!Number.isSafeInteger(pid) || pid < 1) return null;
+      if (currentPid != null && currentCommand == null) return null;
+      currentPid = pid;
+      currentCommand = null;
+    } else if (field === "c") {
+      if (currentPid == null || value === "" || currentCommand != null) return null;
+      currentCommand = value;
+      holders.set(currentPid, { pid: currentPid, command: value });
+    } else if (field === "f") {
+      if (currentPid == null || currentCommand == null || value === "") return null;
+    } else {
+      return null;
+    }
+  }
+
+  return currentPid != null && currentCommand != null ? [...holders.values()] : null;
+}
+
 export function checkForOtherOpencodeProcesses(
+  dbPath: string = DEFAULT_DB_PATH,
   dependencies: ProcessCheckDependencies = {},
-): { safe: boolean; count: number; pids: number[] } {
+): ProcessCheckResult {
   const spawnSync = dependencies.spawnSync ?? ((args: string[]) => Bun.spawnSync(args));
-  const result = spawnSync(["pgrep", "-f", "opencode"]);
-  const classification = classifyPgrepExitCode(result.exitCode);
-
-  if (classification === "error") {
-    // pgrep unavailable or crashed — cannot verify safety, refuse to proceed
-    return { safe: false, count: -1, pids: [] };
-  }
-
-  if (classification === "no_procs") {
-    return { safe: true, count: 0, pids: [] };
-  }
-
-  const output = result.stdout instanceof Buffer
-    ? result.stdout.toString("utf8")
-    : String(result.stdout ?? "");
-
   const ownPid = dependencies.ownPid ?? process.pid;
-  const pids = output
-    .split("\n")
-    .map((line) => parseInt(line.trim(), 10))
-    .filter((pid) => !isNaN(pid) && pid !== ownPid);
+  const holdersByPid = new Map<number, ProcessHolder>();
+  const paths = [dbPath, `${dbPath}-wal`, `${dbPath}-shm`];
 
-  return { safe: pids.length === 0, count: pids.length, pids };
+  for (const path of paths) {
+    let result: { exitCode: number | null; stdout?: unknown };
+    try {
+      result = spawnSync(["lsof", "-F", "pc", path]);
+    } catch (error) {
+      return {
+        safe: false,
+        count: -1,
+        pids: [],
+        holders: [],
+        error: `lsof failed for ${path}: ${formatErrorMessage(error)}`,
+      };
+    }
+
+    if (result.exitCode === 1) {
+      const output = result.stdout == null ? "" : outputToString(result.stdout);
+      if (output == null || output.trim() !== "") {
+        return {
+          safe: false,
+          count: -1,
+          pids: [],
+          holders: [],
+          error: `lsof returned unparseable output for ${path}`,
+        };
+      }
+      continue;
+    }
+
+    if (result.exitCode !== 0) {
+      return {
+        safe: false,
+        count: -1,
+        pids: [],
+        holders: [],
+        error: `lsof returned exit code ${String(result.exitCode)} for ${path}`,
+      };
+    }
+
+    const holders = parseLsofOutput(result.stdout);
+    if (holders == null) {
+      return {
+        safe: false,
+        count: -1,
+        pids: [],
+        holders: [],
+        error: `lsof returned unparseable output for ${path}`,
+      };
+    }
+    for (const holder of holders) {
+      if (holder.pid !== ownPid) holdersByPid.set(holder.pid, holder);
+    }
+  }
+
+  const holders = [...holdersByPid.values()];
+  const pids = holders.map(({ pid }) => pid);
+
+  return { safe: holders.length === 0, count: holders.length, pids, holders };
 }
 
 // ─── Safety Gate Helpers ──────────────────────────────────────────────────────
 
 /**
- * Returns a refused SectionResultData if other OpenCode processes are running,
+ * Returns a refused SectionResultData if another process holds the database,
  * or null if it is safe to proceed with a destructive DB operation.
  */
-function refuseIfOtherOpencodeProcesses(): SectionResultData | null {
-  const procCheck = checkForOtherOpencodeProcesses();
+export function refuseIfOtherOpencodeProcesses(
+  dbPath: string = DEFAULT_DB_PATH,
+  dependencies: ProcessCheckDependencies = {},
+): SectionResultData | null {
+  const procCheck = checkForOtherOpencodeProcesses(dbPath, dependencies);
   if (!procCheck.safe) {
     const reason = procCheck.count === -1
-      ? "Could not verify other OpenCode processes are stopped (pgrep unavailable); refusing to run this destructive operation. Re-run where process detection works."
-      : `Found ${procCheck.count} other opencode process(es) running (PIDs: ${procCheck.pids.join(", ")}). Close all OpenCode instances and re-run.`;
+      ? `Could not verify database holders with lsof (${procCheck.error ?? "unknown error"}); refusing to run this destructive operation. Re-run where process detection works.`
+      : `Found ${procCheck.count} process(es) holding the OpenCode database: ${procCheck.holders.map(({ command, pid }) => `${command} (PID ${pid})`).join(", ")}. Close all OpenCode instances and re-run.`;
     return {
       refused: true,
       reason,
@@ -1446,7 +1529,7 @@ async function runDbPruneExecute(options: CliOptions): Promise<SectionResult> {
   const cutoffDate = new Date(cutoffMs).toISOString().slice(0, 10);
 
   // Safety gate: check for other opencode processes
-  const procRefusal = refuseIfOtherOpencodeProcesses();
+  const procRefusal = refuseIfOtherOpencodeProcesses(options.dbPath);
   if (procRefusal != null) {
     return { label: "DB Prune (refused)", data: procRefusal };
   }
@@ -1559,7 +1642,7 @@ async function runDbEventPruneExecute(options: CliOptions): Promise<SectionResul
   const days = options.pruneEventsOlderDays as number;
   const cutoffMs = Date.now() - days * 24 * 3600 * 1000;
   const cutoffDate = new Date(cutoffMs).toISOString().slice(0, 10);
-  const procRefusal = refuseIfOtherOpencodeProcesses();
+  const procRefusal = refuseIfOtherOpencodeProcesses(options.dbPath);
   if (procRefusal != null) {
     return {
       label: "DB Event Prune (refused)",
@@ -1604,7 +1687,7 @@ async function runSetIncrementalVacuum(options: CliOptions): Promise<SectionResu
   const label = "DB Set Incremental Vacuum";
 
   // Safety gate: check for other opencode processes
-  const procRefusal = refuseIfOtherOpencodeProcesses();
+  const procRefusal = refuseIfOtherOpencodeProcesses(options.dbPath);
   if (procRefusal != null) {
     return { label: `${label} (refused)`, data: procRefusal };
   }

--- a/.config/opencode/scripts/opencode-doctor.ts
+++ b/.config/opencode/scripts/opencode-doctor.ts
@@ -2208,8 +2208,13 @@ async function main(): Promise<void> {
   process.exit(0);
 }
 
-main().catch((error: unknown) => {
-  const message = error instanceof Error ? error.message : String(error);
-  console.error(`OpenCode doctor failed: ${message}`);
-  process.exit(1);
-});
+// Only run the CLI when executed directly. Without this guard, importing the
+// module for tests runs the full doctor, which spawns a server and floods
+// test output with report text.
+if (import.meta.main) {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`OpenCode doctor failed: ${message}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
`opencode-doctor` refuses to run its destructive operations — `--prune-older --execute`, `--prune-events-older --execute`, `--set-incremental-vacuum` — while another process is using the database. That interlock did not work.

It shelled out to `pgrep -f "opencode"`, and **`pgrep` cannot see the OpenCode process tree from a process running inside it**. With the TUI at PID 75090 and its `harness` parent at 75084, every variant came back empty:

```
pgrep -f opencode          -> (empty) rc=1
pgrep -x opencode          -> (empty) rc=1
pgrep -f harness-darwin-arm64 -> (empty) rc=1
pgrep .        | grep -x 75090 -> not present   (603 processes enumerated)
pgrep -x Finder            -> 622 rc=0
```

`ps` listed both PIDs plainly the whole time. From a clean Terminal window `pgrep -f opencode` finds them; from inside the session it finds nothing. Since the doctor is normally invoked from within OpenCode, the gate reported "nothing running" and destructive operations were cleared to proceed against a live ~68 GB database.

## Fix

Ask who actually holds the file instead of guessing from process names. `lsof` works from the context where `pgrep` fails, checking the database plus its `-wal` and `-shm` siblings, and costs ~0.4s because it reads the kernel FD table rather than the file.

It also catches holders no name heuristic would find — a `magic-context-dashboard` process was holding the database alongside OpenCode.

The gate fails closed on every uncertain path: a spawn failure, any exit code other than 0 or 1, output that doesn't parse, or a stray field in the record stream all produce a refusal. A detection method that reports "nothing found" when it cannot actually see is worse than none here, because it converts an unsafe state into a green light. Refusals name each holder as `command (PID n)`.

## Entrypoint guard

The module called `main()` unconditionally at import, so importing it from the test suite ran the whole doctor — spawning a server and burying the summary under report output, leaving the exit code as the only trustworthy signal. Guarded with `import.meta.main`. Test output went from an unreadable dump to:

```
 84 pass
 0 fail
 319 expect() calls
```

## Verification

From a plain Terminal window, outside any OpenCode session.

With OpenCode running:

```
  pgrep -f opencode -> 2661 2662 75090 (rc=0)
  lsof holders:
    75090 opencode

  safe          : false
  holders       : opencode (PID 75090)
  DESTRUCTIVE OP WOULD: REFUSE
```

With OpenCode closed:

```
  pgrep -f opencode -> (rc=1)
  lsof holders:
    (none)

  safe          : true
  holder count  : 0
```

And the real command, which previously would have proceeded:

```
$ mise run opencode:doctor -- --prune-older=3650 --execute

DB Prune (refused)
{
  "refused": true,
  "reason": "Found 1 process(es) holding the OpenCode database: opencode (PID 4444). Close all OpenCode instances and re-run."
}
```

Nothing was deleted at any point.

## Note

Destructive operations now also refuse while the Magic Context dashboard is running, since it holds the database too. That is intended — a concurrent holder is a concurrent holder, and the refusal names it. Allowlisting by name would reintroduce exactly the assumption that made the previous gate fail.

The tests covering these fail-closed paths still don't run in CI (#2366).
