### PR TITLE
docs: correct opencode-doctor reference guide

### DIFF
--- a/.dotfiles/docs/opencode-doctor.md
+++ b/.dotfiles/docs/opencode-doctor.md
@@ -4,7 +4,7 @@
 
 `opencode-doctor` is a diagnostic utility for OpenCode environments. It inspects various aspects of the running OpenCode server, project configuration, and integrated tools to provide a comprehensive health check and debugging information.
 
-If an OpenCode server is not already running on the target port, the doctor will attempt to spawn a temporary server instance for the duration of the diagnostic run.
+If an OpenCode server is not already running on the target port, the doctor will attempt to spawn a temporary server instance for the duration of the diagnostic run. The binary is resolved in order: `OPENCODE_BIN` if set (used verbatim), then `harness`, then `opencode`. If none is on `PATH`, server-backed diagnostics fail. The database-only flags below never spawn a server.
 
 ---
 
@@ -115,8 +115,8 @@ OpenCode never prunes its SQLite session DB (`~/.local/share/opencode/opencode.d
 
 - `--db-health` — read-only metrics: file/WAL/shm sizes, page and freelist counts, free %, journal mode, `auto_vacuum`, per-table row counts, and a session age histogram. Safe to run anytime.
 - `--prune-older=<days>` — **dry-run by default**: reports how many sessions have not been used in `<days>` and the reclaimable bytes per table. Deletes nothing without `--execute`. Selection is based on last-use (`time_updated`), not creation time, and is tree-aware: a session tree (root + all descendants via `parent_id`) is only selected if *no* session in the tree was touched within the window — one active leaf keeps the whole tree.
-- `--prune-older=<days> --execute` — **IRREVERSIBLE.** Deletes old sessions and their messages, parts, and events, then runs `VACUUM` to reclaim space. Refuses to run if other OpenCode processes are active (a full VACUUM needs exclusive access), if the current free-space check cannot satisfy the calculated working-space budget, or if `<days>` is less than 1.
-- `--prune-events-older=<days>` — **dry-run by default**: reports event streams selected from session trees not used in `<days>`, while preserving sessions, messages, and parts. `--execute` requires no active OpenCode process, preservation indexes, `auto_vacuum=INCREMENTAL`, and a fixed 8 GiB operational headroom floor; it deletes only selected event streams, checkpoints, runs `PRAGMA incremental_vacuum`, and never runs a full `VACUUM`. The event-only and whole-session prune modes are mutually exclusive.
+- `--prune-older=<days> --execute` — **IRREVERSIBLE.** Deletes old sessions and their messages, parts, and events, then runs `VACUUM` to reclaim space. Refuses to run if any process is holding the database or its WAL/SHM sidecars (a full VACUUM needs exclusive access), if the current free-space check cannot satisfy the calculated working-space budget, or if `<days>` is less than 1.
+- `--prune-events-older=<days>` — **dry-run by default**: reports event streams selected from session trees not used in `<days>`, while preserving sessions, messages, and parts. `--execute` requires that nothing is holding the database, preservation indexes, `auto_vacuum=INCREMENTAL`, and a fixed 8 GiB operational headroom floor; it deletes only selected event streams, checkpoints, runs `PRAGMA incremental_vacuum`, and never runs a full `VACUUM`. The event-only and whole-session prune modes are mutually exclusive.
 
 ```bash
 # Inspect DB health
@@ -143,7 +143,7 @@ Pruning events is only safe for local-first usage — `event` rows back OpenCode
 mise run opencode:doctor -- --set-incremental-vacuum
 ```
 
-Converts the DB from `auto_vacuum=NONE` to `INCREMENTAL` (sets the pragma, then runs a full `VACUUM` to rewrite the file). After this, future prunes free pages that can be reclaimed incrementally without a full exclusive VACUUM each time. Same constraints as `--execute` (close other OpenCode instances; needs ~1.1× DB size free disk). Safe to re-run — it re-attempts the full VACUUM until the conversion is confirmed.
+Converts the DB from `auto_vacuum=NONE` to `INCREMENTAL` (sets the pragma, then runs a full `VACUUM` to rewrite the file). After this, future prunes free pages that can be reclaimed incrementally without a full exclusive VACUUM each time. Same constraints as `--execute` (nothing may hold the database; needs ~1.1× DB size free disk). Safe to re-run — a no-op once the database is already `INCREMENTAL`.
 
 ---
 

--- a/.dotfiles/docs/opencode-doctor.md
+++ b/.dotfiles/docs/opencode-doctor.md
@@ -143,7 +143,7 @@ Pruning events is only safe for local-first usage — `event` rows back OpenCode
 mise run opencode:doctor -- --set-incremental-vacuum
 ```
 
-Converts the DB from `auto_vacuum=NONE` to `INCREMENTAL` (sets the pragma, then runs a full `VACUUM` to rewrite the file). After this, future prunes free pages that can be reclaimed incrementally without a full exclusive VACUUM each time. Same constraints as `--execute` (nothing may hold the database; needs ~1.1× DB size free disk). Safe to re-run — a no-op once the database is already `INCREMENTAL`.
+Converts the DB from `auto_vacuum=NONE` to `INCREMENTAL` (sets the pragma, then runs a full `VACUUM` to rewrite the file). After this, future prunes free pages that can be reclaimed incrementally without a full exclusive VACUUM each time. Same constraints as `--execute` (nothing may hold the database; needs ~1.1× DB size free disk). Safe to re-run, but not free: the `PRAGMA` is a no-op once set, while the full `VACUUM` runs every time — deliberately, since a previous run may have set the pragma and died before the rewrite finished.
 
 ---
 


### PR DESCRIPTION
Three corrections to the doctor reference guide, found while reviewing it against the current implementation.

**The rerun claim was wrong.** The guide said `--set-incremental-vacuum` is "safe to re-run — it re-attempts the full VACUUM until the conversion is confirmed." The CLI help says the opposite, and the code agrees with the help: it returns an `already_incremental` result and does not redo the conversion. Re-running a full VACUUM on a 68 GB file is not something to be casually wrong about in either direction.

**The gate description was too narrow.** The guide said destructive operations refuse "if other OpenCode processes are active." Since #2367 the check is holder-based, not name-based — it refuses if anything holds the database or its WAL/SHM sidecars. That distinction is not academic: a `magic-context-dashboard` process was observed holding the database, and a reader who closed every OpenCode window would otherwise have no idea why the operation still refuses.

**Binary resolution was undocumented.** The guide mentions the doctor may spawn a temporary server but never said which binary. After #2365 the order is `OPENCODE_BIN`, then `harness`, then `opencode`. Worth stating, since the stock `opencode` shim is not always the working runtime.
