### PR TITLE
fix(runbook): point Discord token setup at a hook that runs

### DIFF
--- a/.dotfiles/docs/runbooks/discord-admin-agent.md
+++ b/.dotfiles/docs/runbooks/discord-admin-agent.md
@@ -80,27 +80,29 @@ security add-generic-password \
   -U
 ```
 
-Export it at shell startup via a gitignored file under `.config/bash/local.d/`:
+Export it at shell startup from `~/.zshrc.local`, which `.config/zsh/.zshrc` sources and the `*.local` allowlist rule keeps untracked:
 
 ```bash
-# .config/bash/local.d/discord.bash  (gitignored — DO NOT commit)
+# ~/.zshrc.local  (untracked — DO NOT commit)
 if command -v security >/dev/null 2>&1; then
   export DISCORD_TOKEN="$(security find-generic-password -s discord-bot-fro-bot -w 2>/dev/null)"
   export DISCORD_GUILD_ID="<your-guild-id>"
 fi
 ```
 
+Do **not** use `.config/bash/local.d/` — no shell sources it, so the exports never take effect. See the Shell Config Organization section of `AGENTS.md`. This hook is zsh-only; interactive bash has no machine-local hook, so export the variables inline there if you need them.
+
 ### Option B — plaintext local-only env file
 
 If you don't want to use Keychain, set the env vars directly in a gitignored file:
 
 ```bash
-# .config/bash/local.d/discord.bash  (gitignored — DO NOT commit)
+# ~/.zshrc.local  (untracked — DO NOT commit)
 export DISCORD_TOKEN="<paste-discord-bot-token>"
 export DISCORD_GUILD_ID="<your-guild-id>"
 ```
 
-Filesystem permissions: `chmod 600 ~/.config/bash/local.d/discord.bash` so only your user can read it.
+Filesystem permissions: `chmod 600 ~/.zshrc.local` so only your user can read it.
 
 ### Option C — 1Password CLI (future)
 
@@ -113,11 +115,11 @@ export DISCORD_TOKEN="$(op read 'op://Personal/discord-fro-bot/credential')"
 ### Where the token MUST NOT live
 
 - Any tracked file under `~/.dotfiles/` (including this runbook, the plan, AGENTS.md, opencode.json)
-- `~/.config/bash/exports` (tracked) or `~/.config/bash/init.d/*.bash` (tracked)
+- `~/.config/bash/exports` (tracked) or `~/.config/bash/init.d/*.bash` (tracked, and never sourced)
 - Any `.env` in a tracked directory
 - Any Discord MCP server config snippet that gets committed
 
-The dotfiles' `.gitignore` allowlist + `~/.config/git/ignore` global-credential-shape patterns + the gitleaks pre-commit hook are the three defense layers; rely on all three.
+The dotfiles' `.dotfiles/ignore` allowlist + `~/.config/git/ignore` global-credential-shape patterns + the gitleaks pre-commit hook are the three defense layers; rely on all three.
 
 ---
 


### PR DESCRIPTION
The token-sourcing section of the Discord admin-agent runbook does not work as written.

Both Option A (Keychain) and Option B (plaintext) instruct exporting `DISCORD_TOKEN` from a file under `.config/bash/local.d/`. Nothing sources that directory — it was part of the `.bashrc` → `main` → `init.d/*` → `local.d/*` chain corrected in #2498, which never executed. Following the runbook exactly produces an unset `DISCORD_TOKEN`, and the failure is silent: the file is present, readable, and correct, so the only symptom is the MCP server not authenticating.

Verified on this machine, where `.config/bash/local.d/discord.bash` has existed since May:

```console
$ zsh -ic 'echo "[$DISCORD_TOKEN] [$DISCORD_GUILD_ID]"'
[] []
```

Both options now use `~/.zshrc.local`, which `.config/zsh/.zshrc:39` sources and the `*.local` rule keeps untracked — the same properties the runbook wanted from `local.d/`. The section also states explicitly that `local.d/` does not work, so the old instructions do not get reconstructed later, and notes the hook is zsh-only since interactive bash has no machine-local equivalent.

Also corrects the allowlist filename in the defense-layers line, left over from the `.dotfiles/.gitignore` → `.dotfiles/ignore` rename.

Two notes:

- `docs/plans/2026-05-18-001-feat-discord-server-revival-plan.md:204` describes the same `local.d/` approach. Left unchanged — plan documents record what was decided at the time, and the runbook is the operational reference.
- Anyone who already followed the old instructions has a `.config/bash/local.d/discord.bash` that has never taken effect. Moving those exports to `~/.zshrc.local` is a local action this PR cannot perform.
