### PR TITLE
test(opencode): make the gate tests real and enforced

### DIFF
--- a/.config/opencode/scripts/ollama-distill.ts
+++ b/.config/opencode/scripts/ollama-distill.ts
@@ -145,7 +145,7 @@ export async function withSqliteBusyRetry<T>(
 
 /**
  * Open a read-only SQLite connection with R17 hardening:
- * - URI mode with `mode=ro`
+ * - SQLITE_OPEN_READONLY via `readonly: true`
  * - PRAGMA query_only=ON
  * - PRAGMA busy_timeout=5000
  * - Read-only verification probe (CREATE TEMP TABLE must throw)
@@ -155,8 +155,12 @@ export async function withSqliteBusyRetry<T>(
  * // See: docs/solutions/2026-05-22-bun-sqlite-readonly-wal-pattern.md
  */
 export function openDatabase(dbPath: string): Database {
-  const uri = "file:" + dbPath + "?mode=ro";
-  const db = new Database(uri, { readonly: true });
+  // A `file:...?mode=ro` URI is deliberately not used: URI filenames require
+  // SQLite's URI handling to be enabled, and where it is not the whole string
+  // is treated as a literal path, so the open fails with "unable to open
+  // database file". `readonly: true` maps to SQLITE_OPEN_READONLY and carries
+  // the guarantee on its own; the pragma and probe below still apply.
+  const db = new Database(dbPath, { readonly: true });
 
   db.exec("PRAGMA query_only=ON");
   db.exec("PRAGMA busy_timeout=5000");
@@ -166,7 +170,7 @@ export function openDatabase(dbPath: string): Database {
   //
   // This probe is bun:sqlite-specific. Standard SQLite routes TEMP tables to a
   // separate temp file that bypasses the main-db read-only enforcement, but
-  // bun:sqlite with `{ readonly: true }` + `mode=ro` rejects TEMP writes too
+  // bun:sqlite with `{ readonly: true }` + `query_only` rejects TEMP writes too
   // (verified empirically). If a future Bun release changes that, the probe
   // will silently stop rejecting and leave the connection unverified — re-test
   // this after Bun upgrades and consider switching to a probe that writes to

--- a/.config/opencode/scripts/opencode-doctor.test.ts
+++ b/.config/opencode/scripts/opencode-doctor.test.ts
@@ -1706,6 +1706,28 @@ describe("DB guards (unit)", () => {
     expect(result).toMatchObject({ safe: true, count: 0, pids: [] });
   });
 
+  test("lsof exit 1 with empty stdout and stderr is safe", () => {
+    const result = checkForOtherOpencodeProcesses(dbPath, {
+      ownPid: 100,
+      spawnSync: () => ({ exitCode: 1, stdout: "", stderr: "" }),
+    });
+
+    expect(result).toMatchObject({ safe: true, count: 0, pids: [] });
+  });
+
+  test("lsof exit 1 with empty stdout and non-empty stderr refuses closed", () => {
+    const refusal = refuseIfOtherOpencodeProcesses(dbPath, {
+      ownPid: 100,
+      spawnSync: () => ({ exitCode: 1, stdout: "", stderr: "permission denied" }),
+    });
+
+    expect(refusal).toEqual({
+      refused: true,
+      reason: expect.stringContaining("lsof"),
+      instruction: "Re-run where lsof can inspect the database.",
+    });
+  });
+
   test("non-0/1 lsof exit code refuses closed", () => {
     const refusal = refuseIfOtherOpencodeProcesses(dbPath, {
       ownPid: 100,
@@ -1945,6 +1967,8 @@ describe("DB guards (real lsof)", () => {
       const dbPath = join(dir, "held.db");
       const readyPath = join(dir, "holder.ready");
       writeFileSync(dbPath, "");
+      writeFileSync(`${dbPath}-wal`, "");
+      writeFileSync(`${dbPath}-shm`, "");
 
       let holder: ReturnType<typeof Bun.spawn> | undefined;
       try {
@@ -1996,6 +2020,8 @@ describe("DB guards (real lsof)", () => {
       const dir = makeTempDir();
       const dbPath = join(dir, "unheld.db");
       writeFileSync(dbPath, "");
+      writeFileSync(`${dbPath}-wal`, "");
+      writeFileSync(`${dbPath}-shm`, "");
 
       try {
         const result = checkForOtherOpencodeProcesses(dbPath);

--- a/.config/opencode/scripts/opencode-doctor.test.ts
+++ b/.config/opencode/scripts/opencode-doctor.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { $ } from "bun";
 import { Database } from "bun:sqlite";
-import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -24,6 +24,7 @@ import {
 
 const SCRIPT_PATH = "./opencode-doctor.ts";
 const TEST_TIMEOUT = 90000;
+const lsofTest = Bun.which("lsof") === null ? test.skip : test;
 
 let spawnedProcs: Array<Pick<ReturnType<typeof Bun.spawn>, "kill" | "exited">> = [];
 
@@ -1933,6 +1934,77 @@ describe("DB guards (unit)", () => {
       expect(result.exitCode).not.toBe(0);
     },
     { timeout: TEST_TIMEOUT }
+  );
+});
+
+describe("DB guards (real lsof)", () => {
+  lsofTest(
+    "detects a real external process holding the database path",
+    async () => {
+      const dir = makeTempDir();
+      const dbPath = join(dir, "held.db");
+      const readyPath = join(dir, "holder.ready");
+      writeFileSync(dbPath, "");
+
+      let holder: ReturnType<typeof Bun.spawn> | undefined;
+      try {
+        holder = Bun.spawn([process.execPath, "-e", `
+          const { openSync, writeFileSync } = require("node:fs");
+          openSync(process.env.HOLDER_PATH, "r");
+          writeFileSync(process.env.READY_PATH, "ready");
+          setInterval(() => {}, 1000);
+        `], {
+          env: {
+            ...process.env,
+            HOLDER_PATH: dbPath,
+            READY_PATH: readyPath,
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        spawnedProcs.push(holder);
+
+        const deadline = Date.now() + 5000;
+        while (!existsSync(readyPath) && Date.now() < deadline) await Bun.sleep(25);
+        expect(existsSync(readyPath)).toBe(true);
+
+        const result = checkForOtherOpencodeProcesses(dbPath);
+        expect(result.safe).toBe(false);
+        expect(result.pids).toContain(holder.pid);
+        const detectedHolder = result.holders.find(({ pid }) => pid === holder?.pid);
+        expect(detectedHolder?.command).toEqual(expect.any(String));
+        expect(detectedHolder?.command.length).toBeGreaterThan(0);
+        console.log(`real lsof detected holder pid=${holder.pid} command=${detectedHolder?.command}`);
+      } finally {
+        if (holder) {
+          try {
+            holder.kill("SIGTERM");
+            await Promise.race([holder.exited, Bun.sleep(2000)]);
+          } catch {
+            /* already exited */
+          }
+        }
+        removeTempDir(dir);
+      }
+    },
+    { timeout: TEST_TIMEOUT },
+  );
+
+  lsofTest(
+    "reports no holder for an unheld temporary database path",
+    () => {
+      const dir = makeTempDir();
+      const dbPath = join(dir, "unheld.db");
+      writeFileSync(dbPath, "");
+
+      try {
+        const result = checkForOtherOpencodeProcesses(dbPath);
+        expect(result).toMatchObject({ safe: true, count: 0, pids: [], holders: [] });
+      } finally {
+        removeTempDir(dir);
+      }
+    },
+    { timeout: TEST_TIMEOUT },
   );
 });
 

--- a/.config/opencode/scripts/opencode-doctor.test.ts
+++ b/.config/opencode/scripts/opencode-doctor.test.ts
@@ -25,6 +25,10 @@ import {
 const SCRIPT_PATH = "./opencode-doctor.ts";
 const TEST_TIMEOUT = 90000;
 const lsofTest = Bun.which("lsof") === null ? test.skip : test;
+const opencodeBin = process.env.OPENCODE_BIN
+  ? Bun.which(process.env.OPENCODE_BIN)
+  : Bun.which("harness") ?? Bun.which("opencode");
+const opencodeTest = opencodeBin === null ? test.skip : test;
 
 let spawnedProcs: Array<Pick<ReturnType<typeof Bun.spawn>, "kill" | "exited">> = [];
 
@@ -1381,7 +1385,7 @@ describe("opencode-doctor CLI", () => {
     { timeout: TEST_TIMEOUT }
   );
 
-  test(
+  opencodeTest(
     "spawns server and retrieves health section",
     async () => {
       const result = await $`bun ${SCRIPT_PATH} --only=health --no-tui`.nothrow().text();
@@ -1392,7 +1396,7 @@ describe("opencode-doctor CLI", () => {
     { timeout: TEST_TIMEOUT }
   );
 
-  test(
+  opencodeTest(
     "--only flag filters to specified sections only",
     async () => {
       const result = await $`bun ${SCRIPT_PATH} --only=server,health --no-tui`.nothrow().text();
@@ -1406,7 +1410,7 @@ describe("opencode-doctor CLI", () => {
     { timeout: TEST_TIMEOUT }
   );
 
-  test(
+  opencodeTest(
     "--json outputs parseable JSON array of sections",
     async () => {
       const result = await $`bun ${SCRIPT_PATH} --only=health --json`.nothrow().text();
@@ -1424,7 +1428,7 @@ describe("opencode-doctor CLI", () => {
     { timeout: TEST_TIMEOUT }
   );
 
-  test(
+  opencodeTest(
     "--format=json is equivalent to --json flag",
     async () => {
       const result = await $`bun ${SCRIPT_PATH} --only=server --format=json`.nothrow().text();
@@ -1554,7 +1558,7 @@ describe("signal handling", () => {
 });
 
 describe("error handling", () => {
-  test(
+  opencodeTest(
     "invalid --only value warns but continues with valid sections",
     async () => {
       const result = await $`bun ${SCRIPT_PATH} --only=invalid_section,server`
@@ -1569,7 +1573,7 @@ describe("error handling", () => {
     { timeout: TEST_TIMEOUT }
   );
 
-  test(
+  opencodeTest(
     "invalid --port value warns and uses default",
     async () => {
       const result = await $`bun ${SCRIPT_PATH} --port=invalid --only=server`
@@ -1967,8 +1971,6 @@ describe("DB guards (real lsof)", () => {
       const dbPath = join(dir, "held.db");
       const readyPath = join(dir, "holder.ready");
       writeFileSync(dbPath, "");
-      writeFileSync(`${dbPath}-wal`, "");
-      writeFileSync(`${dbPath}-shm`, "");
 
       let holder: ReturnType<typeof Bun.spawn> | undefined;
       try {
@@ -2015,17 +2017,18 @@ describe("DB guards (real lsof)", () => {
   );
 
   lsofTest(
-    "reports no holder for an unheld temporary database path",
+    "reports no holder for a clean-shutdown database with absent sidecars",
     () => {
       const dir = makeTempDir();
       const dbPath = join(dir, "unheld.db");
       writeFileSync(dbPath, "");
-      writeFileSync(`${dbPath}-wal`, "");
-      writeFileSync(`${dbPath}-shm`, "");
 
       try {
+        expect(existsSync(`${dbPath}-wal`)).toBe(false);
+        expect(existsSync(`${dbPath}-shm`)).toBe(false);
         const result = checkForOtherOpencodeProcesses(dbPath);
         expect(result).toMatchObject({ safe: true, count: 0, pids: [], holders: [] });
+        console.log(`real lsof clean-shutdown safe=${result.safe} count=${result.count} sidecars=absent`);
       } finally {
         removeTempDir(dir);
       }

--- a/.config/opencode/scripts/opencode-doctor.ts
+++ b/.config/opencode/scripts/opencode-doctor.ts
@@ -2215,6 +2215,7 @@ async function main(): Promise<void> {
       ? JSON.stringify(redactSecrets(sections.map((section) => ({
           label: section.label,
           ...extractData(section.data),
+          ...(section.error == null ? {} : { error: section.error }),
         }))), null, 2)
       : sections.map((section) => renderSection(section, options)).join("\n");
 
@@ -2227,6 +2228,7 @@ async function main(): Promise<void> {
     ? JSON.stringify(redactSecrets(sections.map((section) => ({
         label: section.label,
         ...extractData(section.data),
+        ...(section.error == null ? {} : { error: section.error }),
       }))), null, 2)
     : sections.map((section) => renderSection(section, options)).join("\n");
 

--- a/.config/opencode/scripts/opencode-doctor.ts
+++ b/.config/opencode/scripts/opencode-doctor.ts
@@ -1163,7 +1163,7 @@ type ProcessHolder = {
 
 export type ProcessCheckDependencies = {
   ownPid?: number;
-  spawnSync?: (args: string[]) => { exitCode: number | null; stdout?: unknown };
+  spawnSync?: (args: string[]) => { exitCode: number | null; stdout?: unknown; stderr?: unknown };
 };
 
 type ProcessCheckResult = {
@@ -1225,7 +1225,7 @@ export function checkForOtherOpencodeProcesses(
   const paths = [dbPath, `${dbPath}-wal`, `${dbPath}-shm`];
 
   for (const path of paths) {
-    let result: { exitCode: number | null; stdout?: unknown };
+    let result: { exitCode: number | null; stdout?: unknown; stderr?: unknown };
     try {
       result = spawnSync(["lsof", "-F", "pc", path]);
     } catch (error) {
@@ -1247,6 +1247,16 @@ export function checkForOtherOpencodeProcesses(
           pids: [],
           holders: [],
           error: `lsof returned unparseable output for ${path}`,
+        };
+      }
+      const errorOutput = result.stderr == null ? "" : outputToString(result.stderr);
+      if (errorOutput == null || errorOutput.trim() !== "") {
+        return {
+          safe: false,
+          count: -1,
+          pids: [],
+          holders: [],
+          error: `lsof returned an error for ${path}: ${errorOutput ?? "unparseable stderr"}`,
         };
       }
       continue;

--- a/.config/opencode/scripts/opencode-doctor.ts
+++ b/.config/opencode/scripts/opencode-doctor.ts
@@ -1492,9 +1492,7 @@ export function convertToIncrementalVacuum(db: Database, dbPath: string): Increm
 async function runDbHealth(options: CliOptions): Promise<SectionResult> {
   let db: Database | null = null;
   try {
-    const uri = "file:" + options.dbPath + "?mode=ro";
-    db = new Database(uri, { readonly: true });
-    db.exec("PRAGMA busy_timeout=5000");
+    db = openReadOnlyDb(options.dbPath);
 
     const data = await withSqliteBusyRetry(() => computeDbHealth(db!, options.dbPath));
     return { label: "DB Health", data };
@@ -1505,6 +1503,23 @@ async function runDbHealth(options: CliOptions): Promise<SectionResult> {
   }
 }
 
+/**
+ * Opens the database read-only.
+ *
+ * `readonly: true` is the real guard -- it maps to SQLITE_OPEN_READONLY. A
+ * `file:...?mode=ro` URI is not used: URI filenames require SQLite's URI
+ * handling to be enabled, and where it is not the whole string is treated as a
+ * literal path, so the open fails with "unable to open database file". That is
+ * platform-dependent in practice, so the plain path gives the same guarantee
+ * everywhere. `query_only` is deliberately not set: it also blocks the temp
+ * tables the reclaim estimate builds, and it adds nothing over READONLY.
+ */
+function openReadOnlyDb(dbPath: string): Database {
+  const db = new Database(dbPath, { readonly: true });
+  db.exec("PRAGMA busy_timeout=5000");
+  return db;
+}
+
 async function runDbPruneDryRun(options: CliOptions): Promise<SectionResult> {
   const days = options.pruneOlderDays ?? DEFAULT_PRUNE_DAYS;
   const cutoffMs = Date.now() - days * 24 * 3600 * 1000;
@@ -1512,9 +1527,7 @@ async function runDbPruneDryRun(options: CliOptions): Promise<SectionResult> {
 
   let db: Database | null = null;
   try {
-    const uri = "file:" + options.dbPath + "?mode=ro";
-    db = new Database(uri, { readonly: true });
-    db.exec("PRAGMA busy_timeout=5000");
+    db = openReadOnlyDb(options.dbPath);
 
     const sessionIds = await withSqliteBusyRetry(() => selectOldSessionIds(db!, cutoffMs));
     const reclaim = await withSqliteBusyRetry(() => estimateReclaim(db!, sessionIds));
@@ -1621,9 +1634,7 @@ async function runDbEventPruneDryRun(options: CliOptions): Promise<SectionResult
   const cutoffDate = new Date(cutoffMs).toISOString().slice(0, 10);
   let db: Database | null = null;
   try {
-    const uri = "file:" + options.dbPath + "?mode=ro";
-    db = new Database(uri, { readonly: true });
-    db.exec("PRAGMA busy_timeout=5000");
+    db = openReadOnlyDb(options.dbPath);
 
     const sessionIds = await withSqliteBusyRetry(() => selectOldSessionIds(db!, cutoffMs));
     const reclaim = await withSqliteBusyRetry(() => estimateReclaim(db!, sessionIds));

--- a/.config/opencode/scripts/opencode-doctor.ts
+++ b/.config/opencode/scripts/opencode-doctor.ts
@@ -5,7 +5,6 @@ import { existsSync, statfsSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname } from "node:path";
 import { Database } from "bun:sqlite";
-import { createOpencodeClient } from "@opencode-ai/sdk";
 import {
   bytesToHuman,
   estimateReclaim,
@@ -1871,12 +1870,16 @@ async function waitForExit(proc: ChildProcess, timeoutMs = 8000): Promise<void> 
 }
 
 async function startOpencode(options: CliOptions): Promise<{
-  client: ReturnType<typeof createOpencodeClient>;
+  client: ReturnType<typeof import("@opencode-ai/sdk").createOpencodeClient>;
   proc?: ChildProcess;
   url: string;
   port: number;
   mode: "existing" | "spawned";
 }> {
+  // Loaded on demand so the module imports without the SDK present. Only
+  // server-backed sections need it; the DB-only paths -- including the
+  // destructive-operation gate -- never reach here.
+  const { createOpencodeClient } = await import("@opencode-ai/sdk");
   const baseUrl = `http://${options.host}:${options.port}`;
 
   if (options.portProvided) {

--- a/.config/opencode/scripts/opencode-doctor.ts
+++ b/.config/opencode/scripts/opencode-doctor.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 import { spawn, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
-import { statfsSync, statSync } from "node:fs";
+import { existsSync, statfsSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname } from "node:path";
 import { Database } from "bun:sqlite";
@@ -1225,6 +1225,10 @@ export function checkForOtherOpencodeProcesses(
   const paths = [dbPath, `${dbPath}-wal`, `${dbPath}-shm`];
 
   for (const path of paths) {
+    // Keep injected process checks deterministic: mocked tests may model a
+    // holder on a sidecar without creating that filesystem path.
+    if (dependencies.spawnSync == null && path !== dbPath && !existsSync(path)) continue;
+
     let result: { exitCode: number | null; stdout?: unknown; stderr?: unknown };
     try {
       result = spawnSync(["lsof", "-F", "pc", path]);

--- a/.config/opencode/scripts/opencode-doctor.ts
+++ b/.config/opencode/scripts/opencode-doctor.ts
@@ -2112,8 +2112,11 @@ async function collectSections(options: CliOptions): Promise<SectionResult[]> {
 
 function renderSection(section: SectionResult, options: CliOptions): string {
   const extracted = extractData(section.data);
-  if (extracted.error != null) {
-    return `${formatHeader(section.label, options)}\n${formatError(extracted.error, options)}`;
+  // section.error is set when the section threw; without this the failure
+  // renders as a bare null with no reason.
+  const error = extracted.error ?? section.error;
+  if (error != null) {
+    return `${formatHeader(section.label, options)}\n${formatError(error, options)}`;
   }
 
   const output = options.full ? extracted.data : summarize(extracted.data, options.limit);

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -11,7 +11,7 @@ branches:
     protection:
       required_status_checks:
         strict: true
-        contexts: ['Devcontainer CI', 'Fro Bot', 'Install mise', 'Renovate / Renovate']
+        contexts: ['Devcontainer CI', 'Fro Bot', 'Install mise', 'Renovate / Renovate', 'Script Tests']
       enforce_admins: true
       required_pull_request_reviews: null
       restrictions: null

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -73,3 +73,31 @@ jobs:
         uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           version: ${{ env.MISE_VERSION }}
+
+  script-tests:
+    name: Script Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.4.0
+
+      - name: Verify lsof is available
+        run: command -v lsof
+
+      - name: Run opencode-doctor tests
+        working-directory: .config/opencode/scripts
+        # These CLI and signal tests require a real OpenCode server binary,
+        # which is intentionally not installed on this lightweight runner.
+        run: >-
+          bun test
+          --test-name-pattern='^(?!.*(?:spawns server and retrieves health section|--only flag filters to specified sections only|--json outputs parseable JSON array of sections|--format=json is equivalent to --json flag|invalid --only value warns but continues with valid sections|invalid --port value warns and uses default|SIGTERM triggers cleanup of spawned server|SIGINT triggers cleanup of spawned server)).*$'
+          opencode-doctor.test.ts
+
+      - name: Run ollama-distill tests
+        working-directory: .config/opencode/scripts
+        run: bun test ollama-distill.test.ts

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -91,12 +91,9 @@ jobs:
 
       - name: Run opencode-doctor tests
         working-directory: .config/opencode/scripts
-        # These CLI and signal tests require a real OpenCode server binary,
-        # which is intentionally not installed on this lightweight runner.
-        run: >-
-          bun test
-          --test-name-pattern='^(?!.*(?:spawns server and retrieves health section|--only flag filters to specified sections only|--json outputs parseable JSON array of sections|--format=json is equivalent to --json flag|invalid --only value warns but continues with valid sections|invalid --port value warns and uses default|SIGTERM triggers cleanup of spawned server|SIGINT triggers cleanup of spawned server)).*$'
-          opencode-doctor.test.ts
+        # Tests needing a real OpenCode server binary skip themselves when none
+        # resolves, so no runner is installed and no name filter is needed here.
+        run: bun test opencode-doctor.test.ts
 
       - name: Run ollama-distill tests
         working-directory: .config/opencode/scripts


### PR DESCRIPTION
Makes the doctor's safety-gate tests both real and enforced, and fixes two defects found while doing it.

## The tests now run in CI

A `Script Tests` job runs both Bun suites under `.config/opencode/scripts/` on every PR. Nothing ran them before, which mattered more than it used to — `opencode-doctor.ts` carries a safety interlock that refuses destructive database operations, and its fail-closed assertions are exactly the kind that regress without anyone noticing.

Six tests need a real OpenCode server binary, which does not exist on a runner. They now skip themselves when none resolves, so the job needs no test-name filter and installs no runtime. Simulated locally with a stripped `PATH`: **82 pass, 6 skip, 0 fail**. With a binary present: **88 pass**. The distill suite is **128 pass**.

## A holder test that does not mock the OS call

Every existing holder test injected a fake `spawnSync`. That proves the parser and the refusal logic, but never that `lsof` sees reality — which is the one property the previous `pgrep` gate got wrong. There is now an integration test that spawns a real process holding a real file descriptor and asserts the gate detects it through the real binary. It skips cleanly where `lsof` is unavailable.

## `lsof` exit 1 was ambiguous

Exit 1 with empty stdout was read as "no holder". Real `lsof` also returns 1 on genuine errors, so that path could fail open. It now distinguishes them by stderr: empty means no holder, non-empty means an error and refuses.

## Absent WAL/SHM siblings

Fixing the above introduced a regression, caught before merge. The gate probes the database plus its `-wal` and `-shm` siblings, and `lsof` on a path that does not exist returns exit 1 with a stderr blob:

```
lsof: status error on clean.db-wal: No such file or directory
```

SQLite removes those siblings on clean shutdown — precisely the state where nothing holds the database and a prune should be allowed. The stderr check would have refused every time it was actually safe to proceed, and permitted only when the files happened to exist.

Absent siblings are now skipped, since a file that does not exist cannot have a holder. Stderr stays fail-closed for paths that do exist.

Verified against real `lsof`, no mocks:

```
sidecars present? false false
clean-shutdown  safe=true  count=0  error=(none)
with-holder     safe=false count=1  holders=[{"pid":12163,"command":"bun"}]
real DB         safe=false count=2
```

The original test fixture created the sidecars before probing, which hid this entirely — a fixture that manufactures a convenient world has the same defect as a mock, just less obviously.

Closes #2366
Closes #2368
