### PR TITLE
ci: run the script tests on macOS as well as Linux

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -74,9 +74,13 @@ jobs:
         with:
           version: ${{ env.MISE_VERSION }}
 
-  script-tests:
-    name: Script Tests
-    runs-on: ubuntu-latest
+  script-tests-matrix:
+    name: Script Tests (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -98,3 +102,24 @@ jobs:
       - name: Run ollama-distill tests
         working-directory: .config/opencode/scripts
         run: bun test ollama-distill.test.ts
+
+  # Aggregates the matrix into one stable status context. Branch protection
+  # requires 'Script Tests'; a matrix reports per-leg names instead, so without
+  # this the required check would never report and every PR would block.
+  # `if: always()` matters for the same reason -- a skipped required check
+  # blocks just as hard as a missing one.
+  script-tests:
+    name: Script Tests
+    runs-on: ubuntu-latest
+    needs: [script-tests-matrix]
+    if: always()
+    steps:
+      - name: Check matrix result
+        env:
+          RESULT: ${{ needs.script-tests-matrix.result }}
+        run: |
+          if [ "$RESULT" != "success" ]; then
+            echo "Script Tests matrix did not succeed: $RESULT"
+            exit 1
+          fi
+          echo "All Script Tests legs passed."


### PR DESCRIPTION
Runs the script test suites on macOS as well as Linux.

Wiring these suites into CI caught four defects, and every one of them came from Linux behaving differently to macOS — a read-only SQLite open that only works where URI handling is enabled, and a dependency that only resolved through an ambient install. The fix made Linux the enforced platform. It also left macOS, which is where these scripts actually run day to day, with no coverage at all.

```yaml
strategy:
  fail-fast: false
  matrix:
    os: [ubuntu-latest, macos-latest]
```

`fail-fast: false` so a failure on one platform still reports the other — the difference between the two is usually the interesting part.

## Why there is an aggregator job

Branch protection requires a status context named exactly `Script Tests`. A matrix does not produce that name; it produces `Script Tests (ubuntu-latest)` and `Script Tests (macos-latest)`. Converting the job in place would mean the required context never reports again, and every PR — including this one — would sit unmergeable forever.

So the matrix runs under its own name and a small job named `Script Tests` aggregates it:

```yaml
script-tests:
  name: Script Tests
  needs: [script-tests-matrix]
  if: always()
```

`if: always()` is load-bearing for the same reason. Without it a failing leg would skip the aggregator, and a skipped required check blocks exactly as hard as a missing one.

This also avoids touching branch protection at all — the required contexts stay as they are.

## Verification

`actionlint` clean, and the macOS leg reproduced locally in a CI-shaped layout with no ambient `node_modules` and no OpenCode binary on `PATH`: **82 pass, 6 skip, 0 fail** for the doctor suite and **128 pass** for distill, with `lsof` at `/usr/sbin/lsof`.

The Linux leg is already known good from the previous PR. What neither can confirm until this runs is the hosted macOS runner image itself.
