### PR TITLE
fix(opencode): correct destructive-operation help text

### DIFF
--- a/.config/opencode/scripts/opencode-doctor.ts
+++ b/.config/opencode/scripts/opencode-doctor.ts
@@ -383,7 +383,7 @@ DB Maintenance (no server required):
   --prune-events-older <days>
                              Event-only retention: delete selected event streams while preserving
                              sessions, messages, and parts. Tree-aware and dry-run by default.
-                             --execute requires no active OpenCode process, indexed preservation
+                             --execute requires that nothing holds the DB, indexed preservation
                              predicates, auto_vacuum=INCREMENTAL, and 8 GiB operational headroom;
                              it uses incremental vacuum and never runs full VACUUM.
                              Mutually exclusive with --prune-older.
@@ -394,8 +394,8 @@ DB Maintenance (no server required):
                             then runs a full VACUUM to rewrite the file with the new mode.
                             After this, future prunes can reclaim free pages incrementally
                             via PRAGMA incremental_vacuum without a full exclusive VACUUM.
-                            Requires all other OpenCode instances to be closed and ~1.1x
-                            the DB file size in free disk space (same constraints as prune
+                            Requires that nothing holds the DB or its WAL/SHM siblings,
+                            and ~1.1x the DB file size free (same constraints as prune
                             --execute). Safe to re-run, but not free: the PRAGMA is a
                             no-op once set, while the full VACUUM runs every time.
   --db-path <path>          Override DB path (default: ~/.local/share/opencode/opencode.db)

--- a/.config/opencode/scripts/opencode-doctor.ts
+++ b/.config/opencode/scripts/opencode-doctor.ts
@@ -396,7 +396,8 @@ DB Maintenance (no server required):
                             via PRAGMA incremental_vacuum without a full exclusive VACUUM.
                             Requires all other OpenCode instances to be closed and ~1.1x
                             the DB file size in free disk space (same constraints as prune
-                            --execute). Safe to re-run: no-op if already INCREMENTAL.
+                            --execute). Safe to re-run, but not free: the PRAGMA is a
+                            no-op once set, while the full VACUUM runs every time.
   --db-path <path>          Override DB path (default: ~/.local/share/opencode/opencode.db)
 
 Sections:


### PR DESCRIPTION
Two corrections to `--help` for the destructive database operations. Both are cases where the help text describes behavior the code does not have.

## Re-running the incremental-vacuum conversion is not a no-op

The help said:

```
Safe to re-run: no-op if already INCREMENTAL.
```

`convertToIncrementalVacuum` always runs a full `VACUUM`, regardless of the starting `auto_vacuum` mode. Only the `PRAGMA` is skipped when the mode is already set. That is deliberate, and the comment above it explains why:

> even if already INCREMENTAL, we still run a full VACUUM to guarantee the on-disk layout is correct — a previous run may have set the PRAGMA but failed before VACUUM completed, leaving the file in a half-converted state

Two tests pin the behavior, including the already-INCREMENTAL case. The wording matters because on the current ~68 GB database a re-run is a full exclusive file rewrite, not an instant check.

This is also the line that misled the reference guide, which claimed the same thing until it was corrected in #2370.

## The gate is holder-based, not name-based

The help described the prerequisites as "no active OpenCode process" and "all other OpenCode instances closed". Since #2367 the check asks who actually holds the database and its WAL/SHM siblings, and refuses on any holder regardless of process name. A `magic-context-dashboard` process has held it in practice — closing every OpenCode window would not clear the gate in that case, and the old wording gives no hint why.

#2370 already corrected this wording in `docs/opencode-doctor.md`, so until now the guide and `--help` disagreed.

The refusal message itself is unchanged: it names each holder as `command (PID n)`, which is already actionable.

Verified by rendering `--help` and running the suite: 84 pass, 0 fail.

Closes #2371
