### PR TITLE
fix(mise): use Aqua backend for pnpm 12

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -2,7 +2,7 @@
 node = "24.21.0"
 npm = "12.0.2"
 bun = "1.4.2"
-pnpm = "12.4.0"
+"aqua:pnpm/pnpm" = "12.4.0"
 python = "3.14.7"
 pipx = "1.17.2"
 "pipx:poetry" = "2.4.3"


### PR DESCRIPTION
Root cause: the installed legacy asdf-pnpm plugin only discovers `.js`/`.cjs`; pnpm 12 ships `.mjs`, so `BIN_PATH` stays unset and `mise install` fails under `set -u`.

Fix: select `aqua:pnpm/pnpm` explicitly so an installed legacy plugin cannot override registry resolution.

Verification: reproduced the failure before; full `mise install` passes after; pnpm resolves to Aqua 12.4.0; pnpx is available.
