### PR TITLE
fix(devcontainer): stop exporting GIT_DIR into the container environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -73,10 +73,11 @@
         "XDG_STATE_HOME": "${containerWorkspaceFolder}/.local/state",
         "ZDOTDIR": "${containerWorkspaceFolder}/.config/zsh"
     },
+    // GIT_DIR/GIT_WORK_TREE are deliberately not set here: exporting them globally
+    // hijacks every git invocation in the container, including ones tools make
+    // internally. Use the `.dotfiles` alias, which scopes them per command.
     "remoteEnv": {
-        "GH_TOKEN": "${localEnv:GH_TOKEN}",
-        "GIT_DIR": "${containerWorkspaceFolder}/.dotfiles",
-        "GIT_WORK_TREE": "${containerWorkspaceFolder}"
+        "GH_TOKEN": "${localEnv:GH_TOKEN}"
     },
     "remoteUser": "vscode",
     "workspaceFolder": "/home/vscode",

--- a/.devcontainer/features/mise/install.sh
+++ b/.devcontainer/features/mise/install.sh
@@ -14,7 +14,8 @@ echo "(*) Installing mise-en-place..."
 apt-get update && apt-get install -y --no-install-recommends zstd && rm -rf /var/lib/apt/lists/*
 
 MISE_INSTALL_PATH=/usr/local/bin/mise
-curl https://mise.run | MISE_INSTALL_PATH="$MISE_INSTALL_PATH" sh
+MISE_VERSION=2026.9.0 # renovate: datasource=github-releases packageName=jdx/mise
+curl https://mise.run | MISE_INSTALL_PATH="$MISE_INSTALL_PATH" MISE_VERSION="$MISE_VERSION" sh
 
 echo "(*) Installing uv (required by mise pipx backend)..."
 curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh

--- a/.devcontainer/features/mise/install.sh
+++ b/.devcontainer/features/mise/install.sh
@@ -14,7 +14,8 @@ echo "(*) Installing mise-en-place..."
 apt-get update && apt-get install -y --no-install-recommends zstd && rm -rf /var/lib/apt/lists/*
 
 MISE_INSTALL_PATH=/usr/local/bin/mise
-MISE_VERSION=2026.9.0 # renovate: datasource=github-releases packageName=jdx/mise
+# renovate: datasource=github-releases packageName=jdx/mise
+MISE_VERSION=2026.9.0
 curl https://mise.run | MISE_INSTALL_PATH="$MISE_INSTALL_PATH" MISE_VERSION="$MISE_VERSION" sh
 
 echo "(*) Installing uv (required by mise pipx backend)..."

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,8 +4,12 @@
   customManagers: [
     {
       customType: 'regex',
-      description: 'Update _VERSION variables in the global Mise config file.',
-      managerFilePatterns: ['/(^|/)\\.?mise\\.toml$/', '/(^|/)\\.?mise/config\\.toml$/'],
+        description: 'Update _VERSION variables in the global Mise config file and the devcontainer mise feature.',
+        managerFilePatterns: [
+          '/(^|/)\\.?mise\\.toml$/',
+          '/(^|/)\\.?mise/config\\.toml$/',
+          '/(^|/)\\.devcontainer/features/mise/install\\.sh$/'
+        ],
       matchStrings: [
         '# renovate: datasource=(?<datasource>[a-z-.]+?)(?: depName=(?<depName>.+?))?(?: (?:packageName|lookupName)=(?<packageName>.+?))?(?: versioning=(?<versioning>[^\\s]+?))?\\s+?.+?_VERSION=(?<currentValue>.+?)\\s'
       ],


### PR DESCRIPTION
`Devcontainer CI` has failed on every run since 2026-09-01, blocking all open PRs. The failure is `mise install` dying on python:

```
mise WARN  Failed to resolve tool version list for python: python@3.14.7:
  failed to execute command: ~/.cache/mise/python/pyenv/plugins/python-build/bin/python-build
  --definitions: No such file or directory (os error 2)
mise ERROR Failed to install tools: core:python@3.14.7, pipx:poetry@2.4.2
```

## Cause

`devcontainer.json` exported `GIT_DIR` and `GIT_WORK_TREE` through `remoteEnv`, which applies to every remote process — including `postCreateCommand`, i.e. `mise install`.

mise resolves python's version list by cloning pyenv and running `python-build --definitions`. With `GIT_DIR` exported, mise's internal git calls were redirected at the dotfiles bare repo, the pyenv checkout never landed, and mise then executed a binary that wasn't there. python failed, `pipx:poetry` was skipped as a dependent, and `devcontainer up` failed.

The bug was latent. mise only started needing pyenv for python version resolution in 2026.9.0, released 2026-09-01 — which the devcontainer picked up immediately because the feature installed mise unpinned. The cutover is visible to the minute: the last passing run was 12:35, the first failure 12:37.

## Changes

- Drop `GIT_DIR`/`GIT_WORK_TREE` from `remoteEnv`. The dotfiles clone is unaffected: the `dotfiles-dev` post-create script sets both itself with `${GIT_DIR:-...}` defaults and exports them process-locally. Interactive use keeps the `.dotfiles` alias, which scopes them per command.
- Pin the feature's mise install to the same Renovate-managed version `main.yaml` already uses, so a mise release can't change container behavior without a PR.

## Verification

Same published image, same mise 2026.9.1, same config, one variable flipped:

| `GIT_DIR` | result |
|---|---|
| exported as `remoteEnv` did | `python-build --definitions` fails, matching CI |
| unset | `Python 3.14.7` installs from a precompiled build |

Full sequence re-run in the published image with the fix applied: dotfiles bare-repo clone and checkout succeed, then `mise install` resolves python from `cpython-3.14.7+20260901-x86_64-unknown-linux-gnu` with no pyenv involvement.

Six other hypotheses were tested and ruled out: mise version alone, GitHub API rate limiting, an invalid token, user identity, the pipx dependency chain, and the full tool config.

The mise pin is deliberately 2026.9.0 rather than an older release — 2026.9.x works correctly once `GIT_DIR` is no longer exported, so pinning backward would mask the cause.
