### PR TITLE
ci: stop caching mise in the install smoke test

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -67,11 +67,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Cache deliberately disabled. Nothing downstream consumes these tools --
+      # this job exists to prove every tool in .config/mise/config.toml installs
+      # cleanly, and a cache hit skips the install being verified. It also cost
+      # far more than it saved: keyed on mise version x config hash x ref, it
+      # accumulated nine ~993MB entries (8.9GB of the repo's 10GB cache budget)
+      # and LRU-evicted every other cache, including the ~40KB agent session
+      # caches that carry continuity between runs.
       - name: Install mise
         env:
           MISE_VERSION: 2026.9.1 # renovate: datasource=github-releases packageName=jdx/mise
         uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          cache: false
           version: ${{ env.MISE_VERSION }}
 
   script-tests-matrix:


### PR DESCRIPTION
The `install-mise` job is two steps — checkout, then `mise-action`. Nothing downstream consumes the tools it installs; the job exists to prove every tool in `.config/mise/config.toml` installs cleanly.

A cache hit skips that install. So the job had quietly stopped verifying the one thing it exists to verify.

## It was also eating the repository's cache budget

| Prefix | Caches | Total |
|---|---:|---:|
| `mise-v1` | 9 | **8,940 MB** |
| `opencode-tools` | 7 | 382 MB |
| `bun-*` | 2 | 56 MB |
| `renovate-cache` | 1 | 2 MB |
| `opencode-storage` | 10 | **0.58 MB** |

The key varies on mise version × config hash × ref, so every Renovate bump to mise or to a tool version minted another ~993 MB entry. Nine of them, against roughly 500 MB for everything else in the repo combined — against a 10 GB cap.

## What that was costing

GitHub evicts least-recently-used once a repository passes the cap, so the small caches went first.

The agent session caches — 0.58 MB across ten entries — were being evicted within hours. A scheduled run on `main` saved one at 15:33 on 09-03; it was gone by the next morning. That cache is the one pull request runs can inherit, since PR-scoped caches are invisible to each other and only default-branch caches are visible everywhere. Losing it is why runs kept starting with no memory of prior work on the same PR.

The tools cache went the same way, and that one has a second-order cost: it covers `~/.cache/opencode`, where provider metadata lives. Across 19 recent runs, every run that hit the tools cache reached its first session call in 5–8 seconds. Four of the eight that missed it took 181s, 295s, 298s, and 300s — the last failing outright with `fetch failed`. A tools-cache miss was necessary for every slow run, and no run that hit it was ever slow.

## The trade

That job now pays a full cold install every run — which is the behavior it is meant to be testing, so the cost buys back honesty as well as 8.9 GB.

I have also purged the nine existing `mise-v1` entries so the relief is immediate rather than waiting on 7-day expiry.