### PR TITLE
chore(devcontainer): pin the uv and starship installers

### DIFF
--- a/.devcontainer/features/dotfiles-dev/install.sh
+++ b/.devcontainer/features/dotfiles-dev/install.sh
@@ -39,7 +39,9 @@ fi
 
 if ! command -v starship > /dev/null 2>&1; then
     # Install Starship
-    curl -fsSL https://starship.rs/install.sh | sh -s -- -y
+    # renovate: datasource=github-releases packageName=starship/starship
+    STARSHIP_VERSION=v1.26.0
+    curl -fsSL https://starship.rs/install.sh | sh -s -- -y -v "${STARSHIP_VERSION}"
 fi
 
 if [ ! -d "${DOTFILES_DEV_PATH}" ]; then

--- a/.devcontainer/features/dotfiles-dev/install.sh
+++ b/.devcontainer/features/dotfiles-dev/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -eo pipefail
 
 USERNAME="${USERNAME:-"automatic"}"
 

--- a/.devcontainer/features/mise/install.sh
+++ b/.devcontainer/features/mise/install.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-set -e
+# pipefail matters for the pinned installers below: a versioned URL that 404s
+# pipes an empty script into `sh`, which exits 0 and would hide a bad pin.
+set -eo pipefail
 
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'

--- a/.devcontainer/features/mise/install.sh
+++ b/.devcontainer/features/mise/install.sh
@@ -19,7 +19,11 @@ MISE_VERSION=2026.9.1
 curl https://mise.run | MISE_INSTALL_PATH="$MISE_INSTALL_PATH" MISE_VERSION="$MISE_VERSION" sh
 
 echo "(*) Installing uv (required by mise pipx backend)..."
-curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+# The uv installer bakes its version in, so pin via the versioned URL rather
+# than an env var.
+# renovate: datasource=github-releases packageName=astral-sh/uv
+UV_VERSION=0.12.9
+curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | env UV_INSTALL_DIR=/usr/local/bin sh
 
 # Validation and activation of mise taken from:
 # https://github.com/RouL/devcontainer-features/blob/2ba3812809d9c933cf459f1413e67f63a9a894e3/src/mise/install.sh

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,8 @@
         managerFilePatterns: [
           '/(^|/)\\.?mise\\.toml$/',
           '/(^|/)\\.?mise/config\\.toml$/',
-          '/(^|/)\\.devcontainer/features/mise/install\\.sh$/'
+          '/(^|/)\\.devcontainer/features/mise/install\\.sh$/',
+          '/(^|/)\\.devcontainer/features/dotfiles-dev/install\\.sh$/'
         ],
       matchStrings: [
         '# renovate: datasource=(?<datasource>[a-z-.]+?)(?: depName=(?<depName>.+?))?(?: (?:packageName|lookupName)=(?<packageName>.+?))?(?: versioning=(?<versioning>[^\\s]+?))?\\s+?.+?_VERSION=(?<currentValue>.+?)\\s'


### PR DESCRIPTION
Closes #2496.

`uv` and `starship` were installed with unpinned `curl | sh`, so container behavior could change on an upstream release with no commit here to correlate against. That is the same shape as the mise installer behind the recent three-day `Devcontainer CI` outage (#2488): the repository had not changed, which is exactly what made it expensive to diagnose.

The two installers pin differently, and neither matches mise's:

- **uv** bakes `APP_VERSION` into the script and ignores `UV_VERSION` entirely, so it pins through the versioned URL `https://astral.sh/uv/${UV_VERSION}/install.sh`.
- **starship** accepts `-v <version>`, defaulting to `latest`.

Renovate's `_VERSION` custom manager now also covers `features/dotfiles-dev/install.sh`, so all three pins are bumped by PR rather than by hand. The manager already picked up the mise pin from the last change — it has since bumped it to 2026.9.1, which confirms that path works end to end.

Version formats differ by upstream convention: `starship` tags with a `v` prefix, `uv` and `mise` do not.

## pipefail

Pinning through a versioned URL introduces a failure mode the other two installers do not have. When the URL 404s, `curl -f` writes nothing, `sh` receives an empty script and exits 0, and `set -e` sees no failure — so a bad pin would install nothing and still report success. `Devcontainer CI` runs only `devcontainer-info` after the build and asserts nothing about `uv`, so that would pass too.

Both feature scripts now set `pipefail`. The `mise.run` and starship pipes were already safe, since they fetch an unversioned script that resolves the pinned version internally and exits non-zero itself; the uv line differs because the versioned fetch *is* what fails.

## Verification

In a container with the pins applied:

- `uv --version` → `uv 0.12.9`
- `starship --version` → `starship 1.26.0`
- a nonexistent uv version now exits 22 instead of 0, with execution stopping at that line

The `_VERSION` regex captures all three pins with the correct package names (`jdx/mise`, `astral-sh/uv`, `starship/starship`). Both scripts pass `shellcheck` and `bash -n`. The two `set -e` occurrences inside the generated `post-create.sh` heredoc are deliberately unchanged — that script declares its own shebang.
