### PR TITLE
chore(opencode): add a copilot fallback for fast-generic

### DIFF
--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -42,7 +42,7 @@
         "mcps": []
       },
       "fast-generic": {
-        "model": "openai/gpt-5.3-codex-spark",
+        "model": ["openai/gpt-5.3-codex-spark", "github-copilot/gpt-5.4-mini"],
         "variant": "low"
       }
     },
@@ -132,7 +132,7 @@
         "mcps": []
       },
       "fast-generic": {
-        "model": "openai/gpt-5.3-codex-spark",
+        "model": ["openai/gpt-5.3-codex-spark", "github-copilot/gpt-5.4-mini"],
         "variant": "low"
       }
     },
@@ -176,7 +176,7 @@
         "mcps": []
       },
       "fast-generic": {
-        "model": "openai/gpt-5.3-codex-spark",
+        "model": ["openai/gpt-5.3-codex-spark", "github-copilot/gpt-5.4-mini"],
         "variant": "low"
       }
     },


### PR DESCRIPTION
Gives `fast-generic` a second model to fall through to when the primary starts rate-limiting, instead of aborting the session.

OMO expresses a fallback as an ordered chain on the agent's `model` field — an array rather than a string, tried in order. There is no preset-level or global fallback setting, so it lives on the agent:

```jsonc
"fast-generic": {
  "model": ["openai/gpt-5.3-codex-spark", "github-copilot/gpt-5.4-mini"],
  "variant": "low"
}
```

Applied to `openai`, `mixed`, and `mixed-fable`. The two opencode-go presets keep a single model.

`fast-generic` is the right place for this. It runs routine mechanical work — git reconnaissance, commit preparation, no-edit validation — which a mini model completes acceptably, and it's the highest-call-count lane, so it's where rate limits actually land. The agents where a mid-task quality drop would matter are deliberately left to abort visibly instead.

`gpt-5.4-mini` supports the `low` variant, so the variant carries over cleanly on a swap. Root `fallback` stays unset, so the defaults apply: enabled, three consecutive rate-limit responses on a model before moving to the next.

Verified against a running server rather than by reading config: under the active `mixed` preset, `fast-generic` resolves to `openai/gpt-5.3-codex-spark` with `variant: low` and its prompt intact — the array is accepted and the primary is taken from its first entry.
