### PR TITLE
docs(solutions): record the Linux read-only SQLite failure

### DIFF
--- a/.dotfiles/docs/solutions/2026-05-22-bun-sqlite-readonly-wal-pattern.md
+++ b/.dotfiles/docs/solutions/2026-05-22-bun-sqlite-readonly-wal-pattern.md
@@ -1,5 +1,6 @@
 ---
 date: 2026-05-22
+last_updated: 2026-08-25
 category: pattern
 tags: [bun, sqlite, wal, read-only, opencode]
 problem-area: reading a live WAL SQLite database from a Bun CLI without disturbing the writer
@@ -16,7 +17,7 @@ A Bun/TypeScript CLI needs to read OpenCode's live SQLite session store (`~/.loc
 3. Handle the case where OpenCode commits a schema migration while the CLI holds a connection
 4. Survive transient SQLITE_BUSY / SQLITE_LOCKED returns during WAL checkpoints or short writer transactions
 
-Standard SQLite "open read-only" guidance is the URI mode (`file:path?mode=ro`) OR `PRAGMA query_only=ON`. Neither alone is sufficient for a connection that lives across multiple queries against a heavily-active writer.
+Standard SQLite "open read-only" guidance is the URI mode (`file:path?mode=ro`) OR `PRAGMA query_only=ON`. Neither alone is sufficient for a connection that lives across multiple queries against a heavily-active writer — and the URI form is not portable at all (see the 2026-08-25 correction below).
 
 ## Solution
 
@@ -26,8 +27,9 @@ Defense-in-depth read-only enforcement, verified empirically at startup:
 import { Database } from "bun:sqlite"
 
 function openReadOnly(dbPath: string): Database {
-  // 1. URI mode + readonly option (the real guard — bun:sqlite honors both)
-  const db = new Database(`file:${dbPath}?mode=ro`, { readonly: true })
+  // 1. SQLITE_OPEN_READONLY via the readonly option — this is the real guard.
+  //    Do NOT use a `file:${dbPath}?mode=ro` URI here: it is not portable.
+  const db = new Database(dbPath, { readonly: true })
 
   // 2. PRAGMA query_only as belt-and-suspenders (per-connection;
   //    enforced by the SQLite library, not the OS file mode)
@@ -98,6 +100,18 @@ function withBusyRetry<T>(fn: () => T, attempts = 3, backoffMs = 100): T {
   throw lastErr
 }
 ```
+
+### Correction, 2026-08-25: do not use a `file:` URI
+
+This pattern originally opened with ``new Database(`file:${dbPath}?mode=ro`, { readonly: true })`` and described the URI as part of the guard. That is wrong, and it fails outright on Linux.
+
+URI filenames only mean anything when SQLite's URI handling is enabled. Where it is not, the entire string is treated as a literal path, so the open throws `unable to open database file`. Verified with bun 1.4.0 on both platforms: it works on macOS and fails on `ubuntu-latest`. The symptom is easy to misread, because only read paths use the URI — writes keep working.
+
+`{ readonly: true }` maps to `SQLITE_OPEN_READONLY` and carries the guarantee on its own. Layers 2-4 below are unaffected.
+
+One caveat if you adopt layer 2 elsewhere: `PRAGMA query_only=ON` also blocks temp tables. It is right here, because the probe in layer 4 depends on `CREATE TEMP TABLE` being rejected — but it will break a read-only connection that builds temp tables for analysis. `opencode-doctor.ts` omits it for exactly that reason.
+
+See [`2026-08-25-bun-sqlite-readonly-opencode-ci-failures.md`](2026-08-25-bun-sqlite-readonly-opencode-ci-failures.md).
 
 ## What this does not protect against
 

--- a/.dotfiles/docs/solutions/2026-08-25-bun-sqlite-readonly-opencode-ci-failures.md
+++ b/.dotfiles/docs/solutions/2026-08-25-bun-sqlite-readonly-opencode-ci-failures.md
@@ -1,0 +1,119 @@
+---
+title: "Read-only SQLite opens via a file: URI failed on Linux, hidden until the scripts first ran in CI"
+date: 2026-08-25
+category: database-issues
+module: opencode-doctor
+problem_type: database_issue
+component: tooling
+symptoms:
+  - "every read-only section failed on ubuntu-latest with `unable to open database file` while the read-write `--execute` path worked"
+  - "`Cannot find module '@opencode-ai/sdk'` on a clean checkout, so zero tests ran"
+  - "a section that threw rendered as `\"data\": null` in JSON and a bare `null` in text, with exit 1 and no reason given"
+root_cause: wrong_api
+resolution_type: code_fix
+severity: high
+related_components:
+  - database
+  - testing_framework
+  - development_workflow
+tags:
+  - bun
+  - sqlite
+  - read-only
+  - linux
+  - ci
+  - opencode-doctor
+  - ollama-distill
+---
+
+# Read-only SQLite opens via file: URI failed on Linux, hidden until the scripts first ran in CI
+
+## Problem
+
+Two Bun test suites under `.config/opencode/scripts/` had never run in any CI workflow. Both were green on macOS. Wiring them into a `Script Tests` job on `ubuntu-latest` exposed four independent defects in the same change, the largest being that every read-only database open failed on Linux.
+
+## Symptoms
+
+- `Cannot find module '@opencode-ai/sdk'` — the module could not import at all, so zero tests ran.
+- `unable to open database file` from every read-only section, while the read-write `--execute` path worked normally. That asymmetry is the signature.
+- Failed sections printed `"data": null` in JSON and a bare `null` in text, with exit code 1 and no reason anywhere.
+
+## What Didn't Work
+
+**Reading the CLI help as the authority on behavior.** It disagreed with the implementation, and trusting it produced a documentation fix that was itself wrong.
+
+**Adding `PRAGMA query_only=ON` to the doctor's read-only helper.** It broke the prune dry-run with `attempt to write a readonly database`, because `estimateReclaim` builds temp tables. A connection can be read-only with respect to the main database and still need temp writes.
+
+**Claiming text output already handled section errors.** The commit that fixed the JSON emitter asserted this in its message. It was false — `renderSection` read only the error nested inside section data, never `SectionResult.error`. Fixing one output path is not evidence about the others.
+
+**A fixture that pre-created the SQLite sidecars.** An earlier `lsof` change treated exit 1 with non-empty stderr as an error, which is right for paths that exist and wrong for paths that do not — and SQLite deletes `-wal`/`-shm` on clean shutdown, exactly when a prune is safe. The integration test called `writeFileSync` on both sidecars before probing, so the suite stayed green while the gate would have refused every clean-shutdown prune.
+
+## Solution
+
+### Open read-only with the flag, not a URI
+
+```ts
+// before — fails on Linux
+new Database("file:" + dbPath + "?mode=ro", { readonly: true })
+
+// after
+function openReadOnlyDb(dbPath: string): Database {
+  const db = new Database(dbPath, { readonly: true });
+  db.exec("PRAGMA busy_timeout=5000");
+  return db;
+}
+```
+
+Applied to three call sites in `opencode-doctor.ts` and to `openDatabase` in `ollama-distill.ts`. The distiller keeps its stronger guard, which still works without the URI:
+
+```ts
+const db = new Database(dbPath, { readonly: true });
+db.exec("PRAGMA query_only=ON");
+db.exec("PRAGMA busy_timeout=5000");
+// probe: CREATE TEMP TABLE must throw, or the connection is not read-only
+```
+
+### Load the SDK only when a server is needed
+
+```ts
+// before — top-level, on a dependency nothing declared
+import { createOpencodeClient } from "@opencode-ai/sdk";
+
+// after — inside startOpencode, with the type erased at build time
+const { createOpencodeClient } = await import("@opencode-ai/sdk");
+```
+
+The type reference becomes `ReturnType<typeof import("@opencode-ai/sdk").createOpencodeClient>`, erased under `verbatimModuleSyntax`. DB-only paths — including the destructive-operation gate — never reach the import.
+
+### Surface section errors in both output formats
+
+```ts
+// text
+const error = extracted.error ?? section.error;
+
+// json
+label: section.label,
+...extractData(section.data),
+...(section.error == null ? {} : { error: section.error }),
+```
+
+## Why This Works
+
+`readonly: true` maps to `SQLITE_OPEN_READONLY`, which is the actual guard. A `file:...?mode=ro` filename only means anything if SQLite's URI handling is enabled; where it is not, the whole string is taken as a literal path, nothing exists there, and the open fails. That is why reads failed while writes succeeded — only the read path used a URI. Both platforms ran bun 1.4.0, so this is a platform difference in SQLite URI handling, not a version difference.
+
+The error-reporting fixes are what made the rest tractable. Before them, CI reported `data: null` and exit 1 for a failure whose cause was one string away.
+
+## Prevention
+
+- Prefer open flags over URI filenames. `{ readonly: true }` is portable; `?mode=ro` depends on a build option you do not control.
+- Do not add `query_only` to a connection that legitimately writes temp tables. Read-only to the main database and read-only to temp storage are different guarantees.
+- Every output format needs its own error test. An error visible in one serializer says nothing about the others.
+- Fixtures must model lifecycle states, including files that are normally absent. Creating `-wal`/`-shm` because it makes a test convenient removes the case most likely to break.
+- Run platform-sensitive scripts on a platform other than the one they were written on.
+
+## Related Issues
+
+- [`docs/solutions/2026-05-22-bun-sqlite-readonly-wal-pattern.md`](2026-05-22-bun-sqlite-readonly-wal-pattern.md) — the layered read-only pattern this code follows. Its URI-mode layer is corrected by this finding.
+- [`docs/solutions/2026-08-19-opencode-doctor-quiescence-gate-fail-open.md`](2026-08-19-opencode-doctor-quiescence-gate-fail-open.md) — the `lsof` safety gate whose follow-ups shipped alongside this work.
+- marcusrbrown/.dotfiles#2366 — the Bun suites did not run in CI.
+- marcusrbrown/.dotfiles#2368 — `lsof` gate follow-ups.


### PR DESCRIPTION
Records what the first Linux CI run of the script test suites exposed, and corrects an older pattern doc that recommended the thing which broke.

## New: `2026-08-25-bun-sqlite-readonly-opencode-ci-failures.md`

Four defects surfaced the first time these suites ran off macOS. The largest: every read-only database open used `new Database("file:" + path + "?mode=ro", { readonly: true })`, which fails on Linux with `unable to open database file`. URI filenames only mean something when SQLite's URI handling is enabled; where it is not, the whole string is a literal path. Both platforms ran bun 1.4.0, so this is a platform difference, not a version one.

The symptom is easy to misread — only read paths used the URI, so every read-only section failed while `--execute` worked fine.

The doc also captures the three that came with it: an undeclared `@opencode-ai/sdk` import that resolved locally only through an untracked sibling manifest, and section errors dropped from both the JSON and text output paths — the latter being why the CI failure had no diagnostic at all until it was fixed.

The failed attempts are recorded too, since each cost real time: trusting `--help` over the implementation, adding `PRAGMA query_only=ON` to a connection whose reclaim estimate needs temp tables, asserting a fix in a commit message without checking the other output path, and a test fixture that pre-created the SQLite sidecars and thereby hid a regression in the absent-sidecar case.

## Corrected: `2026-05-22-bun-sqlite-readonly-wal-pattern.md`

That doc described the URI as "the real guard — bun:sqlite honors both". It is not, and following it produces code that fails on Linux. Layer 1 now uses the plain path, with a dated correction explaining why and a note that `query_only` — correct there, because the read-only probe depends on it — will break a connection that builds temp tables.

The rest of the pattern is unchanged and still correct.
