### PR TITLE
feat(scripts): add prompt-cache plateau detector

### DIFF
--- a/.config/mise/tasks/opencode/cache-plateau
+++ b/.config/mise/tasks/opencode/cache-plateau
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+#MISE description="Detect OpenCode sessions stuck in sustained prompt-cache collapse"
+#MISE dir="{{cwd}}"
+exec bun "$HOME/.config/opencode/scripts/cache-plateau.ts" "$@"

--- a/.config/opencode/scripts/cache-plateau.test.ts
+++ b/.config/opencode/scripts/cache-plateau.test.ts
@@ -1,0 +1,591 @@
+import { describe, test, expect } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  parseAssistantTurn,
+  fetchScoredTurns,
+  fetchTransformDecisions,
+  selectCandidateSessions,
+  detectPlateaus,
+  buildPlateauRun,
+  scanSession,
+  parseSinceDuration,
+  parseArgs,
+  DEFAULT_MIN_RUN,
+  DEFAULT_MAX_REUSE,
+  DEFAULT_FLAT_ABS_TOLERANCE,
+  DEFAULT_FLAT_PCT_TOLERANCE,
+  MIN_TOTAL_TOKENS,
+  type AssistantTurn,
+  type TransformDecision,
+} from "./cache-plateau";
+
+// ─── Temp DB Helpers ──────────────────────────────────────────────────────────
+
+function makeTempDir(): string {
+  const dir = join(tmpdir(), `cache-plateau-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function removeTempDir(dir: string): void {
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // ignore cleanup errors
+  }
+}
+
+function createOpencodeTestDb(dir: string): { db: Database; dbPath: string } {
+  const dbPath = join(dir, "opencode.db");
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE session (
+      id TEXT PRIMARY KEY,
+      title TEXT,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL
+    );
+    CREATE TABLE message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      data TEXT NOT NULL DEFAULT '{}'
+    );
+  `);
+  return { db, dbPath };
+}
+
+function createContextTestDb(dir: string): { db: Database; dbPath: string } {
+  const dbPath = join(dir, "context.db");
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE transform_decisions (
+      session_id TEXT NOT NULL,
+      harness TEXT NOT NULL DEFAULT 'opencode',
+      message_id TEXT,
+      ts_ms INTEGER NOT NULL,
+      decision TEXT NOT NULL,
+      materialized INTEGER NOT NULL DEFAULT 0,
+      materialize_reason TEXT,
+      emergency INTEGER NOT NULL DEFAULT 0,
+      dropped_tokens INTEGER NOT NULL DEFAULT 0,
+      dropped_count INTEGER NOT NULL DEFAULT 0,
+      input_tokens INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+  return { db, dbPath };
+}
+
+function insertSession(db: Database, id: string, title: string, timeCreated: number, timeUpdated: number): void {
+  db.query("INSERT INTO session (id, title, time_created, time_updated) VALUES (?, ?, ?, ?)").run(
+    id,
+    title,
+    timeCreated,
+    timeUpdated,
+  );
+}
+
+type TurnSpec = {
+  id: string;
+  timeCreated: number;
+  input: number;
+  read: number;
+  write?: number;
+  modelID?: string;
+  providerID?: string;
+  error?: unknown;
+};
+
+function assistantMessageData(spec: TurnSpec): string {
+  return JSON.stringify({
+    role: "assistant",
+    modelID: spec.modelID ?? "gpt-6-astra",
+    providerID: spec.providerID ?? "openai",
+    tokens: {
+      input: spec.input,
+      output: 100,
+      reasoning: 0,
+      cache: { read: spec.read, write: spec.write ?? 0 },
+    },
+    error: spec.error ?? null,
+  });
+}
+
+function insertTurns(db: Database, sessionId: string, specs: TurnSpec[]): void {
+  for (const spec of specs) {
+    db.query("INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)").run(
+      spec.id,
+      sessionId,
+      spec.timeCreated,
+      assistantMessageData(spec),
+    );
+  }
+}
+
+function insertUserMessage(db: Database, sessionId: string, id: string, timeCreated: number): void {
+  db.query("INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)").run(
+    id,
+    sessionId,
+    timeCreated,
+    JSON.stringify({ role: "user" }),
+  );
+}
+
+function insertMaterialization(
+  db: Database,
+  sessionId: string,
+  tsMs: number,
+  materialized: boolean,
+  reason: string | null,
+): void {
+  db.query(
+    "INSERT INTO transform_decisions (session_id, ts_ms, decision, materialized, materialize_reason) VALUES (?, ?, ?, ?, ?)",
+  ).run(sessionId, tsMs, "materialize", materialized ? 1 : 0, reason);
+}
+
+const BASE_MS = 1_788_000_000_000;
+const MIN_TURN = 5_000; // per-turn spacing in ms
+const DETECTION_OPTIONS = {
+  minRun: DEFAULT_MIN_RUN,
+  maxReuse: DEFAULT_MAX_REUSE,
+  flatAbsTolerance: DEFAULT_FLAT_ABS_TOLERANCE,
+  flatPctTolerance: DEFAULT_FLAT_PCT_TOLERANCE,
+};
+
+// ─── parseAssistantTurn ───────────────────────────────────────────────────────
+
+describe("parseAssistantTurn", () => {
+  test("computes reuse as R / (N + R + W), not R / N — accounting must diverge visibly under the wrong formula", () => {
+    // N=1000, R=9000, W=0 → total=10000, reuse=0.9 under correct formula.
+    // Under the wrong R/N formula this would be 9.0 (nonsensical, >1).
+    const row = { id: "m1", time_created: BASE_MS, data: assistantMessageData({ id: "m1", timeCreated: BASE_MS, input: 1000, read: 9000 }) };
+    const turn = parseAssistantTurn(row);
+    expect(turn).not.toBeNull();
+    expect(turn!.total).toBe(10000);
+    expect(turn!.reuse).toBeCloseTo(0.9, 10);
+    expect(turn!.reuse).not.toBeCloseTo(9.0, 1);
+  });
+
+  test("includes cache.write in total", () => {
+    const row = {
+      id: "m1",
+      time_created: BASE_MS,
+      data: assistantMessageData({ id: "m1", timeCreated: BASE_MS, input: 200, read: 800, write: 5000 }),
+    };
+    const turn = parseAssistantTurn(row);
+    expect(turn!.total).toBe(6000);
+    expect(turn!.cacheWrite).toBe(5000);
+  });
+
+  test("excludes turns under MIN_TOTAL_TOKENS", () => {
+    const row = {
+      id: "m1",
+      time_created: BASE_MS,
+      data: assistantMessageData({ id: "m1", timeCreated: BASE_MS, input: 100, read: 100 }),
+    };
+    expect(row.data.length).toBeGreaterThan(0);
+    const turn = parseAssistantTurn(row);
+    expect(turn).toBeNull();
+  });
+
+  test("total exactly at MIN_TOTAL_TOKENS is included", () => {
+    const row = {
+      id: "m1",
+      time_created: BASE_MS,
+      data: assistantMessageData({ id: "m1", timeCreated: BASE_MS, input: MIN_TOTAL_TOKENS, read: 0 }),
+    };
+    const turn = parseAssistantTurn(row);
+    expect(turn).not.toBeNull();
+  });
+
+  test("excludes turns with a non-null error", () => {
+    const row = {
+      id: "m1",
+      time_created: BASE_MS,
+      data: assistantMessageData({ id: "m1", timeCreated: BASE_MS, input: 5000, read: 5000, error: { name: "boom" } }),
+    };
+    const turn = parseAssistantTurn(row);
+    expect(turn).toBeNull();
+  });
+
+  test("skips malformed JSON", () => {
+    const row = { id: "m1", time_created: BASE_MS, data: "{not json" };
+    expect(parseAssistantTurn(row)).toBeNull();
+  });
+
+  test("skips non-assistant role", () => {
+    const row = { id: "m1", time_created: BASE_MS, data: JSON.stringify({ role: "user" }) };
+    expect(parseAssistantTurn(row)).toBeNull();
+  });
+
+  test("skips missing tokens shape", () => {
+    const row = { id: "m1", time_created: BASE_MS, data: JSON.stringify({ role: "assistant" }) };
+    expect(parseAssistantTurn(row)).toBeNull();
+  });
+});
+
+// ─── detectPlateaus ───────────────────────────────────────────────────────────
+
+describe("detectPlateaus", () => {
+  function turn(overrides: Partial<AssistantTurn> & { input: number; read: number; write?: number }): AssistantTurn {
+    const total = overrides.input + overrides.read + (overrides.write ?? 0);
+    return {
+      messageId: overrides.messageId ?? "m",
+      timeCreatedMs: overrides.timeCreatedMs ?? BASE_MS,
+      modelID: overrides.modelID ?? "gpt-6-astra",
+      providerID: overrides.providerID ?? "openai",
+      input: overrides.input,
+      cacheRead: overrides.read,
+      cacheWrite: overrides.write ?? 0,
+      total,
+      reuse: overrides.read / total,
+    };
+  }
+
+  test("a clean session with healthy growing reuse produces no detection", () => {
+    // Reuse climbs steadily above maxReuse — never qualifies as low-reuse.
+    const turns: AssistantTurn[] = [];
+    let read = 5000;
+    for (let i = 0; i < 10; i++) {
+      const input = 500;
+      read += 4000; // reuse grows each turn, well above 0.25 quickly
+      turns.push(turn({ messageId: `m${i}`, timeCreatedMs: BASE_MS + i * MIN_TURN, input, read }));
+    }
+    const results = detectPlateaus(turns, [], DETECTION_OPTIONS);
+    expect(results).toHaveLength(0);
+  });
+
+  test("a true plateau: flat R, growing total, no materialization inside the run — detected", () => {
+    const turns: AssistantTurn[] = [];
+    const pinnedR = 21248;
+    for (let i = 0; i < 18; i++) {
+      // N dominates total so reuse stays low (mirrors real collapse: R small vs huge uncached input).
+      const input = 200_000 + i * 2_000; // total grows each turn
+      turns.push(turn({ messageId: `m${i}`, timeCreatedMs: BASE_MS + i * MIN_TURN, input, read: pinnedR }));
+    }
+    const results = detectPlateaus(turns, [], DETECTION_OPTIONS);
+    expect(results).toHaveLength(1);
+    expect(results[0].startIdx).toBe(0);
+    expect(results[0].endIdx).toBe(17);
+  });
+
+  test("a plateau immediately following materialized=1 INSIDE the run is suppressed by rule 4", () => {
+    const turns: AssistantTurn[] = [];
+    const pinnedR = 21248;
+    for (let i = 0; i < 10; i++) {
+      const input = 200_000 + i * 2_000;
+      turns.push(turn({ messageId: `m${i}`, timeCreatedMs: BASE_MS + i * MIN_TURN, input, read: pinnedR }));
+    }
+    // A materialization lands squarely inside the run (after turn 0, before turn 9),
+    // splitting it into two sub-runs of length 5 each — neither is disqualified,
+    // but the split boundary itself must not be crossed by a single reported run.
+    const midTs = turns[5].timeCreatedMs - 1;
+    const decisions: TransformDecision[] = [{ tsMs: midTs, materialized: true, materializeReason: "system_hash" }];
+    const results = detectPlateaus(turns, decisions, DETECTION_OPTIONS);
+    // No single result should span across the materialization boundary (index 5).
+    for (const r of results) {
+      expect(r.startIdx < 5 && r.endIdx >= 5).toBe(false);
+    }
+  });
+
+  test("a materialization exactly at or before the first turn is the legitimate trigger, not a suppressor", () => {
+    const turns: AssistantTurn[] = [];
+    const pinnedR = 21248;
+    for (let i = 0; i < 5; i++) {
+      const input = 200_000 + i * 2_000;
+      turns.push(turn({ messageId: `m${i}`, timeCreatedMs: BASE_MS + i * MIN_TURN, input, read: pinnedR }));
+    }
+    const decisions: TransformDecision[] = [
+      { tsMs: turns[0].timeCreatedMs - 100, materialized: true, materializeReason: "system_hash" },
+    ];
+    const results = detectPlateaus(turns, decisions, DETECTION_OPTIONS);
+    expect(results).toHaveLength(1);
+    expect(results[0].triggerReason).toBe("system_hash");
+  });
+
+  test("a single-turn dip below --min-run is not detected", () => {
+    const turns: AssistantTurn[] = [
+      turn({ messageId: "m0", timeCreatedMs: BASE_MS, input: 50000, read: 5000 }), // reuse healthy
+      turn({ messageId: "m1", timeCreatedMs: BASE_MS + MIN_TURN, input: 10000, read: 2000 }), // one low-reuse dip
+      turn({ messageId: "m2", timeCreatedMs: BASE_MS + 2 * MIN_TURN, input: 50000, read: 40000 }), // healthy again
+    ];
+    const results = detectPlateaus(turns, [], DETECTION_OPTIONS);
+    expect(results).toHaveLength(0);
+  });
+
+  test("R that is not flat (drifts beyond tolerance) is not detected", () => {
+    const turns: AssistantTurn[] = [];
+    for (let i = 0; i < 6; i++) {
+      const input = 1000;
+      const read = 5000 + i * 10000; // drifts far beyond flat tolerance
+      turns.push(turn({ messageId: `m${i}`, timeCreatedMs: BASE_MS + i * MIN_TURN, input, read }));
+    }
+    const results = detectPlateaus(turns, [], DETECTION_OPTIONS);
+    expect(results).toHaveLength(0);
+  });
+
+  test("total that does not grow across the run is not detected", () => {
+    const turns: AssistantTurn[] = [];
+    const pinnedR = 21248;
+    for (let i = 0; i < 6; i++) {
+      turns.push(turn({ messageId: `m${i}`, timeCreatedMs: BASE_MS + i * MIN_TURN, input: 1000, read: pinnedR }));
+    }
+    const results = detectPlateaus(turns, [], DETECTION_OPTIONS);
+    expect(results).toHaveLength(0);
+  });
+
+  test("missing context.db (transformDecisions=null) degrades: still detects, flags reducedConfidence", () => {
+    const turns: AssistantTurn[] = [];
+    const pinnedR = 21248;
+    for (let i = 0; i < 6; i++) {
+      const input = 200_000 + i * 2_000;
+      turns.push(turn({ messageId: `m${i}`, timeCreatedMs: BASE_MS + i * MIN_TURN, input, read: pinnedR }));
+    }
+    const results = detectPlateaus(turns, null, DETECTION_OPTIONS);
+    expect(results).toHaveLength(1);
+    expect(results[0].reducedConfidence).toBe(true);
+  });
+
+  test("tolerates a single-turn provider-side partial-cache-miss blip inside an otherwise-pinned run (real-world shape)", () => {
+    // Mirrors the observed live-data shape: 18 turns pinned at R=21248 with one
+    // turn dropping to R=3712 mid-run (no materialization event caused it).
+    const turns: AssistantTurn[] = [];
+    const pinnedR = 21248;
+    for (let i = 0; i < 18; i++) {
+      const input = 240_000 + i * 1_300;
+      const read = i === 14 ? 3712 : pinnedR;
+      turns.push(turn({ messageId: `m${i}`, timeCreatedMs: BASE_MS + i * MIN_TURN, input, read }));
+    }
+    const results = detectPlateaus(turns, [], DETECTION_OPTIONS);
+    expect(results).toHaveLength(1);
+    expect(results[0].startIdx).toBe(0);
+    expect(results[0].endIdx).toBe(17);
+  });
+
+  test("two or more outlier blips beyond the outlier budget are NOT tolerated as flat", () => {
+    const turns: AssistantTurn[] = [];
+    const pinnedR = 21248;
+    for (let i = 0; i < 5; i++) {
+      const input = 240_000 + i * 1_300;
+      // 2 of 5 turns deviate sharply — well beyond floor(5*0.1)=0 outlier budget.
+      const read = i === 1 || i === 3 ? 3712 : pinnedR;
+      turns.push(turn({ messageId: `m${i}`, timeCreatedMs: BASE_MS + i * MIN_TURN, input, read }));
+    }
+    const results = detectPlateaus(turns, [], DETECTION_OPTIONS);
+    expect(results).toHaveLength(0);
+  });
+
+  test("a materialization landing a few seconds AFTER the run's first turn (within TRIGGER_GRACE_MS) is still the legitimate trigger, not a split", () => {
+    const turns: AssistantTurn[] = [];
+    const pinnedR = 21248;
+    for (let i = 0; i < 6; i++) {
+      const input = 240_000 + i * 1_300;
+      turns.push(turn({ messageId: `m${i}`, timeCreatedMs: BASE_MS + i * MIN_TURN, input, read: pinnedR }));
+    }
+    // ts_ms lands 3.2s after the first turn's time_created — mirrors the observed
+    // live-data skew between transform_decisions.ts_ms and message.time_created.
+    const decisions: TransformDecision[] = [
+      { tsMs: turns[0].timeCreatedMs + 3200, materialized: true, materializeReason: "system_hash" },
+    ];
+    const results = detectPlateaus(turns, decisions, DETECTION_OPTIONS);
+    expect(results).toHaveLength(1);
+    expect(results[0].startIdx).toBe(0);
+    expect(results[0].endIdx).toBe(5);
+    expect(results[0].triggerReason).toBe("system_hash");
+  });
+
+  test("a materialization beyond TRIGGER_GRACE_MS after the first turn still splits the run", () => {
+    const turns: AssistantTurn[] = [];
+    const pinnedR = 21248;
+    for (let i = 0; i < 6; i++) {
+      const input = 240_000 + i * 1_300;
+      turns.push(turn({ messageId: `m${i}`, timeCreatedMs: BASE_MS + i * MIN_TURN, input, read: pinnedR }));
+    }
+    // Well beyond the 15s grace window, and before turn 1 (BASE_MS + MIN_TURN) — must split.
+    const decisions: TransformDecision[] = [
+      { tsMs: turns[0].timeCreatedMs + 16_000, materialized: true, materializeReason: "system_hash" },
+    ];
+    const results = detectPlateaus(turns, decisions, DETECTION_OPTIONS);
+    // The materialization splits the run before it reaches turn 5 — no result
+    // should span the full [0,5] window uninterrupted.
+    for (const r of results) {
+      expect(r.endIdx).toBeLessThan(5);
+    }
+  });
+});
+
+// ─── DB-backed integration tests ───────────────────────────────────────────────
+
+describe("fetchScoredTurns / fetchTransformDecisions / selectCandidateSessions", () => {
+  test("excludes turns under 1024 total tokens and error turns via SQL + JS filtering", () => {
+    const dir = makeTempDir();
+    try {
+      const { db } = createOpencodeTestDb(dir);
+      insertSession(db, "ses_1", "Test session", BASE_MS, BASE_MS);
+      insertTurns(db, "ses_1", [
+        { id: "t0", timeCreated: BASE_MS, input: 100, read: 100 }, // under threshold
+        { id: "t1", timeCreated: BASE_MS + MIN_TURN, input: 5000, read: 5000, error: { name: "x" } }, // error
+        { id: "t2", timeCreated: BASE_MS + 2 * MIN_TURN, input: 5000, read: 5000 }, // valid
+      ]);
+      insertUserMessage(db, "ses_1", "u0", BASE_MS + 3 * MIN_TURN);
+
+      const turns = fetchScoredTurns(db, "ses_1");
+      expect(turns).toHaveLength(1);
+      expect(turns[0].messageId).toBe("t2");
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("--model filter narrows turns at the SQL layer", () => {
+    const dir = makeTempDir();
+    try {
+      const { db } = createOpencodeTestDb(dir);
+      insertSession(db, "ses_1", "Test session", BASE_MS, BASE_MS);
+      insertTurns(db, "ses_1", [
+        { id: "t0", timeCreated: BASE_MS, input: 5000, read: 5000, modelID: "gpt-6-astra" },
+        { id: "t1", timeCreated: BASE_MS + MIN_TURN, input: 5000, read: 5000, modelID: "claude-sonnet-4.6" },
+      ]);
+
+      const turns = fetchScoredTurns(db, "ses_1", "gpt-6-astra");
+      expect(turns).toHaveLength(1);
+      expect(turns[0].modelID).toBe("gpt-6-astra");
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("selectCandidateSessions respects the since window", () => {
+    const dir = makeTempDir();
+    try {
+      const { db } = createOpencodeTestDb(dir);
+      insertSession(db, "old", "Old session", BASE_MS - 100_000, BASE_MS - 100_000);
+      insertSession(db, "recent", "Recent session", BASE_MS, BASE_MS);
+
+      const rows = selectCandidateSessions(db, BASE_MS - 1000);
+      expect(rows.map((r) => r.id)).toEqual(["recent"]);
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("fetchTransformDecisions reads materialized rows in ts order", () => {
+    const dir = makeTempDir();
+    try {
+      const { db } = createContextTestDb(dir);
+      insertMaterialization(db, "ses_1", BASE_MS + 200, true, "ttl_idle");
+      insertMaterialization(db, "ses_1", BASE_MS + 100, true, "system_hash");
+      insertMaterialization(db, "ses_1", BASE_MS + 150, false, null);
+
+      const decisions = fetchTransformDecisions(db, "ses_1");
+      expect(decisions.map((d) => d.tsMs)).toEqual([BASE_MS + 100, BASE_MS + 150, BASE_MS + 200]);
+      expect(decisions[0].materializeReason).toBe("system_hash");
+      db.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+});
+
+describe("scanSession end-to-end (fixture DBs, opened readonly: true, never file: URI)", () => {
+  test("detects the known-shape plateau across two DBs and reports reducedConfidence=false", () => {
+    const dir = makeTempDir();
+    try {
+      const { db: opencodeDb } = createOpencodeTestDb(dir);
+      const { db: contextDb } = createContextTestDb(dir);
+
+      insertSession(opencodeDb, "ses_plateau", "Plateau session", BASE_MS, BASE_MS + 18 * MIN_TURN);
+      const specs: TurnSpec[] = [];
+      const pinnedR = 21248;
+      for (let i = 0; i < 18; i++) {
+        specs.push({ id: `t${i}`, timeCreated: BASE_MS + i * MIN_TURN, input: 200_000 + i * 2_000, read: pinnedR });
+      }
+      insertTurns(opencodeDb, "ses_plateau", specs);
+      insertMaterialization(contextDb, "ses_plateau", BASE_MS - 1000, true, "system_hash");
+
+      const result = scanSession(opencodeDb, contextDb, "ses_plateau", "Plateau session", undefined, DETECTION_OPTIONS);
+      expect(result.plateaus).toHaveLength(1);
+      expect(result.plateaus[0].reducedConfidence).toBe(false);
+      expect(result.plateaus[0].triggerReason).toBe("system_hash");
+      expect(result.plateaus[0].wastedTokens).toBeGreaterThan(0);
+
+      opencodeDb.close();
+      contextDb.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+
+  test("scanSession with contextDb=null degrades gracefully (no throw, reducedConfidence=true)", () => {
+    const dir = makeTempDir();
+    try {
+      const { db: opencodeDb } = createOpencodeTestDb(dir);
+      insertSession(opencodeDb, "ses_plateau", "Plateau session", BASE_MS, BASE_MS + 6 * MIN_TURN);
+      const specs: TurnSpec[] = [];
+      const pinnedR = 21248;
+      for (let i = 0; i < 6; i++) {
+        specs.push({ id: `t${i}`, timeCreated: BASE_MS + i * MIN_TURN, input: 200_000 + i * 2_000, read: pinnedR });
+      }
+      insertTurns(opencodeDb, "ses_plateau", specs);
+
+      const result = scanSession(opencodeDb, null, "ses_plateau", "Plateau session", undefined, DETECTION_OPTIONS);
+      expect(result.plateaus).toHaveLength(1);
+      expect(result.plateaus[0].reducedConfidence).toBe(true);
+
+      opencodeDb.close();
+    } finally {
+      removeTempDir(dir);
+    }
+  });
+});
+
+// ─── CLI parsing ──────────────────────────────────────────────────────────────
+
+describe("parseSinceDuration", () => {
+  test("parses days, hours, minutes", () => {
+    const now = Date.now();
+    expect(parseSinceDuration("7d")).toBeLessThanOrEqual(now - 6 * 86_400_000);
+    expect(parseSinceDuration("24h")).toBeLessThanOrEqual(now - 23 * 3_600_000);
+    expect(parseSinceDuration("90m")).toBeLessThanOrEqual(now - 89 * 60_000);
+  });
+
+  test("returns null on unparseable input", () => {
+    expect(parseSinceDuration("banana")).toBeNull();
+    expect(parseSinceDuration("7")).toBeNull();
+    expect(parseSinceDuration("")).toBeNull();
+  });
+});
+
+describe("parseArgs", () => {
+  test("applies defaults with no flags", () => {
+    const opts = parseArgs([]);
+    expect(opts.minRun).toBe(DEFAULT_MIN_RUN);
+    expect(opts.maxReuse).toBe(DEFAULT_MAX_REUSE);
+    expect(opts.json).toBe(false);
+    expect(opts.session).toBeUndefined();
+  });
+
+  test("parses --session, --model, --json, --limit", () => {
+    const opts = parseArgs(["--session", "ses_xxx", "--model", "gpt-6-astra", "--json", "--limit", "5"]);
+    expect(opts.session).toBe("ses_xxx");
+    expect(opts.model).toBe("gpt-6-astra");
+    expect(opts.json).toBe(true);
+    expect(opts.limit).toBe(5);
+  });
+
+  test("--help short-circuits other flag parsing", () => {
+    const opts = parseArgs(["--help"]);
+    expect(opts.help).toBe(true);
+  });
+
+  test("invalid --max-reuse falls back to default with a warning", () => {
+    const opts = parseArgs(["--max-reuse", "2.5"]);
+    expect(opts.maxReuse).toBe(DEFAULT_MAX_REUSE);
+  });
+});

--- a/.config/opencode/scripts/cache-plateau.ts
+++ b/.config/opencode/scripts/cache-plateau.ts
@@ -108,7 +108,9 @@ const DEFAULT_CONTEXT_DB_PATH = join(homedir(), ".local/share/cortexkit/magic-co
  * SQLITE_OPEN_READONLY and works on both macOS and Linux.
  */
 export function openReadOnlyDb(dbPath: string): Database {
-  return new Database(dbPath, { readonly: true });
+  const db = new Database(dbPath, { readonly: true });
+  db.exec("PRAGMA busy_timeout=5000");
+  return db;
 }
 
 /**

--- a/.config/opencode/scripts/cache-plateau.ts
+++ b/.config/opencode/scripts/cache-plateau.ts
@@ -1,0 +1,844 @@
+#!/usr/bin/env bun
+import { Database } from "bun:sqlite";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type AssistantTurn = {
+  messageId: string;
+  timeCreatedMs: number;
+  modelID: string;
+  providerID: string;
+  input: number; // N — uncached input tokens (tokens.input)
+  cacheRead: number; // R — tokens.cache.read
+  cacheWrite: number; // W — tokens.cache.write ?? 0
+  total: number; // N + R + W — full prompt size
+  reuse: number; // R / total
+};
+
+export type TransformDecision = {
+  tsMs: number;
+  materialized: boolean;
+  materializeReason: string | null;
+};
+
+export type DetectionOptions = {
+  minRun: number;
+  maxReuse: number;
+  flatAbsTolerance: number;
+  flatPctTolerance: number;
+};
+
+export type RawPlateauRun = {
+  startIdx: number; // 0-based, inclusive, index into the scored turn array
+  endIdx: number; // 0-based, inclusive
+  reducedConfidence: boolean; // true when context.db was unavailable and rule 4 was skipped
+  triggerReason: string | null;
+  triggerTsMs: number | null;
+};
+
+export type PlateauRun = {
+  sessionId: string;
+  title: string;
+  model: string;
+  providerID: string;
+  runLength: number;
+  totalTurnsScored: number;
+  startIndex: number; // 1-based ordinal within the scored turn sequence
+  endIndex: number; // 1-based ordinal within the scored turn sequence
+  startTimeMs: number;
+  endTimeMs: number;
+  reuseMin: number;
+  reuseMax: number;
+  cacheReadPinned: number; // median R across the run
+  cacheReadMin: number;
+  cacheReadMax: number;
+  totalFirst: number;
+  totalLast: number;
+  wastedTokens: number; // sum(N + W) across the run
+  triggerReason: string | null;
+  triggerTsMs: number | null;
+  wallClockGapsMs: number[];
+  reducedConfidence: boolean;
+};
+
+export type SessionScanResult = {
+  sessionId: string;
+  title: string;
+  scoredTurnCount: number;
+  plateaus: PlateauRun[];
+};
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+export const DEFAULT_MIN_RUN = 3;
+export const DEFAULT_MAX_REUSE = 0.25;
+export const DEFAULT_FLAT_ABS_TOLERANCE = 2048;
+export const DEFAULT_FLAT_PCT_TOLERANCE = 0.05;
+export const MIN_TOTAL_TOKENS = 1024; // below this a turn is below the cache-eligibility threshold — noise, skip
+export const DEFAULT_SINCE = "7d";
+export const DEFAULT_LIMIT = 20;
+
+// transform_decisions.ts_ms is recorded a few seconds into request processing,
+// while message.time_created is stamped at request dispatch — observed skew on
+// real data is ~3-4s. A materialization within this grace window of a run's
+// first turn is still its legitimate trigger, not a mid-run reset.
+export const TRIGGER_GRACE_MS = 15_000;
+
+// A pinned-R run can contain a rare single-turn provider-side partial cache
+// miss (a genuine but transient reuse dip) without that turn being a real
+// context reset. Flatness tolerates up to this fraction of the run's turns
+// falling outside the per-turn tolerance band around the median.
+export const FLAT_OUTLIER_BUDGET_FRACTION = 0.1;
+
+const DEFAULT_OPENCODE_DB_PATH = join(homedir(), ".local/share/opencode/opencode.db");
+const DEFAULT_CONTEXT_DB_PATH = join(homedir(), ".local/share/cortexkit/magic-context/context.db");
+
+// ─── DB Access ────────────────────────────────────────────────────────────────
+
+/**
+ * Open a read-only SQLite connection.
+ *
+ * A `file:...?mode=ro` URI is deliberately not used: URI filenames require
+ * SQLite's URI handling to be enabled, and where it is not the whole string
+ * is treated as a literal path, so the open fails with "unable to open
+ * database file" on Linux. Plain path + `{ readonly: true }` maps to
+ * SQLITE_OPEN_READONLY and works on both macOS and Linux.
+ */
+export function openReadOnlyDb(dbPath: string): Database {
+  return new Database(dbPath, { readonly: true });
+}
+
+/**
+ * Open the context.db connection if the file exists and is readable.
+ * Returns null (not a throw) on any failure — callers degrade gracefully:
+ * detection still runs, rule 4 (materialization check) is skipped, and the
+ * output flags reduced confidence.
+ */
+export function tryOpenContextDb(dbPath: string): Database | null {
+  if (!existsSync(dbPath)) return null;
+  try {
+    return openReadOnlyDb(dbPath);
+  } catch {
+    return null;
+  }
+}
+
+type MessageRow = { id: string; time_created: number; data: string };
+
+/**
+ * Parse a message.data JSON blob into a scored AssistantTurn.
+ * Returns null (skip) on: malformed JSON, non-assistant role, a non-null
+ * `error`, missing/malformed tokens shape, or total < MIN_TOTAL_TOKENS.
+ *
+ * Token accounting: tokens.input is the UNCACHED portion. total = N + R + W.
+ * reuse = R / total — never R / N.
+ */
+export function parseAssistantTurn(row: MessageRow): AssistantTurn | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(row.data);
+  } catch {
+    return null;
+  }
+
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const obj = parsed as Record<string, unknown>;
+
+  if (obj.role !== "assistant") return null;
+  if (obj.error != null) return null;
+
+  const tokens = obj.tokens;
+  if (typeof tokens !== "object" || tokens === null) return null;
+  const t = tokens as Record<string, unknown>;
+
+  const input = typeof t.input === "number" ? t.input : null;
+  if (input === null) return null;
+
+  const cache = t.cache;
+  if (typeof cache !== "object" || cache === null) return null;
+  const c = cache as Record<string, unknown>;
+
+  const read = typeof c.read === "number" ? c.read : null;
+  if (read === null) return null;
+  const write = typeof c.write === "number" ? c.write : 0;
+
+  const total = input + read + write;
+  if (total < MIN_TOTAL_TOKENS) return null;
+
+  const modelID = typeof obj.modelID === "string" ? obj.modelID : "unknown";
+  const providerID = typeof obj.providerID === "string" ? obj.providerID : "unknown";
+
+  return {
+    messageId: row.id,
+    timeCreatedMs: row.time_created,
+    modelID,
+    providerID,
+    input,
+    cacheRead: read,
+    cacheWrite: write,
+    total,
+    reuse: read / total,
+  };
+}
+
+/**
+ * Fetch and parse all scored assistant turns for a session, time-ordered.
+ * `json_extract` filters at the SQL layer so unrelated rows (user messages,
+ * other models when --model is set) are never pulled into JS for a 66GB DB.
+ */
+export function fetchScoredTurns(db: Database, sessionId: string, model?: string): AssistantTurn[] {
+  const rows = model
+    ? db
+        .query<MessageRow, [string, string]>(
+          `SELECT id, time_created, data FROM message
+           WHERE session_id = ? AND json_extract(data, '$.role') = 'assistant'
+             AND json_extract(data, '$.modelID') = ?
+           ORDER BY time_created ASC`,
+        )
+        .all(sessionId, model)
+    : db
+        .query<MessageRow, [string]>(
+          `SELECT id, time_created, data FROM message
+           WHERE session_id = ? AND json_extract(data, '$.role') = 'assistant'
+           ORDER BY time_created ASC`,
+        )
+        .all(sessionId);
+
+  const turns: AssistantTurn[] = [];
+  for (const row of rows) {
+    const turn = parseAssistantTurn(row);
+    if (turn) turns.push(turn);
+  }
+  return turns;
+}
+
+type TransformDecisionRow = { ts_ms: number; materialized: number; materialize_reason: string | null };
+
+export function fetchTransformDecisions(db: Database, sessionId: string): TransformDecision[] {
+  const rows = db
+    .query<TransformDecisionRow, [string]>(
+      `SELECT ts_ms, materialized, materialize_reason FROM transform_decisions
+       WHERE session_id = ? ORDER BY ts_ms ASC`,
+    )
+    .all(sessionId);
+
+  return rows.map((r) => ({
+    tsMs: r.ts_ms,
+    materialized: r.materialized === 1,
+    materializeReason: r.materialize_reason,
+  }));
+}
+
+type SessionRow = { id: string; title: string | null };
+
+export function selectCandidateSessions(
+  db: Database,
+  sinceMs: number,
+): Array<{ id: string; title: string }> {
+  const rows = db
+    .query<SessionRow, [number]>(
+      `SELECT id, title FROM session WHERE time_updated >= ? ORDER BY time_created ASC`,
+    )
+    .all(sinceMs);
+  return rows.map((r) => ({ id: r.id, title: r.title ?? "(untitled)" }));
+}
+
+export function fetchSessionTitle(db: Database, sessionId: string): string | null {
+  const row = db.query<{ title: string | null }, [string]>(`SELECT title FROM session WHERE id = ?`).get(sessionId);
+  return row ? (row.title ?? "(untitled)") : null;
+}
+
+// ─── Detection ────────────────────────────────────────────────────────────────
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 !== 0 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/**
+ * Split a maximal low-reuse [s,e] segment at any materialized=1 event that
+ * occurs strictly after turns[s].timeCreatedMs (the run's first turn is
+ * allowed a legitimate triggering materialization; anything after that
+ * *inside* the run means a fresh legitimate reset happened, so the run
+ * splits there rather than being disqualified wholesale). Each resulting
+ * sub-segment gets re-evaluated against minRun/flat/growth independently.
+ */
+function splitSegmentByMaterialization(
+  turns: AssistantTurn[],
+  s: number,
+  e: number,
+  materializedEvents: TransformDecision[],
+): Array<[number, number]> {
+  const boundarySet = new Set<number>();
+
+  for (const ev of materializedEvents) {
+    if (ev.tsMs <= turns[s].timeCreatedMs + TRIGGER_GRACE_MS) continue; // legitimate trigger for the segment start, not a split
+    if (ev.tsMs > turns[e].timeCreatedMs) continue; // outside this segment's window
+
+    for (let k = s + 1; k <= e; k++) {
+      if (turns[k].timeCreatedMs >= ev.tsMs) {
+        boundarySet.add(k);
+        break;
+      }
+    }
+  }
+
+  const boundaries = [...boundarySet].sort((a, b) => a - b);
+  const segments: Array<[number, number]> = [];
+  let start = s;
+  for (const b of boundaries) {
+    segments.push([start, b - 1]);
+    start = b;
+  }
+  segments.push([start, e]);
+  return segments;
+}
+
+/**
+ * Closest materialized=1 row at or before `atOrBeforeMs` (allowing
+ * TRIGGER_GRACE_MS of slack for the ts_ms-vs-time_created skew described
+ * above), or null if none / unavailable.
+ */
+function findTriggerReason(
+  transformDecisions: TransformDecision[] | null,
+  atOrBeforeMs: number,
+): TransformDecision | null {
+  if (!transformDecisions) return null;
+  let best: TransformDecision | null = null;
+  for (const d of transformDecisions) {
+    if (!d.materialized) continue;
+    if (d.tsMs <= atOrBeforeMs + TRIGGER_GRACE_MS && (!best || d.tsMs > best.tsMs)) best = d;
+  }
+  return best;
+}
+
+/**
+ * Detect plateau runs within a time-ordered, already-scored turn sequence.
+ *
+ * A plateau is a run of >= minRun consecutive turns where reuse stays below
+ * maxReuse, R (cache read) stays flat within tolerance, and total prompt
+ * size still grows — i.e. the model keeps paying full or near-full prompt
+ * cost turn after turn with no recovery. `transformDecisions === null` means
+ * context.db was unavailable: rule 4 (materialization check) is skipped and
+ * every detection in that mode is flagged reducedConfidence.
+ */
+export function detectPlateaus(
+  turns: AssistantTurn[],
+  transformDecisions: TransformDecision[] | null,
+  options: DetectionOptions,
+): RawPlateauRun[] {
+  const results: RawPlateauRun[] = [];
+  if (turns.length === 0) return results;
+
+  const materializedEvents = transformDecisions ? transformDecisions.filter((d) => d.materialized) : [];
+
+  let i = 0;
+  while (i < turns.length) {
+    if (turns[i].reuse >= options.maxReuse) {
+      i++;
+      continue;
+    }
+
+    let j = i;
+    while (j + 1 < turns.length && turns[j + 1].reuse < options.maxReuse) j++;
+    // [i, j] is the maximal contiguous low-reuse segment.
+
+    const segments = transformDecisions
+      ? splitSegmentByMaterialization(turns, i, j, materializedEvents)
+      : [[i, j] as [number, number]];
+
+    for (const [s, e] of segments) {
+      const runLength = e - s + 1;
+      if (runLength < options.minRun) continue;
+
+      const reads = turns.slice(s, e + 1).map((t) => t.cacheRead);
+      const med = median(reads);
+      const tolerance = Math.max(options.flatAbsTolerance, options.flatPctTolerance * med);
+      // Literal max-min flatness is too brittle against real data: a single
+      // transient provider-side partial cache miss inside an otherwise-pinned
+      // run shouldn't disqualify the whole plateau. Tolerate a small budget of
+      // per-turn outliers instead of requiring every turn within tolerance.
+      const outliers = reads.filter((r) => Math.abs(r - med) > tolerance).length;
+      const outlierBudget = Math.floor(runLength * FLAT_OUTLIER_BUDGET_FRACTION);
+      const flat = outliers <= outlierBudget;
+
+      const growth = turns[e].total > turns[s].total;
+
+      if (!flat || !growth) continue;
+
+      const trigger = findTriggerReason(transformDecisions, turns[s].timeCreatedMs);
+      results.push({
+        startIdx: s,
+        endIdx: e,
+        reducedConfidence: transformDecisions === null,
+        triggerReason: trigger?.materializeReason ?? null,
+        triggerTsMs: trigger?.tsMs ?? null,
+      });
+    }
+
+    i = j + 1;
+  }
+
+  return results;
+}
+
+export function buildPlateauRun(
+  sessionId: string,
+  title: string,
+  turns: AssistantTurn[],
+  totalTurnsScored: number,
+  raw: RawPlateauRun,
+): PlateauRun {
+  const runTurns = turns.slice(raw.startIdx, raw.endIdx + 1);
+  const reuses = runTurns.map((t) => t.reuse);
+  const reads = runTurns.map((t) => t.cacheRead);
+  const wastedTokens = runTurns.reduce((sum, t) => sum + t.input + t.cacheWrite, 0);
+
+  const gaps: number[] = [];
+  for (let k = 1; k < runTurns.length; k++) {
+    gaps.push(runTurns[k].timeCreatedMs - runTurns[k - 1].timeCreatedMs);
+  }
+
+  return {
+    sessionId,
+    title,
+    model: runTurns[0].modelID,
+    providerID: runTurns[0].providerID,
+    runLength: runTurns.length,
+    totalTurnsScored,
+    startIndex: raw.startIdx + 1,
+    endIndex: raw.endIdx + 1,
+    startTimeMs: runTurns[0].timeCreatedMs,
+    endTimeMs: runTurns[runTurns.length - 1].timeCreatedMs,
+    reuseMin: Math.min(...reuses),
+    reuseMax: Math.max(...reuses),
+    cacheReadPinned: median(reads),
+    cacheReadMin: Math.min(...reads),
+    cacheReadMax: Math.max(...reads),
+    totalFirst: runTurns[0].total,
+    totalLast: runTurns[runTurns.length - 1].total,
+    wastedTokens,
+    triggerReason: raw.triggerReason,
+    triggerTsMs: raw.triggerTsMs,
+    wallClockGapsMs: gaps,
+    reducedConfidence: raw.reducedConfidence,
+  };
+}
+
+export function scanSession(
+  opencodeDb: Database,
+  contextDb: Database | null,
+  sessionId: string,
+  title: string,
+  model: string | undefined,
+  options: DetectionOptions,
+): SessionScanResult {
+  const turns = fetchScoredTurns(opencodeDb, sessionId, model);
+  const transformDecisions = contextDb ? fetchTransformDecisions(contextDb, sessionId) : null;
+  const raw = detectPlateaus(turns, transformDecisions, options);
+  const plateaus = raw.map((r) => buildPlateauRun(sessionId, title, turns, turns.length, r));
+  return { sessionId, title, scoredTurnCount: turns.length, plateaus };
+}
+
+// ─── CLI: Duration Parsing ──────────────────────────────────────────────────────
+
+/** Parse `--since` values: `7d`, `24h`, `90m`. Returns epoch ms, or null if unparseable. */
+export function parseSinceDuration(value: string): number | null {
+  const match = /^(\d+)(d|h|m)$/.exec(value);
+  if (!match) return null;
+  const amount = parseInt(match[1], 10);
+  const unitMs = match[2] === "d" ? 86_400_000 : match[2] === "h" ? 3_600_000 : 60_000;
+  return Date.now() - amount * unitMs;
+}
+
+// ─── CLI: Flag Parsing ──────────────────────────────────────────────────────────
+
+export type CliOptions = {
+  session?: string;
+  model?: string;
+  sinceMs: number;
+  minRun: number;
+  maxReuse: number;
+  flatPctTolerance: number;
+  json: boolean;
+  limit: number;
+  help: boolean;
+};
+
+const KNOWN_FLAGS = new Set([
+  "--session",
+  "--model",
+  "--since",
+  "--min-run",
+  "--max-reuse",
+  "--flat-tolerance",
+  "--json",
+  "--limit",
+  "--help",
+  "-h",
+]);
+
+function warnUnknownFlag(flag: string): void {
+  console.warn(`Warning: Unknown flag "${flag}" ignored`);
+}
+
+function warnInvalidValue(flag: string, value: string, expected: string): void {
+  console.warn(`Warning: Invalid value "${value}" for ${flag}, expected ${expected}. Using default.`);
+}
+
+export function parseArgs(argv: string[]): CliOptions {
+  const args = new Map<string, string | boolean>();
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+
+    if (arg === "-h" || arg === "--help") {
+      args.set("--help", true);
+      continue;
+    }
+
+    if (!arg.startsWith("--")) continue;
+
+    const eqIndex = arg.indexOf("=");
+    if (eqIndex !== -1) {
+      const key = arg.slice(0, eqIndex);
+      const rawValue = arg.slice(eqIndex + 1);
+      if (!KNOWN_FLAGS.has(key)) {
+        warnUnknownFlag(key);
+        continue;
+      }
+      args.set(key, rawValue);
+      continue;
+    }
+
+    if (!KNOWN_FLAGS.has(arg)) {
+      warnUnknownFlag(arg);
+      continue;
+    }
+
+    if (arg === "--json") {
+      args.set(arg, true);
+      continue;
+    }
+
+    const nextValue = argv[i + 1];
+    if (nextValue != null && !nextValue.startsWith("--")) {
+      args.set(arg, nextValue);
+      i += 1;
+      continue;
+    }
+
+    args.set(arg, true);
+  }
+
+  if (args.get("--help") === true) {
+    return {
+      sinceMs: Date.now(),
+      minRun: DEFAULT_MIN_RUN,
+      maxReuse: DEFAULT_MAX_REUSE,
+      flatPctTolerance: DEFAULT_FLAT_PCT_TOLERANCE,
+      json: false,
+      limit: DEFAULT_LIMIT,
+      help: true,
+    };
+  }
+
+  const sessionValue = args.get("--session");
+  const modelValue = args.get("--model");
+
+  const sinceValue = args.get("--since");
+  let sinceMs = Date.now() - 7 * 86_400_000;
+  if (sinceValue != null && sinceValue !== true) {
+    const parsed = parseSinceDuration(String(sinceValue));
+    if (parsed === null) {
+      warnInvalidValue("--since", String(sinceValue), "duration like 7d, 24h, or 90m");
+    } else {
+      sinceMs = parsed;
+    }
+  }
+
+  const minRunValue = args.get("--min-run");
+  let minRun = DEFAULT_MIN_RUN;
+  if (minRunValue != null && minRunValue !== true) {
+    const parsed = Number(minRunValue);
+    if (!Number.isInteger(parsed) || parsed < 2) {
+      warnInvalidValue("--min-run", String(minRunValue), "integer >= 2");
+    } else {
+      minRun = parsed;
+    }
+  }
+
+  const maxReuseValue = args.get("--max-reuse");
+  let maxReuse = DEFAULT_MAX_REUSE;
+  if (maxReuseValue != null && maxReuseValue !== true) {
+    const parsed = Number(maxReuseValue);
+    if (!Number.isFinite(parsed) || parsed <= 0 || parsed >= 1) {
+      warnInvalidValue("--max-reuse", String(maxReuseValue), "float between 0 and 1");
+    } else {
+      maxReuse = parsed;
+    }
+  }
+
+  const flatToleranceValue = args.get("--flat-tolerance");
+  let flatPctTolerance = DEFAULT_FLAT_PCT_TOLERANCE;
+  if (flatToleranceValue != null && flatToleranceValue !== true) {
+    const parsed = Number(flatToleranceValue);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      warnInvalidValue("--flat-tolerance", String(flatToleranceValue), "non-negative float (fraction, e.g. 0.05)");
+    } else {
+      flatPctTolerance = parsed;
+    }
+  }
+
+  const jsonValue = args.get("--json");
+  const json = jsonValue === true;
+
+  const limitValue = args.get("--limit");
+  let limit = DEFAULT_LIMIT;
+  if (limitValue != null && limitValue !== true) {
+    const parsed = Number(limitValue);
+    if (!Number.isInteger(parsed) || parsed < 1) {
+      warnInvalidValue("--limit", String(limitValue), "positive integer");
+    } else {
+      limit = parsed;
+    }
+  }
+
+  return {
+    session: sessionValue != null && sessionValue !== true ? String(sessionValue) : undefined,
+    model: modelValue != null && modelValue !== true ? String(modelValue) : undefined,
+    sinceMs,
+    minRun,
+    maxReuse,
+    flatPctTolerance,
+    json,
+    limit,
+    help: false,
+  };
+}
+
+// ─── CLI: Output ──────────────────────────────────────────────────────────────
+
+const USAGE = `cache-plateau — detect sessions stuck in sustained prompt-cache collapse.
+
+USAGE:
+  cache-plateau.ts [OPTIONS]
+  mise run opencode:cache-plateau -- [OPTIONS]   # note: -- separator forwards flags through mise
+
+OPTIONS:
+  -h, --help              Show this message.
+  --session <id>          Analyse exactly one session (ignores --since).
+  --model <id>             Filter to a model (e.g. gpt-6-astra).
+  --since <dur>            Recency filter: 7d / 24h / 90m. Default: 7d.
+  --min-run <n>            Minimum consecutive scored turns to call a plateau. Default: 3.
+  --max-reuse <f>          Reuse ceiling (0-1) below which a turn counts as low-reuse. Default: 0.25.
+  --flat-tolerance <f>     Fractional tolerance for "flat R" (used as max(2048, f * median(R))). Default: 0.05.
+  --json                   Machine-readable output.
+  --limit <n>              Max plateaus reported, sorted by wasted tokens desc. Default: 20.
+
+ENVIRONMENT VARIABLES:
+  OPENCODE_DB_PATH   Override OpenCode SQLite path (default: ~/.local/share/opencode/opencode.db)
+  CONTEXT_DB_PATH    Override Magic Context SQLite path (default: ~/.local/share/cortexkit/magic-context/context.db)
+
+EXIT CODES:
+  0   Scan completed (finding plateaus is a normal result, not a failure).
+  1   Real error — unreadable opencode.db, or --session id not found.
+
+EXAMPLES:
+  cache-plateau.ts                                   # scan last 7 days, all models
+  cache-plateau.ts --model gpt-6-astra --since 7d
+  cache-plateau.ts --session ses_xxx --json
+`;
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function truncateTitle(title: string, max = 60): string {
+  return title.length > max ? title.slice(0, max - 1) + "…" : title;
+}
+
+function formatPct(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatIso(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+function renderPlateauText(p: PlateauRun): string {
+  const lines: string[] = [];
+  lines.push(`Session ${p.sessionId} — "${truncateTitle(p.title)}" (${p.model})`);
+  lines.push(
+    `  Run: turns ${p.startIndex}-${p.endIndex} of ${p.totalTurnsScored} (${p.runLength} turns, ${formatIso(p.startTimeMs)} → ${formatIso(p.endTimeMs)})`,
+  );
+  lines.push(`  Reuse: ${formatPct(p.reuseMin)} – ${formatPct(p.reuseMax)}`);
+  lines.push(
+    `  Cache read pinned: ~${Math.round(p.cacheReadPinned).toLocaleString()} tokens (range ${p.cacheReadMin.toLocaleString()}-${p.cacheReadMax.toLocaleString()})`,
+  );
+  lines.push(`  Prompt growth: ${p.totalFirst.toLocaleString()} → ${p.totalLast.toLocaleString()} tokens`);
+  lines.push(`  Wasted tokens: ${p.wastedTokens.toLocaleString()}`);
+  if (p.triggerReason != null && p.triggerTsMs != null) {
+    lines.push(`  Triggered by: ${p.triggerReason} materialization at ${formatIso(p.triggerTsMs)}`);
+  } else if (p.reducedConfidence) {
+    lines.push(`  Triggered by: unknown (context.db unavailable — reduced confidence)`);
+  } else {
+    lines.push(`  Triggered by: no preceding materialization found`);
+  }
+  if (p.wallClockGapsMs.length > 0) {
+    const gapsSec = p.wallClockGapsMs.map((ms) => Math.round(ms / 1000));
+    lines.push(`  Wall-clock gaps: ${gapsSec.map((s) => `${s}s`).join(", ")}`);
+  }
+  return lines.join("\n");
+}
+
+type Summary = {
+  sessions_scanned: number;
+  plateaus_found: number;
+  total_wasted_tokens: number;
+  worst_session: { session_id: string; title: string; wasted_tokens: number } | null;
+  context_db_available: boolean;
+};
+
+function renderText(plateaus: PlateauRun[], summary: Summary, options: CliOptions): void {
+  if (!summary.context_db_available) {
+    console.log(
+      "Warning: context.db unavailable — rule 4 (materialization check) skipped; detections below are flagged reducedConfidence and may include sessions that were legitimately reset once.\n",
+    );
+  }
+
+  if (plateaus.length === 0) {
+    console.log("No cache plateaus detected.\n");
+  } else {
+    for (const p of plateaus) {
+      console.log(renderPlateauText(p));
+      console.log("");
+    }
+  }
+
+  console.log("Summary");
+  console.log("-------");
+  console.log(`Sessions scanned: ${summary.sessions_scanned}`);
+  console.log(`Plateaus found: ${summary.plateaus_found}`);
+  console.log(`Total wasted tokens: ${summary.total_wasted_tokens.toLocaleString()}`);
+  if (summary.worst_session) {
+    console.log(
+      `Worst session: ${summary.worst_session.session_id} — "${truncateTitle(summary.worst_session.title)}" (${summary.worst_session.wasted_tokens.toLocaleString()} wasted tokens)`,
+    );
+  } else {
+    console.log("Worst session: none");
+  }
+  if (plateaus.length < summary.plateaus_found) {
+    console.log(`(showing top ${plateaus.length} of ${summary.plateaus_found}, --limit=${options.limit})`);
+  }
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+export async function main(): Promise<number> {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (options.help) {
+    console.log(USAGE);
+    return 0;
+  }
+
+  const opencodeDbPath = process.env.OPENCODE_DB_PATH ?? DEFAULT_OPENCODE_DB_PATH;
+  const contextDbPath = process.env.CONTEXT_DB_PATH ?? DEFAULT_CONTEXT_DB_PATH;
+
+  let opencodeDb: Database;
+  try {
+    opencodeDb = openReadOnlyDb(opencodeDbPath);
+  } catch (err) {
+    const message = `Failed to open OpenCode DB at ${opencodeDbPath}: ${formatErrorMessage(err)}`;
+    if (options.json) {
+      console.log(JSON.stringify([{ label: "cache-plateau-scan", error: message }], null, 2));
+    } else {
+      console.error(`Error: ${message}`);
+    }
+    return 1;
+  }
+
+  const contextDb = tryOpenContextDb(contextDbPath);
+  const contextDbAvailable = contextDb !== null;
+
+  const detectionOptions: DetectionOptions = {
+    minRun: options.minRun,
+    maxReuse: options.maxReuse,
+    flatAbsTolerance: DEFAULT_FLAT_ABS_TOLERANCE,
+    flatPctTolerance: options.flatPctTolerance,
+  };
+
+  const results: SessionScanResult[] = [];
+
+  try {
+    if (options.session) {
+      const title = fetchSessionTitle(opencodeDb, options.session);
+      if (title === null) {
+        const message = `Session not found: ${options.session}`;
+        if (options.json) {
+          console.log(JSON.stringify([{ label: "cache-plateau-scan", error: message }], null, 2));
+        } else {
+          console.error(`Error: ${message}`);
+        }
+        return 1;
+      }
+      results.push(scanSession(opencodeDb, contextDb, options.session, title, options.model, detectionOptions));
+    } else {
+      const candidates = selectCandidateSessions(opencodeDb, options.sinceMs);
+      for (const row of candidates) {
+        results.push(scanSession(opencodeDb, contextDb, row.id, row.title, options.model, detectionOptions));
+      }
+    }
+  } catch (err) {
+    const message = `Scan failed: ${formatErrorMessage(err)}`;
+    if (options.json) {
+      console.log(JSON.stringify([{ label: "cache-plateau-scan", error: message }], null, 2));
+    } else {
+      console.error(`Error: ${message}`);
+    }
+    return 1;
+  } finally {
+    opencodeDb.close();
+    contextDb?.close();
+  }
+
+  const allPlateaus = results.flatMap((r) => r.plateaus);
+  allPlateaus.sort((a, b) => b.wastedTokens - a.wastedTokens);
+  const limited = allPlateaus.slice(0, options.limit);
+
+  const totalWasted = allPlateaus.reduce((sum, p) => sum + p.wastedTokens, 0);
+  const worst = allPlateaus[0] ?? null;
+
+  const summary: Summary = {
+    sessions_scanned: results.length,
+    plateaus_found: allPlateaus.length,
+    total_wasted_tokens: totalWasted,
+    worst_session: worst
+      ? { session_id: worst.sessionId, title: worst.title, wasted_tokens: worst.wastedTokens }
+      : null,
+    context_db_available: contextDbAvailable,
+  };
+
+  if (options.json) {
+    const data = {
+      since_ms: options.session ? null : options.sinceMs,
+      model: options.model ?? null,
+      plateaus: limited,
+      summary,
+    };
+    console.log(JSON.stringify([{ label: "cache-plateau-scan", data }], null, 2));
+  } else {
+    renderText(limited, summary, options);
+  }
+
+  return 0;
+}
+
+if (import.meta.main) {
+  main().then((code) => process.exit(code));
+}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -111,6 +111,10 @@ jobs:
         working-directory: .config/opencode/scripts
         run: bun test ollama-distill.test.ts
 
+      - name: Run cache-plateau tests
+        working-directory: .config/opencode/scripts
+        run: bun test cache-plateau.test.ts
+
   # Aggregates the matrix into one stable status context. Branch protection
   # requires 'Script Tests'; a matrix reports per-leg names instead, so without
   # this the required check would never report and every PR would block.


### PR DESCRIPTION
Finds OpenCode sessions burning tokens on repeated full-price prompts by scanning the session store and context-plugin decision log read-only. It looks for consecutive low-reuse runs where cache reads stay flat while the prompt keeps growing, and ignores stretches explained by an intentional context rewrite.

Run it with ; use , , and  for filtering and machine-readable output. The change is covered by 32 tests built around temporary fixture databases.