### PR TITLE
chore(opencode): switch preset models to opencode-go

### DIFF
--- a/.config/opencode/oh-my-opencode-slim.jsonc
+++ b/.config/opencode/oh-my-opencode-slim.jsonc
@@ -10,8 +10,8 @@
         "mcps": ["*", "!context7"]
       },
       "oracle": {
-        "model": "anthropic/claude-opus-5",
-        "variant": "high",
+        "model": "opencode-go/qwen3.8-max",
+        "variant": "max",
         "skills": ["ce:brainstorm", "ce:ideate", "simplify", "systematic:*", "reflect"],
         "mcps": []
       },

--- a/.config/opencode/systematic.jsonc
+++ b/.config/opencode/systematic.jsonc
@@ -17,8 +17,8 @@
       "variant": "low"
     },
     "workflow": {
-      "model": "anthropic/claude-sonnet-5",
-      "variant": "low"
+      "model": "opencode-go/deepseek-v4.1-flash",
+      "variant": "high"
     }
   },
   "agents": {
@@ -31,8 +31,8 @@
       "variant": "high"
     },
     "systematic-implementer": {
-      "model": "anthropic/claude-sonnet-5",
-      "variant": "medium"
+      "model": "opencode-go/deepseek-v4.1-flash",
+      "variant": "high"
     }
   },
   "workflow_guard": {


### PR DESCRIPTION
- update the slim preset oracle from Anthropic Claude Opus to opencode-go/qwen3.8-max with the max variant
- move the systematic workflow and implementer agents from Claude Sonnet to opencode-go/deepseek-v4.1-flash at higher reasoning settings
- align the OpenCode model routing presets with the current local provider configuration