### PR TITLE
chore(opencode): update model routing

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -4,7 +4,7 @@
     "@cortexkit/opencode-anthropic-auth@1.21.0",
     "@cortexkit/opencode-openai-auth@0.6.4",
     "oh-my-opencode-slim@2.2.11",
-    "@cortexkit/opencode-magic-context@0.41.0",
+    "@cortexkit/opencode-magic-context@0.41.1",
     "@cortexkit/aft-opencode@0.54.0",
     "opencode-copilot-delegate@0.12.1",
     "@fro.bot/systematic@3.15.0"

--- a/.config/opencode/systematic.jsonc
+++ b/.config/opencode/systematic.jsonc
@@ -17,13 +17,13 @@
       "variant": "low"
     },
     "workflow": {
-      "model": "github-copilot/claude-sonnet-4.6",
+      "model": "anthropic/claude-sonnet-5",
       "variant": "low"
     }
   },
   "agents": {
     "repo-research-analyst": {
-      "model": "github-copilot/gemini-3.5-flash",
+      "model": "github-copilot/gpt-5.4-mini",
       "variant": "low"
     },
     "spec-flow-analyzer": {
@@ -31,7 +31,7 @@
       "variant": "high"
     },
     "systematic-implementer": {
-      "model": "openai/gpt-5.6-luna",
+      "model": "anthropic/claude-sonnet-5",
       "variant": "high"
     }
   },


### PR DESCRIPTION
- bump @cortexkit/opencode-magic-context from 0.41.0 to 0.41.1
- switch workflow and implementer routing to anthropic/claude-sonnet-5
- move repo-research-analyst to github-copilot/gpt-5.4-mini
- keep the systematic config aligned with the current OpenCode model setup