### PR TITLE
fix(opencode): tell the operator to close the actual holders

### DIFF
--- a/.config/opencode/scripts/opencode-doctor.test.ts
+++ b/.config/opencode/scripts/opencode-doctor.test.ts
@@ -1639,7 +1639,7 @@ describe("DB guards (unit)", () => {
     expect(refusal).toEqual({
       refused: true,
       reason: expect.stringContaining("magic-context-dashboard (PID 200)"),
-      instruction: "Close all OpenCode instances and re-run.",
+      instruction: "Close the process(es) listed above and re-run.",
     });
   });
 
@@ -1714,7 +1714,7 @@ describe("DB guards (unit)", () => {
     expect(refusal).toEqual({
       refused: true,
       reason: expect.stringContaining("lsof"),
-      instruction: "Close all OpenCode instances and re-run.",
+      instruction: "Re-run where lsof can inspect the database.",
     });
   });
 
@@ -1729,7 +1729,7 @@ describe("DB guards (unit)", () => {
     expect(refusal).toEqual({
       refused: true,
       reason: expect.stringContaining("spawn failed"),
-      instruction: "Close all OpenCode instances and re-run.",
+      instruction: "Re-run where lsof can inspect the database.",
     });
   });
 
@@ -1744,7 +1744,7 @@ describe("DB guards (unit)", () => {
     expect(refusal).toEqual({
       refused: true,
       reason: expect.stringContaining("lsof"),
-      instruction: "Close all OpenCode instances and re-run.",
+      instruction: "Re-run where lsof can inspect the database.",
     });
   });
 

--- a/.config/opencode/scripts/opencode-doctor.ts
+++ b/.config/opencode/scripts/opencode-doctor.ts
@@ -1295,13 +1295,21 @@ export function refuseIfOtherOpencodeProcesses(
 ): SectionResultData | null {
   const procCheck = checkForOtherOpencodeProcesses(dbPath, dependencies);
   if (!procCheck.safe) {
-    const reason = procCheck.count === -1
-      ? `Could not verify database holders with lsof (${procCheck.error ?? "unknown error"}); refusing to run this destructive operation. Re-run where process detection works.`
-      : `Found ${procCheck.count} process(es) holding the OpenCode database: ${procCheck.holders.map(({ command, pid }) => `${command} (PID ${pid})`).join(", ")}. Close all OpenCode instances and re-run.`;
+    // The gate refuses on any holder, not just OpenCode, so the instruction
+    // points at the processes actually named rather than telling the operator
+    // to close OpenCode -- which would not clear a holder like the Magic
+    // Context dashboard. The detection-failure branch is a different problem
+    // and gets its own instruction.
+    const detectionFailed = procCheck.count === -1;
+    const reason = detectionFailed
+      ? `Could not verify database holders with lsof (${procCheck.error ?? "unknown error"}); refusing to run this destructive operation.`
+      : `Found ${procCheck.count} process(es) holding the OpenCode database: ${procCheck.holders.map(({ command, pid }) => `${command} (PID ${pid})`).join(", ")}.`;
     return {
       refused: true,
       reason,
-      instruction: "Close all OpenCode instances and re-run.",
+      instruction: detectionFailed
+        ? "Re-run where lsof can inspect the database."
+        : "Close the process(es) listed above and re-run.",
     };
   }
   return null;

--- a/.dotfiles/docs/solutions/2026-08-19-opencode-doctor-quiescence-gate-fail-open.md
+++ b/.dotfiles/docs/solutions/2026-08-19-opencode-doctor-quiescence-gate-fail-open.md
@@ -115,11 +115,20 @@ const holders = [...holdersByPid.values()];
 return {safe: holders.length === 0, count: holders.length, pids, holders};
 ```
 
-Refusals name the holders, which makes them actionable:
+Refusals name the holders, and the instruction points at those rather than at OpenCode — closing every OpenCode window would not clear a holder like the dashboard:
 
 ```text
-Found 1 process(es) holding the OpenCode database: opencode (PID 4444).
-Close all OpenCode instances and re-run.
+reason:      Found 2 process(es) holding the OpenCode database:
+             opencode (PID 86132), opencode (PID 90527).
+instruction: Close the process(es) listed above and re-run.
+```
+
+A failure to detect is a different problem and says so, since nothing was found and `lsof` could not look:
+
+```text
+reason:      Could not verify database holders with lsof (spawn failed);
+             refusing to run this destructive operation.
+instruction: Re-run where lsof can inspect the database.
 ```
 
 `pgrep` was removed entirely, along with `classifyPgrepExitCode`.


### PR DESCRIPTION
When a destructive database operation is refused, the message told the operator to close all OpenCode instances. The gate refuses on *any* process holding the database, regardless of name, so that instruction does not necessarily clear it. A Magic Context dashboard process has held the database in practice — closing every OpenCode window would leave the gate refusing with no explanation of why.

The reason string already names each holder as `command (PID n)`. The instruction now points at those:

```
"reason": "Found 2 process(es) holding the OpenCode database: opencode (PID 86132), opencode (PID 90527).",
"instruction": "Close the process(es) listed above and re-run."
```

The detection-failure branch was sharing that same instruction, which made even less sense there — nothing was found, `lsof` could not look. It gets its own now:

```
"reason": "Could not verify database holders with lsof (spawn failed); refusing to run this destructive operation.",
"instruction": "Re-run where lsof can inspect the database."
```

The redundant trailing sentence in each reason is dropped, since the instruction field carries it.

This completes the holder-based wording applied to the reference guide in #2370 and to `--help` in #2426 — the runtime message was the last place still describing the gate by process name.

Verified by running a real `--prune-older --execute` against the live database: it refuses, names both holders, and deletes nothing. Suite is 84 pass, 0 fail, with the four instruction assertions updated to match the branch they exercise.
